### PR TITLE
only creating openshift routes if no LoadBalancer and no ClusterLocal.

### DIFF
--- a/client/van_router_create.go
+++ b/client/van_router_create.go
@@ -78,6 +78,10 @@ func GetVanControllerSpec(options types.VanRouterCreateOptions, van *types.VanRo
 	van.Controller.RoleBindings = roleBindings
 }
 
+func MustCreateOpenshiftRoutes(lbip bool, clusterLocal bool) bool {
+	return !lbip && !clusterLocal
+}
+
 func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanClient, lbip bool) *types.VanRouterSpec {
 	van := &types.VanRouterSpec{}
 	//todo: think through van name, router name, secret names, etc.
@@ -409,7 +413,7 @@ func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanC
 	}
 	van.Transport.Services = svcs
 
-	if !lbip {
+	if MustCreateOpenshiftRoutes(lbip, options.ClusterLocal) {
 		routes := []types.Route{}
 		routes = append(routes, types.Route{
 			Name:          types.InterRouterRouteName,

--- a/client/van_router_create_test.go
+++ b/client/van_router_create_test.go
@@ -1,0 +1,15 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/skupperproject/skupper/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMustCreatOpenshiftRoutes(t *testing.T) {
+	assert.False(t, client.MustCreateOpenshiftRoutes(true, true))
+	assert.False(t, client.MustCreateOpenshiftRoutes(true, false))
+	assert.False(t, client.MustCreateOpenshiftRoutes(false, true))
+	assert.True(t, client.MustCreateOpenshiftRoutes(false, false))
+}


### PR DESCRIPTION
Currently the source assumes: no LoadBalancer means Openshift.
As it is now: 
```

	if !lbip {
		routes := []types.Route{}
```
The source assumes "no loadBalancerIP means openshift routes", if I am not wrong. which misses the --local-cluster option.

If you want to fix this other way, propose, or let me know and I close this one. This pr is just to expose a bug.