### PR TITLE
No branch filters in pipeline.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,13 +75,6 @@ commands:
       - run: kubectl get pods -n public1
 
 yaml-templates:
-  branch_filters: &branch_filters
-    filters:
-      branches:
-        only: /.*/
-      tags:
-        only: /[0-9].*/
-
   release_filters: &release_filters
     filters:
       branches:
@@ -106,31 +99,25 @@ workflows:
   version: 2.1
   build-workflow:
     jobs:
+      - build-linux-amd64
+      - build-darwin-amd64
+      - build-windows-amd64
+      - test
+      - test_makefile
+      - minikube_local_cluster_tests:
+          pre-steps:
+            - prepare_for_local_cluster_tests
+
       - build-linux-386:
           <<: *release_filters
-      - build-linux-amd64:
-          <<: *branch_filters
       - build-darwin-386:
           <<: *release_filters
-      - build-darwin-amd64:
-          <<: *branch_filters
       - build-windows-386:
           <<: *release_filters
-      - build-windows-amd64:
-          <<: *branch_filters
       - build-linux-arm:
           <<: *release_filters
       - build-linux-arm64:
           <<: *release_filters
-      - test:
-          <<: *branch_filters
-      - test_makefile:
-          <<: *branch_filters
-
-      - minikube_local_cluster_tests:
-          <<: *branch_filters
-          pre-steps:
-            - prepare_for_local_cluster_tests
 
       - publish-github-release:
           <<: *release_filters


### PR DESCRIPTION
No need to pollute the pipeline with branch filtering. Circle-ci alrady has a configuration option to avoid excesive amount of builds (and we were building all branches anyway).

See: https://circleci.com/docs/2.0/oss/#only-build-pull-requests