### PR TITLE
tcp_echo integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,13 @@
 version: 2.1
+orbs:
+    docker: circleci/docker@1.0.1
+    kube-orb: circleci/kubernetes@0.11.0
+    go: circleci/go@1.1.1
+
+executors:
+  local_cluster_test_executor:
+    machine:
+      image: circleci/classic:latest
 
 commands:
   make:
@@ -13,6 +22,70 @@ commands:
       - run:
           name: make
           command: make << parameters.target >>
+
+  minikube-install:
+    description: Installs the minikube executable onto the system.
+    parameters:
+      version:
+        default: v0.30.0
+        type: string
+    steps:
+      - run:
+          command: >-
+            curl -Lo minikube
+            https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && 
+            chmod +x minikube && sudo
+            mv minikube /usr/local/bin/
+          name: Install Minikube Executable
+
+  minikube-start:
+    description: Starts the minikube service.
+    steps:
+      - run:
+          command: >-
+            minikube start --vm-driver=docker --cpus 2 --memory 2048
+          name: Start Minikube Cluster
+
+  minikube-start-load-balancer:
+    description: Starts the minikube tunnel
+    steps:
+      - run:
+          command: minikube tunnel
+          name: Start Minikube Tunnel
+          background: true
+
+  prepare_for_local_cluster_tests:
+    description: install right versions of go, docker, kubectl, and also build
+    steps:
+      - run:
+          #TODO add a comment saying why is this needed.
+          name: Export environment variables persistent in execution shell
+          command: |
+            echo 'export KUBECONFIG=/home/circleci/.kube/config' >> $BASH_ENV
+            echo 'export GOROOT=/usr/local/go' >> $BASH_ENV
+            echo 'export GOPATH=$HOME/go' >> $BASH_ENV
+            echo 'export PATH=$GOPATH/bin:$GOROOT/bin:$PATH' >> $BASH_ENV
+            source $BASH_ENV
+      - checkout
+      - run:
+          name: cleanup previous go installation
+          command: sudo rm -rf /usr/local/go
+      - docker/install-docker
+      - go/install
+      - kube-orb/install-kubectl
+      - run: make
+
+  run_cluster_tests:
+    description: run all e2e tests inside the current KUBECONFIG configured cluster
+    parameters:
+      args:
+        default: ""
+        type: string
+    steps:
+      - run:
+          name: Run Tests
+          command: go test -tags=integration -v ./test/integration/...
+      - run: kubectl get pods -n public1
 
 yaml-templates:
   branch_filters: &branch_filters
@@ -78,6 +151,11 @@ workflows:
           <<: *branch_filters
       - test_makefile:
           <<: *branch_filters
+
+      - minikube_local_cluster_tests:
+          <<: *branch_filters
+          pre-steps:
+            - prepare_for_local_cluster_tests
 
       - publish-github-release:
           <<: *release_filters
@@ -184,6 +262,16 @@ jobs:
       - run:
           name: Run Tests
           command: go test ./...
+
+  minikube_local_cluster_tests:
+    executor: local_cluster_test_executor
+    environment: &environment
+    steps:
+      - minikube-install
+      - minikube-start
+      - minikube-start-load-balancer
+      - run: kubectl cluster-info
+      - run_cluster_tests
 
   publish-github-release:
     docker:

--- a/test/cluster/cluster_test_runner.go
+++ b/test/cluster/cluster_test_runner.go
@@ -1,0 +1,125 @@
+package cluster
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/skupperproject/skupper/client"
+	vanClient "github.com/skupperproject/skupper/client"
+)
+
+type ClusterTestRunnerInterface interface {
+	Build(t *testing.T, public1ConficFile, public2ConficFile, private1ConfigFile, private2ConfigFile string)
+	Run()
+}
+
+type ClusterTestRunnerBase struct {
+	Pub1Cluster  *ClusterContext
+	Pub2Cluster  *ClusterContext
+	Priv1Cluster *ClusterContext
+	Priv2Cluster *ClusterContext
+	T            *testing.T
+}
+
+func (r *ClusterTestRunnerBase) Build(t *testing.T, public1ConficFile, public2ConficFile, private1ConfigFile, private2ConfigFile string) {
+	r.Pub1Cluster = BuildClusterContext(t, "public1", public1ConficFile)
+	r.Pub2Cluster = BuildClusterContext(t, "public2", public2ConficFile)
+	r.Priv1Cluster = BuildClusterContext(t, "private1", private1ConfigFile)
+	r.Priv2Cluster = BuildClusterContext(t, "private2", private2ConfigFile)
+	r.T = t
+}
+
+type ClusterContext struct {
+	Namespace         string
+	ClusterConfigFile string
+	VanClient         *vanClient.VanClient
+	t                 *testing.T
+}
+
+func BuildClusterContext(t *testing.T, namespace string, configFile string) *ClusterContext {
+	var err error
+	cc := &ClusterContext{}
+	cc.t = t
+	cc.Namespace = namespace
+	cc.ClusterConfigFile = configFile
+	cc.VanClient, err = client.NewClient(cc.Namespace, "", cc.ClusterConfigFile)
+	assert.Check(cc.t, err)
+	return cc
+}
+
+func _exec(command string, wait bool) {
+	var output []byte
+	var err error
+	fmt.Println(command)
+	cmd := exec.Command("sh", "-c", command)
+	if wait {
+		output, err = cmd.CombinedOutput()
+	} else {
+		cmd.Start()
+		return
+	}
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(output))
+}
+
+func (cc *ClusterContext) exec(main_command string, sub_command string, wait bool) {
+	_exec("KUBECONFIG="+cc.ClusterConfigFile+" "+main_command+" "+cc.Namespace+" "+sub_command, wait)
+}
+
+func (cc *ClusterContext) SkupperExec(command string) {
+	cc.exec("./skupper -n ", command, true)
+}
+
+func (cc *ClusterContext) _kubectl_exec(command string, wait bool) {
+	cc.exec("kubectl -n ", command, wait)
+}
+
+func (cc *ClusterContext) KubectlExec(command string) {
+	cc._kubectl_exec(command, true)
+}
+
+func (cc *ClusterContext) KubectlExecAsync(command string) {
+	cc._kubectl_exec(command, false)
+}
+
+func (cc *ClusterContext) CreateNamespace() {
+	NsSpec := &apiv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cc.Namespace}}
+	_, err := cc.VanClient.KubeClient.CoreV1().Namespaces().Create(NsSpec)
+	assert.Check(cc.t, err)
+}
+
+func (cc *ClusterContext) DeleteNamespace() {
+	err := cc.VanClient.KubeClient.CoreV1().Namespaces().Delete(cc.Namespace, &metav1.DeleteOptions{})
+	if err != nil {
+		log.Panic(err.Error())
+	}
+}
+
+func (cc *ClusterContext) GetService(name string, timeout_S time.Duration) *apiv1.Service {
+	timeout := time.After(timeout_S * time.Second)
+	tick := time.Tick(3 * time.Second)
+	for {
+		select {
+		case <-timeout:
+			log.Panicln("Timed Out Waiting for service.")
+		case <-tick:
+			service, err := cc.VanClient.KubeClient.CoreV1().Services(cc.Namespace).Get(name, metav1.GetOptions{})
+			if err == nil {
+				return service
+			} else {
+				log.Println("Service not ready yet, current pods state: ")
+				cc.KubectlExec("get pods -o wide") //TODO use clientset
+			}
+
+		}
+	}
+}

--- a/test/integration/tcp_echo/tcp_echo.go
+++ b/test/integration/tcp_echo/tcp_echo.go
@@ -1,0 +1,188 @@
+package tcp_echo
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/test/cluster"
+	"gotest.tools/assert"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type TcpEchoClusterTestRunner struct {
+	cluster.ClusterTestRunnerBase
+}
+
+func int32Ptr(i int32) *int32 { return &i }
+
+const minute time.Duration = 60
+
+var deployment *appsv1.Deployment = &appsv1.Deployment{
+	TypeMeta: metav1.TypeMeta{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "tcp-go-echo",
+	},
+	Spec: appsv1.DeploymentSpec{
+		Replicas: int32Ptr(1),
+		Selector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"application": "tcp-go-echo"},
+		},
+		Template: apiv1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"application": "tcp-go-echo",
+				},
+			},
+			Spec: apiv1.PodSpec{
+				Containers: []apiv1.Container{
+					{
+						Name:            "tcp-go-echo",
+						Image:           "quay.io/skupper/tcp-go-echo",
+						ImagePullPolicy: apiv1.PullIfNotPresent,
+						Ports: []apiv1.ContainerPort{
+							{
+								Name:          "http",
+								Protocol:      apiv1.ProtocolTCP,
+								ContainerPort: 80,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+func sendReceive(servAddr string) {
+	strEcho := "Halo"
+	tcpAddr, err := net.ResolveTCPAddr("tcp", servAddr)
+	if err != nil {
+		log.Panicln("ResolveTCPAddr failed:", err.Error())
+	}
+	conn, err := net.DialTCP("tcp", nil, tcpAddr)
+	if err != nil {
+		log.Panicln("Dial failed:", err.Error())
+	}
+	_, err = conn.Write([]byte(strEcho))
+	if err != nil {
+		log.Panicln("Write to server failed:", err.Error())
+	}
+
+	reply := make([]byte, 1024)
+
+	_, err = conn.Read(reply)
+	if err != nil {
+		log.Panicln("Write to server failed:", err.Error())
+	}
+	conn.Close()
+
+	log.Println("Sent to server = ", strEcho)
+	log.Println("Reply from server = ", string(reply))
+
+	if !strings.Contains(string(reply), strings.ToUpper(strEcho)) {
+		log.Panicf("Response from server different that expected: %s", string(reply))
+	}
+}
+
+func (r *TcpEchoClusterTestRunner) RunTests(ctx context.Context) {
+	var publicService *apiv1.Service
+	var privateService *apiv1.Service
+
+	r.Pub1Cluster.KubectlExec("get svc")
+	r.Priv1Cluster.KubectlExec("get svc")
+
+	publicService = r.Pub1Cluster.GetService("tcp-go-echo", 3*minute)
+	privateService = r.Priv1Cluster.GetService("tcp-go-echo", 3*minute)
+
+	fmt.Printf("Public service ClusterIp = %q\n", publicService.Spec.ClusterIP)
+	fmt.Printf("Private service ClusterIp = %q\n", privateService.Spec.ClusterIP)
+
+	time.Sleep(20 * time.Second)
+
+	r.Pub1Cluster.KubectlExecAsync("port-forward service/tcp-go-echo 9090:9090")
+	r.Priv1Cluster.KubectlExecAsync("port-forward service/tcp-go-echo 9091:9090")
+
+	time.Sleep(20 * time.Second) //give time to port forwarding to start
+
+	sendReceive("127.0.0.1:9090")
+	sendReceive("127.0.0.1:9091")
+}
+
+func (r *TcpEchoClusterTestRunner) Setup(ctx context.Context) {
+	r.Pub1Cluster.CreateNamespace()
+	r.Priv1Cluster.CreateNamespace()
+
+	publicDeploymentsClient := r.Pub1Cluster.VanClient.KubeClient.AppsV1().Deployments(r.Pub1Cluster.Namespace)
+
+	fmt.Println("Creating deployment...")
+	result, err := publicDeploymentsClient.Create(deployment)
+	assert.Check(r.T, err)
+
+	fmt.Printf("Created deployment %q.\n", result.GetObjectMeta().GetName())
+
+	fmt.Printf("Listing deployments in namespace %q:\n", "public")
+	list, err := publicDeploymentsClient.List(metav1.ListOptions{})
+	assert.Check(r.T, err)
+
+	for _, d := range list.Items {
+		fmt.Printf(" * %s (%d replicas)\n", d.Name, *d.Spec.Replicas)
+	}
+
+	var vanRouterCreateOpts types.VanRouterCreateOptions = types.VanRouterCreateOptions{
+		SkupperName:       "",
+		IsEdge:            false,
+		EnableController:  true,
+		EnableServiceSync: true,
+		EnableConsole:     false,
+		AuthMode:          types.ConsoleAuthModeUnsecured,
+		User:              "nicob?",
+		Password:          "nopasswordd",
+		ClusterLocal:      false,
+		Replicas:          1,
+	}
+
+	r.Pub1Cluster.VanClient.VanRouterCreate(ctx, vanRouterCreateOpts)
+
+	var vanServiceInterfaceCreateOpts types.VanServiceInterfaceCreateOptions = types.VanServiceInterfaceCreateOptions{
+		Protocol:   "tcp",
+		Address:    "tcp-go-echo",
+		Port:       9090,
+		TargetPort: 9090,
+		Headless:   false,
+	}
+	err = r.Pub1Cluster.VanClient.VanServiceInterfaceCreate(ctx, "deployment", "tcp-go-echo", vanServiceInterfaceCreateOpts)
+	assert.Check(r.T, err)
+
+	err = r.Pub1Cluster.VanClient.VanConnectorTokenCreate(ctx, types.DefaultVanName, "/tmp/public_secret.yaml")
+	assert.Check(r.T, err)
+
+	err = r.Priv1Cluster.VanClient.VanRouterCreate(ctx, vanRouterCreateOpts)
+
+	var vanConnectorCreateOpts types.VanConnectorCreateOptions = types.VanConnectorCreateOptions{
+		Name: "",
+		Cost: 0,
+	}
+	r.Priv1Cluster.VanClient.VanConnectorCreate(ctx, "/tmp/public_secret.yaml", vanConnectorCreateOpts)
+}
+
+func (r *TcpEchoClusterTestRunner) TearDown(ctx context.Context) {
+	r.Pub1Cluster.DeleteNamespace()
+	r.Priv1Cluster.DeleteNamespace()
+}
+
+func (r *TcpEchoClusterTestRunner) Run(ctx context.Context) {
+	defer r.TearDown(ctx)
+	r.Setup(ctx)
+	r.RunTests(ctx)
+}

--- a/test/integration/tcp_echo/tcp_echo_test.go
+++ b/test/integration/tcp_echo/tcp_echo_test.go
@@ -1,0 +1,30 @@
+// +build integration
+
+package tcp_echo
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestTcpEcho(t *testing.T) {
+	testRunner := &TcpEchoClusterTestRunner{}
+
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		homedir, err := os.UserHomeDir()
+		assert.Check(t, err)
+		kubeconfig = path.Join(homedir, ".kube/config")
+	}
+
+	//TODO: accept 4 different kubeconfigs
+	//For now for simplicity we use the same single kubeconfig. Multicluster
+	//support can be enabled easily whe needed.
+	testRunner.Build(t, kubeconfig, kubeconfig, kubeconfig, kubeconfig)
+	ctx := context.Background()
+	testRunner.Run(ctx)
+}


### PR DESCRIPTION
This test is based on the tcp_echo smoke test in the skupper-cli project, one major difference is that this one is "go test" and the skupper-cli one is a "go binary". Being a go-test simplifies many future possible improvements related to reporting, asserting, etc.

A lot of improvements are possible, including running the same test for clusterLocal=true/false, and other different configuration options.

Main goal here is to start having a basic ci-integration working. And being able to improve/extend with future PRs.

To separate integration from normal go-unittests a go built-in feature:
https://mickey.dev/posts/go-build-tags-testing/

So to run locally you just need your KUBECONFIG pointing to a valid cluster, and:

`$ go test -tags=integration -v ./test/integration/...`
