### PR TITLE
Using channel and select instead of time.Sleep

### DIFF
--- a/client/van_connector_create_test.go
+++ b/client/van_connector_create_test.go
@@ -3,12 +3,10 @@ package client
 import (
 	"context"
 	"os"
-	"sort"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/skupperproject/skupper/api/types"
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -17,11 +15,10 @@ import (
 )
 
 func TestConnectorCreateError(t *testing.T) {
+	cli, err := newMockClient("skupper", "", "")
+	assert.Check(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	// Create the client
-	cli, err := newMockClient("skupper", "", "")
 
 	err = cli.VanConnectorCreate(ctx, "./somefile.yaml", types.VanConnectorCreateOptions{
 		Name: "",
@@ -32,69 +29,69 @@ func TestConnectorCreateError(t *testing.T) {
 
 func TestConnectorCreateInterior(t *testing.T) {
 	testcases := []struct {
-		doc             string
-		expectedError   string
-		connName        string
-		connFile        string
-		secretsExpected []string
+		doc                string
+		expectedError      string
+		connName           string
+		connFile           string
+		secretExpectedName string
 	}{
 		{
-			doc:             "Expect generated name to be conn1",
-			expectedError:   "",
-			connName:        "",
-			secretsExpected: []string{"conn1"},
+			doc:                "Expect generated name to be conn1",
+			expectedError:      "",
+			connName:           "",
+			secretExpectedName: "conn1",
 		},
 		{
-			doc:             "Expect secret name to be as provided: conn2",
-			expectedError:   "",
-			connName:        "conn2",
-			secretsExpected: []string{"conn2"},
+			doc:                "Expect secret name to be as provided: conn22",
+			expectedError:      "",
+			connName:           "conn2",
+			secretExpectedName: "conn2",
 		},
 	}
 
-	trans := cmp.Transformer("Sort", func(in []string) []string {
-		out := append([]string(nil), in...)
-		sort.Strings(out)
-		return out
-	})
+	//TODO do a symple loop verifying and asserting no repeated table
+	//connection.
 
 	testPath := "./tmp/"
 	os.Mkdir(testPath, 0755)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cli, err := newMockClient("skupper", "", "")
+	assert.Check(t, err)
+
+	secrets := make(chan *corev1.Secret)
+
+	informers := informers.NewSharedInformerFactory(cli.KubeClient, 0)
+	secretsInformer := informers.Core().V1().Secrets().Informer()
+	secretsInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			secret := obj.(*corev1.Secret)
+			t.Logf("secret added: %s/%s", secret.Namespace, secret.Name)
+			if strings.Contains(secret.Name, "conn") {
+				secrets <- secret
+			}
+		},
+	})
+
+	informers.Start(ctx.Done())
+	cache.WaitForCacheSync(ctx.Done(), secretsInformer.HasSynced)
+
+	err = cli.VanRouterCreate(ctx, types.VanRouterCreateOptions{
+		SkupperName:       "skupper",
+		IsEdge:            false,
+		EnableController:  true,
+		EnableServiceSync: true,
+		EnableConsole:     false,
+		AuthMode:          "",
+		User:              "",
+		Password:          "",
+		ClusterLocal:      true,
+	})
+	assert.Check(t, err, "Unable to create VAN router")
+
 	for _, c := range testcases {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		secretsFound := []string{}
-
-		cli, err := newMockClient("skupper", "", "")
-
-		informers := informers.NewSharedInformerFactory(cli.KubeClient, 0)
-		secretsInformer := informers.Core().V1().Secrets().Informer()
-		secretsInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				secret := obj.(*corev1.Secret)
-				if !strings.HasPrefix(secret.Name, "skupper") {
-					secretsFound = append(secretsFound, secret.Name)
-				}
-			},
-		})
-
-		informers.Start(ctx.Done())
-		cache.WaitForCacheSync(ctx.Done(), secretsInformer.HasSynced)
-
-		err = cli.VanRouterCreate(ctx, types.VanRouterCreateOptions{
-			SkupperName:       "skupper",
-			IsEdge:            false,
-			EnableController:  true,
-			EnableServiceSync: true,
-			EnableConsole:     false,
-			AuthMode:          "",
-			User:              "",
-			Password:          "",
-			ClusterLocal:      true,
-		})
-		assert.Check(t, err, "Unable to create VAN router")
 
 		err = cli.VanConnectorTokenCreate(ctx, c.connName, testPath+c.connName+".yaml")
 		assert.Check(t, err, "Unable to create token")
@@ -105,11 +102,14 @@ func TestConnectorCreateInterior(t *testing.T) {
 		})
 		assert.Check(t, err, "Unable to create connector")
 
-		// TODO: make more deterministic
-		time.Sleep(time.Second * 1)
-		assert.Assert(t, cmp.Equal(c.secretsExpected, secretsFound, trans), c.doc)
-	}
+		select {
+		case secret := <-secrets:
+			assert.Equal(t, secret.Name, c.secretExpectedName, c.doc)
+		case <-time.After(time.Second * 5): //TODO this timeout depend on future running on a real cluster
+			//anyway test does not wait for this confition, it is just the error timeout.
+			t.Error("Informer did not get the added secret")
+		}
 
-	// clean up
+	}
 	os.RemoveAll(testPath)
 }


### PR DESCRIPTION
Test duration reduced notably:
--- PASS: TestConnectorCreateInterior (0.97s)
--- PASS: TestConnectorCreateInterior (4.60s)

Probably the same approach should be used in the remaining tests, I think almost all cases are similar.