### PR TITLE
VanConnectorCreate cluster test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ commands:
           command: go test -tags=integration -v ./test/integration/...
       - run:
           name: Run client tests in real cluster
-          command: go test -v -count=1 ./client -use-real-cluster
+          command: go test -v -count=1 ./client -use-cluster
 
 yaml-templates:
   release_filters: &release_filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,9 +70,11 @@ commands:
         type: string
     steps:
       - run:
-          name: Run Tests
+          name: Run Integration Tests
           command: go test -tags=integration -v ./test/integration/...
-      - run: kubectl get pods -n public1
+      - run:
+          name: Run client tests in real cluster
+          command: go test -v -count=1 ./client -use-real-cluster
 
 yaml-templates:
   release_filters: &release_filters

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"flag"
+	"fmt"
 	"testing"
 
 	"gotest.tools/assert"
@@ -28,4 +30,16 @@ func TestNewClient(t *testing.T) {
 		_, err := newMockClient(c.namespace, c.context, c.kubeConfigPath)
 		assert.Check(t, err, c.doc)
 	}
+}
+
+var runOnRealCluster = flag.Bool("use-real-cluster", false, "client package tests will use KUBECONFIG configured cluster")
+
+func getVanClient(short bool, namespace string) (*VanClient, error) {
+
+	if *runOnRealCluster {
+		fmt.Println("Using real Client!")
+		return NewClient(namespace, "", "")
+	}
+	fmt.Println("Using mock client.")
+	return newMockClient(namespace, "", "")
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"flag"
-	"fmt"
+	"os"
 	"testing"
 
 	"gotest.tools/assert"
@@ -32,14 +32,9 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
-var runOnRealCluster = flag.Bool("use-real-cluster", false, "client package tests will use KUBECONFIG configured cluster")
+var clusterRun = flag.Bool("use-cluster", false, "run tests against a configured cluster")
 
-func getVanClient(short bool, namespace string) (*VanClient, error) {
-
-	if *runOnRealCluster {
-		fmt.Println("Using real Client!")
-		return NewClient(namespace, "", "")
-	}
-	fmt.Println("Using mock client.")
-	return newMockClient(namespace, "", "")
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
 }

--- a/client/van_connector_create_test.go
+++ b/client/van_connector_create_test.go
@@ -21,7 +21,7 @@ func TestConnectorCreateError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cli, err := getVanClient(testing.Short(), "namespace")
+	cli, err := newMockClient("my-namespace", "", "")
 	assert.Assert(t, err)
 
 	err = cli.VanConnectorCreateFromFile(ctx, "./somefile.yaml", types.VanConnectorCreateOptions{
@@ -64,7 +64,13 @@ func TestConnectorCreateInterior(t *testing.T) {
 
 	var namespace string = "testconnectorcreateinterior"
 
-	cli, err := getVanClient(testing.Short(), namespace)
+	var cli *VanClient
+	var err error
+	if *clusterRun {
+		cli, err = NewClient(namespace, "", "")
+	} else {
+		cli, err = newMockClient(namespace, "", "")
+	}
 	assert.Assert(t, err)
 
 	createNamespace := func() {
@@ -130,7 +136,6 @@ func TestConnectorCreateInterior(t *testing.T) {
 
 		// TODO: make more deterministic
 		time.Sleep(time.Second * 1)
-		t.Logf("secretsFound = %v", secretsFound)
 		assert.Assert(t, cmp.Equal(c.secretsExpected, secretsFound, trans), c.doc)
 	}
 


### PR DESCRIPTION
This PR intends to add the ability to run client package unit-test, not only against a clientMock but also against a real cluster.
Based on review, PR modified:
- To run tests against a real cluster just set the "-use-cluster" flag:
`$ go test -v -count=1 ./client -use-cluster`
- This tests have been also added to ci.