### PR TITLE
Updates for console server

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -25,7 +25,6 @@ type VanServiceInterfaceCreateOptions struct {
 	Port       int
 	TargetPort int
 	Headless   bool
-	Aggregate  string
 }
 
 type VanRouterInspectResponse struct {

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -6,16 +6,17 @@ type VanConnectorCreateOptions struct {
 }
 
 type VanRouterCreateOptions struct {
-	SkupperName       string
-	IsEdge            bool
-	EnableController  bool
-	EnableServiceSync bool
-	EnableConsole     bool
-	AuthMode          string
-	User              string
-	Password          string
-	ClusterLocal      bool
-	Replicas          int32
+	SkupperName         string
+	IsEdge              bool
+	EnableController    bool
+	EnableServiceSync   bool
+	EnableRouterConsole bool
+	EnableConsole       bool
+	AuthMode            string
+	User                string
+	Password            string
+	ClusterLocal        bool
+	Replicas            int32
 }
 
 type VanServiceInterfaceCreateOptions struct {
@@ -24,6 +25,7 @@ type VanServiceInterfaceCreateOptions struct {
 	Port       int
 	TargetPort int
 	Headless   bool
+	Aggregate  string
 }
 
 type VanRouterInspectResponse struct {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -24,13 +24,9 @@ const (
 	// NamespaceDefault means the VAN is in the  skupper namespace which is applied when not specified by clients
 	NamespaceDefault    string = "skupper"
 	DefaultVanName      string = "skupper"
+	DefaultSiteName     string = "skupper-site"
 	ClusterLocalPostfix string = ".svc.cluster.local"
 )
-
-// KeyValue holds a key/value pair
-type KeyValue struct {
-	Key, Value string
-}
 
 // TransportMode describes how a qdr is intended to be deployed, either interior or edge
 type TransportMode string
@@ -148,8 +144,6 @@ const (
 	InterRouterListenerPort int32  = 55671
 	InterRouterRouteName    string = "skupper-inter-router"
 	InterRouterProfile      string = "skupper-internal"
-
-//    ConnectorSecretLabel    KeyValue = KeyValue{Key: "skupper.io/type", Value: "connection-token",}
 )
 
 // Service Sync constants
@@ -180,12 +174,14 @@ type DeploymentSpec struct {
 	EnvVar          []corev1.EnvVar        `json:"envVar,omitempty"`
 	Ports           []corev1.ContainerPort `json:"ports,omitempty"`
 	Volumes         []corev1.Volume        `json:"volumes,omitempty"`
-	VolumeMounts    []corev1.VolumeMount   `json:"volumeMounts,omitempty"`
+	VolumeMounts    [][]corev1.VolumeMount `json:"volumeMounts,omitempty"`
 	ConfigMaps      []ConfigMap            `json:"configMaps,omitempty"`
 	Roles           []Role                 `json:"roles,omitempty"`
 	RoleBindings    []RoleBinding          `json:"roleBinding,omitempty"`
+	Routes          []Route                `json:"routes,omitempty"`
 	ServiceAccounts []ServiceAccount       `json:"serviceAccounts,omitempty"`
 	Services        []Service              `json:"services,omitempty"`
+	Sidecars        []*corev1.Container    `json:"sidecars,omitempty"`
 }
 
 // AssemblySpec for the links and connectors that form the VAN topology
@@ -199,7 +195,6 @@ type AssemblySpec struct {
 	Connectors            []Connector  `json:"connectors,omitempty"`
 	InterRouterConnectors []Connector  `json:"interRouterConnectors,omitempty"`
 	EdgeConnectors        []Connector  `json:"edgeConnectors,omitempty"`
-	Routes                []Route      `json:"routes,omitempty"`
 }
 
 type VanRouterStatusSpec struct {
@@ -274,6 +269,7 @@ type Route struct {
 	TargetService string
 	TargetPort    string
 	Termination   routev1.TLSTerminationType
+	SiteOwner     bool
 }
 
 type Service struct {
@@ -281,7 +277,7 @@ type Service struct {
 	Type        string
 	Ports       []corev1.ServicePort
 	Annotations map[string]string
-	Termination routev1.TLSTerminationType
+	SiteOwner   bool
 }
 
 type Credential struct {
@@ -291,10 +287,13 @@ type Credential struct {
 	Hosts       string
 	ConnectJson bool
 	Post        bool
+	SiteOwner   bool
+	Data        map[string][]byte
 }
 
 type CertAuthority struct {
-	Name string
+	Name      string
+	SiteOwner bool
 }
 
 type User struct {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -123,7 +123,7 @@ const (
 	ConsoleDefaultServiceTargetPort        int32  = 8080
 	ConsoleOpenShiftServicePort            int32  = 8888
 	ConsoleOpenShiftOauthServicePort       int32  = 443
-	ConsoleOpenShiftOuathServiceTargetPort int32  = 8443
+	ConsoleOpenShiftOauthServiceTargetPort int32  = 8443
 	ConsoleOpenShiftServingCerts           string = "skupper-proxy-certs"
 )
 
@@ -137,6 +137,8 @@ const (
 
 // Assembly constants
 const (
+	AmqpDefaultPort         int32  = 5672
+	AmqpsDefaultPort        int32  = 5671
 	EdgeRole                string = "edge"
 	EdgeRouteName           string = "skupper-edge"
 	EdgeListenerPort        int32  = 45671
@@ -269,7 +271,6 @@ type Route struct {
 	TargetService string
 	TargetPort    string
 	Termination   routev1.TLSTerminationType
-	SiteOwner     bool
 }
 
 type Service struct {
@@ -277,7 +278,6 @@ type Service struct {
 	Type        string
 	Ports       []corev1.ServicePort
 	Annotations map[string]string
-	SiteOwner   bool
 }
 
 type Credential struct {
@@ -287,13 +287,11 @@ type Credential struct {
 	Hosts       string
 	ConnectJson bool
 	Post        bool
-	SiteOwner   bool
 	Data        map[string][]byte
 }
 
 type CertAuthority struct {
-	Name      string
-	SiteOwner bool
+	Name string
 }
 
 type User struct {

--- a/client/van_connector_create.go
+++ b/client/van_connector_create.go
@@ -87,7 +87,7 @@ func (cli *VanClient) VanConnectorCreate(ctx context.Context, secretFile string,
 			"skupper.io/type": "connection-token",
 		}
 		secret.ObjectMeta.SetOwnerReferences([]metav1.OwnerReference{
-			kube.GetOwnerReference(current),
+			kube.GetDeploymentOwnerReference(current),
 		})
 		_, err = cli.KubeClient.CoreV1().Secrets(cli.Namespace).Create(&secret)
 		if err == nil {

--- a/client/van_router_create.go
+++ b/client/van_router_create.go
@@ -9,8 +9,6 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/skupperproject/skupper/api/types"
@@ -19,7 +17,33 @@ import (
 	"github.com/skupperproject/skupper/pkg/utils/configs"
 )
 
-func GetVanControllerSpec(options types.VanRouterCreateOptions, van *types.VanRouterSpec, transport *appsv1.Deployment) {
+func OauthProxyContainer(serviceAccount string) *corev1.Container {
+	return &corev1.Container{
+		Image: "openshift/oauth-proxy:latest",
+		Name:  "oauth-proxy",
+		Args: []string{
+			"--https-address=:8443",
+			"--provider=openshift",
+			"--openshift-service-account=" + serviceAccount,
+			"--upstream=http://localhost:8888",
+			"--tls-cert=/etc/tls/proxy-certs/tls.crt",
+			"--tls-key=/etc/tls/proxy-certs/tls.key",
+			"--cookie-secret=SECRET",
+		},
+		Ports: []corev1.ContainerPort{
+			corev1.ContainerPort{
+				Name:          "http",
+				ContainerPort: 8080,
+			},
+			corev1.ContainerPort{
+				Name:          "https",
+				ContainerPort: 8443,
+			},
+		},
+	}
+}
+
+func (cli *VanClient) GetVanControllerSpec(options types.VanRouterCreateOptions, van *types.VanRouterSpec, transport *appsv1.Deployment) {
 
 	if os.Getenv("SKUPPER_CONTROLLER_IMAGE") != "" {
 		van.Controller.Image = os.Getenv("SKUPPER_CONTROLLER_IMAGE")
@@ -47,16 +71,40 @@ func GetVanControllerSpec(options types.VanRouterCreateOptions, van *types.VanRo
 	envVars = append(envVars, corev1.EnvVar{Name: "OWNER_NAME", Value: transport.ObjectMeta.Name})
 	envVars = append(envVars, corev1.EnvVar{Name: "OWNER_UID", Value: string(transport.ObjectMeta.UID)})
 
-	volumes := &[]corev1.Volume{}
-	mounts := &[]corev1.VolumeMount{}
+	sidecars := []*corev1.Container{}
+	volumes := []corev1.Volume{}
+	mounts := make([][]corev1.VolumeMount, 0)
+	mounts = append(mounts, []corev1.VolumeMount{})
+
+	if options.AuthMode == string(types.ConsoleAuthModeOpenshift) {
+		sidecars = append(sidecars, OauthProxyContainer("skupper-proxy-controller"))
+		envVars = append(envVars, corev1.EnvVar{Name: "METRICS_PORT", Value: "8888"})
+		envVars = append(envVars, corev1.EnvVar{Name: "METRICS_HOST", Value: "localhost"})
+		mounts = append(mounts, []corev1.VolumeMount{})
+		kube.AppendSecretVolume(&volumes, &mounts[1], "skupper-controller-certs", "/etc/tls/proxy-certs/")
+	} else if options.AuthMode == string(types.ConsoleAuthModeInternal) {
+		envVars = append(envVars, corev1.EnvVar{Name: "METRICS_USERS", Value: "/etc/console-users"})
+		kube.AppendSecretVolume(&volumes, &mounts[0], "skupper-console-users", "/etc/console-users/")
+	}
+
 	if options.EnableServiceSync {
-		origin := utils.RandomId(10)
-		envVars = append(envVars, corev1.EnvVar{Name: "SKUPPER_SERVICE_SYNC_ORIGIN", Value: origin})
-		kube.AppendSecretVolume(volumes, mounts, "skupper", "/etc/messaging/")
+		envVars = append(envVars, corev1.EnvVar{
+			Name: "SKUPPER_SERVICE_SYNC_ORIGIN",
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						"skupper-site",
+					},
+					Key: "id",
+				},
+			},
+		})
+		kube.AppendSecretVolume(&volumes, &mounts[0], "skupper", "/etc/messaging/")
 	}
 	van.Controller.EnvVar = envVars
-	van.Controller.Volumes = *volumes
-	van.Controller.VolumeMounts = *mounts
+	van.Controller.Volumes = volumes
+	van.Controller.VolumeMounts = mounts
+	van.Controller.Sidecars = sidecars
 
 	serviceAccounts := []types.ServiceAccount{}
 	serviceAccounts = append(serviceAccounts, types.ServiceAccount{
@@ -78,18 +126,68 @@ func GetVanControllerSpec(options types.VanRouterCreateOptions, van *types.VanRo
 		Role:           "skupper-edit",
 	})
 	van.Controller.RoleBindings = roleBindings
+
+	svctype := "ClusterIP"
+	metricsPort := []corev1.ServicePort{
+		corev1.ServicePort{
+			Name:       "metrics",
+			Protocol:   "TCP",
+			Port:       8080,
+			TargetPort: intstr.FromInt(8080),
+		},
+	}
+	termination := routev1.TLSTerminationEdge
+	annotations := map[string]string{}
+
+	svcs := []types.Service{}
+	if cli.RouteClient != nil {
+		if options.AuthMode == string(types.ConsoleAuthModeOpenshift) {
+			termination = routev1.TLSTerminationReencrypt
+			metricsPort = []corev1.ServicePort{
+				corev1.ServicePort{
+					Name:       "metrics",
+					Protocol:   "TCP",
+					Port:       443,
+					TargetPort: intstr.FromInt(8443),
+				},
+			}
+			annotations = map[string]string{"service.alpha.openshift.io/serving-cert-secret-name": "skupper-controller-certs"}
+		}
+	} else if !options.ClusterLocal {
+		svctype = "LoadBalancer"
+	}
+	svcs = append(svcs, types.Service{
+		Name:        "skupper-controller",
+		Ports:       metricsPort,
+		Type:        svctype,
+		Annotations: annotations,
+		SiteOwner:   true,
+	})
+	van.Controller.Services = svcs
+
+	routes := []types.Route{}
+	if !options.ClusterLocal && cli.RouteClient != nil {
+		routes = append(routes, types.Route{
+			Name:          "skupper-controller",
+			TargetService: "skupper-controller",
+			TargetPort:    "metrics",
+			Termination:   termination,
+			SiteOwner:     true,
+		})
+	}
+	van.Controller.Routes = routes
 }
 
-func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanClient) *types.VanRouterSpec {
+func (cli *VanClient) GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions) *types.VanRouterSpec {
 	van := &types.VanRouterSpec{}
 	//todo: think through van name, router name, secret names, etc.
 	if options.SkupperName == "" {
-		van.Name = client.Namespace
+		van.Name = cli.Namespace
 	} else {
 		van.Name = options.SkupperName
 	}
 
-	van.Namespace = client.Namespace
+	van.Namespace = cli.Namespace
 	van.AuthMode = types.ConsoleAuthMode(options.AuthMode)
 	van.Transport.LivenessPort = types.TransportLivenessPort
 
@@ -117,15 +215,6 @@ func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanC
 	sslProfiles = append(sslProfiles, types.SslProfile{
 		Name: "skupper-amqps",
 	})
-	//TODO: vcabbage issue with EXTERNAL, requires ANONYMOUS,false
-	//listeners = append(listeners, types.Listener{
-	//	Name:             "amqps",
-	//	Host:             "0.0.0.0",
-	//	Port:             5671,
-	//	SslProfile:       "skupper-amqps",
-	//	SaslMechanisms:   "ANONYMOUS",
-	//	AuthenticatePeer: false,
-	//})
 	listeners = append(listeners, types.Listener{
 		Name:             "amqps",
 		Host:             "0.0.0.0",
@@ -134,28 +223,30 @@ func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanC
 		SaslMechanisms:   "EXTERNAL",
 		AuthenticatePeer: true,
 	})
-	if van.AuthMode == types.ConsoleAuthModeOpenshift {
-		listeners = append(listeners, types.Listener{
-			Name: types.ConsolePortName,
-			Host: "localhost",
-			Port: types.ConsoleOpenShiftServicePort,
-			Http: true,
-		})
-	} else if van.AuthMode == types.ConsoleAuthModeInternal {
-		listeners = append(listeners, types.Listener{
-			Name:             types.ConsolePortName,
-			Host:             "0.0.0.0",
-			Port:             types.ConsoleDefaultServicePort,
-			Http:             true,
-			AuthenticatePeer: true,
-		})
-	} else if van.AuthMode == types.ConsoleAuthModeUnsecured {
-		listeners = append(listeners, types.Listener{
-			Name: types.ConsolePortName,
-			Host: "0.0.0.0",
-			Port: types.ConsoleDefaultServicePort,
-			Http: true,
-		})
+	if options.EnableRouterConsole {
+		if van.AuthMode == types.ConsoleAuthModeOpenshift {
+			listeners = append(listeners, types.Listener{
+				Name: types.ConsolePortName,
+				Host: "localhost",
+				Port: types.ConsoleOpenShiftServicePort,
+				Http: true,
+			})
+		} else if van.AuthMode == types.ConsoleAuthModeInternal {
+			listeners = append(listeners, types.Listener{
+				Name:             types.ConsolePortName,
+				Host:             "0.0.0.0",
+				Port:             types.ConsoleDefaultServicePort,
+				Http:             true,
+				AuthenticatePeer: true,
+			})
+		} else if van.AuthMode == types.ConsoleAuthModeUnsecured {
+			listeners = append(listeners, types.Listener{
+				Name: types.ConsolePortName,
+				Host: "0.0.0.0",
+				Port: types.ConsoleDefaultServicePort,
+				Http: true,
+			})
+		}
 	}
 	if !options.IsEdge {
 		sslProfiles = append(sslProfiles, types.SslProfile{
@@ -212,6 +303,17 @@ func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanC
 		envVars = append(envVars, corev1.EnvVar{Name: "QDROUTERD_AUTO_CREATE_SASLDB_PATH", Value: "/tmp/qdrouterd.sasldb"})
 	}
 	envVars = append(envVars, corev1.EnvVar{Name: "QDROUTERD_CONF", Value: configs.QdrouterdConfig(&van.Assembly)})
+	envVars = append(envVars, corev1.EnvVar{
+		Name: "SKUPPER_SITE_ID",
+		ValueFrom: &corev1.EnvVarSource{
+			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					"skupper-site",
+				},
+				Key: "id",
+			},
+		},
+	})
 	van.Transport.EnvVar = envVars
 
 	ports := []corev1.ContainerPort{}
@@ -219,16 +321,18 @@ func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanC
 		Name:          "amqps",
 		ContainerPort: 5671,
 	})
-	if options.AuthMode == string(types.ConsoleAuthModeOpenshift) {
-		ports = append(ports, corev1.ContainerPort{
-			Name:          types.ConsolePortName,
-			ContainerPort: types.ConsoleOpenShiftServicePort,
-		})
-	} else if options.AuthMode != "" {
-		ports = append(ports, corev1.ContainerPort{
-			Name:          types.ConsolePortName,
-			ContainerPort: types.ConsoleDefaultServicePort,
-		})
+	if options.EnableRouterConsole {
+		if options.AuthMode == string(types.ConsoleAuthModeOpenshift) {
+			ports = append(ports, corev1.ContainerPort{
+				Name:          types.ConsolePortName,
+				ContainerPort: types.ConsoleOpenShiftServicePort,
+			})
+		} else if options.AuthMode != "" {
+			ports = append(ports, corev1.ContainerPort{
+				Name:          types.ConsolePortName,
+				ContainerPort: types.ConsoleDefaultServicePort,
+			})
+		}
 	}
 	ports = append(ports, corev1.ContainerPort{
 		Name:          "http",
@@ -246,20 +350,27 @@ func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanC
 	}
 	van.Transport.Ports = ports
 
-	volumes := &[]corev1.Volume{}
-	mounts := &[]corev1.VolumeMount{}
-	kube.AppendSecretVolume(volumes, mounts, "skupper-amqps", "/etc/qpid-dispatch-certs/skupper-amqps/")
+	sidecars := []*corev1.Container{}
+	volumes := []corev1.Volume{}
+	mounts := make([][]corev1.VolumeMount, 0)
+	mounts = append(mounts, []corev1.VolumeMount{})
+	kube.AppendSecretVolume(&volumes, &mounts[0], "skupper-amqps", "/etc/qpid-dispatch-certs/skupper-amqps/")
 	if !options.IsEdge {
-		kube.AppendSecretVolume(volumes, mounts, "skupper-internal", "/etc/qpid-dispatch-certs/skupper-internal/")
+		kube.AppendSecretVolume(&volumes, &mounts[0], "skupper-internal", "/etc/qpid-dispatch-certs/skupper-internal/")
 	}
-	if options.AuthMode == string(types.ConsoleAuthModeOpenshift) {
-		kube.AppendSecretVolume(volumes, mounts, "skupper-proxy-certs", "/etc/tls/proxy-certs/")
-	} else if options.AuthMode == string(types.ConsoleAuthModeInternal) {
-		kube.AppendSecretVolume(volumes, mounts, "skupper-console-users", "/etc/qpid-dispatch/sasl-users/")
-		kube.AppendConfigVolume(volumes, mounts, "skupper-sasl-config", "/etc/sasl2/")
+	if options.EnableRouterConsole {
+		if options.AuthMode == string(types.ConsoleAuthModeOpenshift) {
+			sidecars = append(sidecars, OauthProxyContainer("skupper"))
+			mounts = append(mounts, []corev1.VolumeMount{})
+			kube.AppendSecretVolume(&volumes, &mounts[1], "skupper-proxy-certs", "/etc/tls/proxy-certs/")
+		} else if options.AuthMode == string(types.ConsoleAuthModeInternal) {
+			kube.AppendSecretVolume(&volumes, &mounts[0], "skupper-console-users", "/etc/qpid-dispatch/sasl-users/")
+			kube.AppendConfigVolume(&volumes, &mounts[0], "skupper-sasl-config", "/etc/sasl2/")
+		}
 	}
-	van.Transport.Volumes = *volumes
-	van.Transport.VolumeMounts = *mounts
+	van.Transport.Volumes = volumes
+	van.Transport.VolumeMounts = mounts
+	van.Transport.Sidecars = sidecars
 
 	roles := []types.Role{}
 	roles = append(roles, types.Role{
@@ -279,7 +390,7 @@ func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanC
 	annotation := map[string]string{}
 	if options.AuthMode == string(types.ConsoleAuthModeOpenshift) {
 		annotation = map[string]string{
-			"serviceaccounts.openshift.io/oauth-redirectreference.primary": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"skupper-console\"}}",
+			"serviceaccounts.openshift.io/oauth-redirectreference.primary": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"skupper-router-console\"}}",
 		}
 	}
 	serviceAccounts = append(serviceAccounts, types.ServiceAccount{
@@ -290,11 +401,13 @@ func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanC
 
 	cas := []types.CertAuthority{}
 	cas = append(cas, types.CertAuthority{
-		Name: "skupper-ca",
+		Name:      "skupper-ca",
+		SiteOwner: true,
 	})
 	if !options.IsEdge {
 		cas = append(cas, types.CertAuthority{
-			Name: "skupper-internal-ca",
+			Name:      "skupper-internal-ca",
+			SiteOwner: false,
 		})
 	}
 	van.CertAuthoritys = cas
@@ -304,9 +417,10 @@ func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanC
 		CA:          "skupper-ca",
 		Name:        "skupper-amqps",
 		Subject:     "skupper-messaging",
-		Hosts:       "skupper-messaging,skupper-messaging." + client.Namespace + ".svc.cluster.local",
+		Hosts:       "skupper-messaging,skupper-messaging." + cli.Namespace + ".svc.cluster.local",
 		ConnectJson: false,
 		Post:        false,
+		SiteOwner:   true,
 	})
 	credentials = append(credentials, types.Credential{
 		CA:          "skupper-ca",
@@ -315,6 +429,7 @@ func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanC
 		Hosts:       "",
 		ConnectJson: true,
 		Post:        false,
+		SiteOwner:   true,
 	})
 	// TODO: deal with clusterLocal and .Routes != nil
 	if !options.IsEdge {
@@ -329,6 +444,21 @@ func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanC
 			Hosts:       "",
 			ConnectJson: false,
 			Post:        post,
+			SiteOwner:   false,
+		})
+	}
+	if options.AuthMode == string(types.ConsoleAuthModeInternal) {
+		credentials = append(credentials, types.Credential{
+			CA:          "",
+			Name:        "skupper-console-users",
+			Subject:     "",
+			Hosts:       "",
+			ConnectJson: false,
+			Post:        false,
+			SiteOwner:   true,
+			Data: map[string][]byte{
+				options.User: []byte(options.Password),
+			},
 		})
 	}
 	van.Credentials = credentials
@@ -347,26 +477,27 @@ func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanC
 		},
 		Type:        "",
 		Annotations: map[string]string{},
+		SiteOwner:   true,
 	})
-	if options.EnableConsole {
+	if options.EnableRouterConsole {
 		if options.AuthMode == string(types.ConsoleAuthModeOpenshift) {
 			svcs = append(svcs, types.Service{
-				Name: "skupper-console",
+				Name: "skupper-router-console",
 				Ports: []corev1.ServicePort{
 					corev1.ServicePort{
 						Name:       "console",
 						Protocol:   "TCP",
 						Port:       443,
-						TargetPort: intstr.FromInt(443),
+						TargetPort: intstr.FromInt(8443),
 					},
 				},
 				Type:        "",
 				Annotations: map[string]string{"service.alpha.openshift.io/serving-cert-secret-name": "skupper-proxy-certs"},
-				Termination: routev1.TLSTerminationReencrypt,
+				SiteOwner:   true,
 			})
 		} else {
 			svcs = append(svcs, types.Service{
-				Name: "skupper-console",
+				Name: "skupper-router-console",
 				Ports: []corev1.ServicePort{
 					corev1.ServicePort{
 						Name:       "console",
@@ -377,15 +508,13 @@ func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanC
 				},
 				Type:        "",
 				Annotations: map[string]string{},
-				Termination: routev1.TLSTerminationEdge,
+				SiteOwner:   true,
 			})
-			// if authmode internl then sasl config map and sasl users
-			// pick it up here!!!!
 		}
 	}
 	if !options.IsEdge {
 		svctype := "ClusterIP"
-		if !options.ClusterLocal && client.RouteClient == nil {
+		if !options.ClusterLocal && cli.RouteClient == nil {
 			svctype = "LoadBalancer"
 		}
 		svcs = append(svcs, types.Service{
@@ -406,35 +535,42 @@ func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanC
 			},
 			Type:        svctype,
 			Annotations: map[string]string{},
-			Termination: routev1.TLSTerminationEdge,
+			SiteOwner:   false,
 		})
 	}
 	van.Transport.Services = svcs
 
 	routes := []types.Route{}
-	if !options.ClusterLocal && client.RouteClient != nil {
+	if !options.ClusterLocal && cli.RouteClient != nil {
 		routes = append(routes, types.Route{
 			Name:          types.InterRouterRouteName,
 			TargetService: types.InterRouterProfile,
 			TargetPort:    types.InterRouterRole,
 			Termination:   routev1.TLSTerminationPassthrough,
+			SiteOwner:     false,
 		})
 		routes = append(routes, types.Route{
 			Name:          types.EdgeRouteName,
 			TargetService: types.InterRouterProfile,
 			TargetPort:    types.EdgeRole,
 			Termination:   routev1.TLSTerminationPassthrough,
+			SiteOwner:     false,
 		})
 	}
-	if options.EnableConsole && client.RouteClient != nil {
+	if options.EnableRouterConsole && cli.RouteClient != nil {
+		termination := routev1.TLSTerminationEdge
+		if options.AuthMode == string(types.ConsoleAuthModeOpenshift) {
+			termination = routev1.TLSTerminationReencrypt
+		}
 		routes = append(routes, types.Route{
 			Name:          "skupper-router-console",
-			TargetService: types.ConsoleServiceName,
+			TargetService: "skupper-router-console",
 			TargetPort:    types.ConsolePortName,
-			Termination:   routev1.TLSTerminationEdge,
+			Termination:   termination,
+			SiteOwner:     true,
 		})
 	}
-	van.Assembly.Routes = routes
+	van.Transport.Routes = routes
 
 	return van
 }
@@ -442,7 +578,7 @@ func GetVanRouterSpecFromOpts(options types.VanRouterCreateOptions, client *VanC
 // VanRouterCreate instantiates a VAN (router and controller) deployment
 func (cli *VanClient) VanRouterCreate(ctx context.Context, options types.VanRouterCreateOptions) error {
 	// todo return error
-	if options.EnableConsole {
+	if options.EnableRouterConsole || options.EnableConsole {
 		if options.AuthMode == string(types.ConsoleAuthModeInternal) || options.AuthMode == "" {
 			options.AuthMode = string(types.ConsoleAuthModeInternal)
 			if options.User == "" {
@@ -461,50 +597,78 @@ func (cli *VanClient) VanRouterCreate(ctx context.Context, options types.VanRout
 		}
 	}
 
-	van := GetVanRouterSpecFromOpts(options, cli)
+	van := cli.GetVanRouterSpecFromOpts(options)
 
-	dep, err := kube.NewTransportDeployment(van, cli.KubeClient)
+	siteData := &map[string]string{
+		"id":   utils.RandomId(10),
+		"name": van.Name,
+	}
+	siteConfig, err := kube.NewConfigMap(types.DefaultSiteName, siteData, nil, van.Namespace, cli.KubeClient)
 	if err != nil {
 		return err
 	}
-	ownerRef := kube.GetOwnerReference(dep)
-	if options.AuthMode == string(types.ConsoleAuthModeInternal) {
-		if err := cli.ensureSaslConfig(&ownerRef); err != nil {
-			return err
-		}
-		if err := cli.ensureSaslUsers(options.User, options.Password, &ownerRef); err != nil {
-			return err
-		}
+
+	siteOwnerRef := kube.GetConfigMapOwnerReference(siteConfig)
+	dep, err := kube.NewTransportDeployment(van, &siteOwnerRef, cli.KubeClient)
+	if err != nil {
+		return err
 	}
 
+	transportOwnerRef := kube.GetDeploymentOwnerReference(dep)
+	if options.AuthMode == string(types.ConsoleAuthModeInternal) {
+		config := `
+pwcheck_method: auxprop
+auxprop_plugin: sasldb
+sasldb_path: /tmp/qdrouterd.sasldb
+`
+		saslData := &map[string]string{
+			"qdrouterd.conf": config,
+		}
+		kube.NewConfigMap("skupper-sasl-config", saslData, &transportOwnerRef, van.Namespace, cli.KubeClient)
+	}
 	for _, sa := range van.Transport.ServiceAccounts {
-		kube.NewServiceAccountWithOwner(sa, ownerRef, van.Namespace, cli.KubeClient)
+		kube.NewServiceAccount(sa, &transportOwnerRef, van.Namespace, cli.KubeClient)
 	}
 	for _, role := range van.Transport.Roles {
-		kube.NewRoleWithOwner(role, ownerRef, van.Namespace, cli.KubeClient)
+		kube.NewRole(role, &transportOwnerRef, van.Namespace, cli.KubeClient)
 	}
 	for _, roleBinding := range van.Transport.RoleBindings {
-		kube.NewRoleBindingWithOwner(roleBinding, ownerRef, van.Namespace, cli.KubeClient)
+		kube.NewRoleBinding(roleBinding, &transportOwnerRef, van.Namespace, cli.KubeClient)
 	}
 	for _, ca := range van.CertAuthoritys {
-		kube.NewCertAuthorityWithOwner(ca, ownerRef, van.Namespace, cli.KubeClient)
+		ownerRef := siteOwnerRef
+		if !ca.SiteOwner {
+			ownerRef = transportOwnerRef
+		}
+		kube.NewCertAuthority(ca, &ownerRef, van.Namespace, cli.KubeClient)
 	}
 	for _, cred := range van.Credentials {
 		if !cred.Post {
-			kube.NewSecretWithOwner(cred, ownerRef, van.Namespace, cli.KubeClient)
+			ownerRef := siteOwnerRef
+			if !cred.SiteOwner {
+				ownerRef = transportOwnerRef
+			}
+			kube.NewSecret(cred, &ownerRef, van.Namespace, cli.KubeClient)
 		}
 	}
 	for _, svc := range van.Transport.Services {
-		kube.NewServiceWithOwner(svc, ownerRef, van.Namespace, cli.KubeClient)
+		ownerRef := siteOwnerRef
+		if !svc.SiteOwner {
+			ownerRef = transportOwnerRef
+		}
+		kube.NewService(svc, van.Transport.Labels, &ownerRef, van.Namespace, cli.KubeClient)
 	}
 	if cli.RouteClient != nil {
-		for _, rte := range van.Assembly.Routes {
-			kube.NewRouteWithOwner(rte, ownerRef, van.Namespace, cli.RouteClient)
+		for _, rte := range van.Transport.Routes {
+			ownerRef := siteOwnerRef
+			if !rte.SiteOwner {
+				ownerRef = transportOwnerRef
+			}
+			kube.NewRoute(rte, &ownerRef, van.Namespace, cli.RouteClient)
 		}
 	}
 
-	// TODO: should this be part of van spec?
-	kube.NewConfigMapWithOwner("skupper-services", ownerRef, van.Namespace, cli.KubeClient)
+	kube.NewConfigMap("skupper-services", nil, &transportOwnerRef, van.Namespace, cli.KubeClient)
 
 	if !options.IsEdge {
 		for _, cred := range van.Credentials {
@@ -545,100 +709,44 @@ func (cli *VanClient) VanRouterCreate(ctx context.Context, options types.VanRout
 						}
 					}
 				}
-				kube.NewSecretWithOwner(cred, ownerRef, van.Namespace, cli.KubeClient)
+				ownerRef := siteOwnerRef
+				if !cred.SiteOwner {
+					ownerRef = transportOwnerRef
+				}
+				kube.NewSecret(cred, &ownerRef, van.Namespace, cli.KubeClient)
 			}
 		}
 	}
 
 	if options.EnableController {
-		GetVanControllerSpec(options, van, dep)
-		depController, err := kube.NewControllerDeployment(van, ownerRef, cli.KubeClient)
+		cli.GetVanControllerSpec(options, van, dep)
+		depController, err := kube.NewControllerDeployment(van, transportOwnerRef, cli.KubeClient)
 		if err != nil {
 			return err
 		}
-		ownerRef = kube.GetOwnerReference(depController)
+		ownerRef := kube.GetDeploymentOwnerReference(depController)
 		for _, sa := range van.Controller.ServiceAccounts {
-			kube.NewServiceAccountWithOwner(sa, ownerRef, van.Namespace, cli.KubeClient)
+			kube.NewServiceAccount(sa, &ownerRef, van.Namespace, cli.KubeClient)
 		}
 		for _, role := range van.Controller.Roles {
-			kube.NewRoleWithOwner(role, ownerRef, van.Namespace, cli.KubeClient)
+			kube.NewRole(role, &ownerRef, van.Namespace, cli.KubeClient)
 		}
 		for _, roleBinding := range van.Controller.RoleBindings {
-			kube.NewRoleBindingWithOwner(roleBinding, ownerRef, van.Namespace, cli.KubeClient)
+			kube.NewRoleBinding(roleBinding, &ownerRef, van.Namespace, cli.KubeClient)
 		}
-	}
-
-	return nil
-}
-
-func (cli *VanClient) ensureSaslConfig(owner *metav1.OwnerReference) error {
-	name := "skupper-sasl-config"
-	_, err := cli.KubeClient.CoreV1().ConfigMaps(cli.Namespace).Get(name, metav1.GetOptions{})
-	if err == nil {
-		fmt.Println("sasl config already exists")
-	} else if errors.IsNotFound(err) {
-		config := `
-pwcheck_method: auxprop
-auxprop_plugin: sasldb
-sasldb_path: /tmp/qdrouterd.sasldb
-`
-		configMap := &corev1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "apps/v1",
-				Kind:       "ConfigMap",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: name,
-			},
-			Data: map[string]string{
-				"qdrouterd.conf": config,
-			},
+		for _, svc := range van.Controller.Services {
+			kube.NewService(svc, van.Controller.Labels, &siteOwnerRef, van.Namespace, cli.KubeClient)
 		}
-		if owner != nil {
-			configMap.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-				*owner,
+		if cli.RouteClient != nil {
+			for _, rte := range van.Controller.Routes {
+				ownerRef := siteOwnerRef
+				if !rte.SiteOwner {
+					ownerRef = transportOwnerRef
+				}
+				kube.NewRoute(rte, &ownerRef, van.Namespace, cli.RouteClient)
 			}
 		}
-		_, err := cli.KubeClient.CoreV1().ConfigMaps(cli.Namespace).Create(configMap)
-		if err != nil {
-			return fmt.Errorf("Failed to create sasl config: %w", err)
-		}
-	} else {
-		return fmt.Errorf("Failed to check for sasl config: %w", err)
 	}
-	return nil
-}
 
-func (cli *VanClient) ensureSaslUsers(user string, password string, owner *metav1.OwnerReference) error {
-	name := "skupper-console-users"
-	_, err := cli.KubeClient.CoreV1().Secrets(cli.Namespace).Get(name, metav1.GetOptions{})
-	if err == nil {
-		fmt.Println("console users secret already exists")
-	} else if errors.IsNotFound(err) {
-		secret := corev1.Secret{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "Secret",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: name,
-			},
-			Data: map[string][]byte{
-				user: []byte(password),
-			},
-		}
-		if owner != nil {
-			secret.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-				*owner,
-			}
-		}
-
-		_, err := cli.KubeClient.CoreV1().Secrets(cli.Namespace).Create(&secret)
-		if err != nil {
-			return fmt.Errorf("Failed to create console users secret: %w", err)
-		}
-	} else {
-		return fmt.Errorf("Failed to create console users secret: %w", err)
-	}
 	return nil
 }

--- a/client/van_router_create_test.go
+++ b/client/van_router_create_test.go
@@ -11,6 +11,7 @@ import (
 	"gotest.tools/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 )
@@ -23,64 +24,152 @@ func transform(in []string) []string {
 
 func TestVanRouterCreateDefaults(t *testing.T) {
 	testcases := []struct {
-		doc              string
-		namespace        string
-		expectedError    string
-		skupperName      string
-		isEdge           bool
-		enableController bool
-		clusterLocal     bool
-		depsExpected     []string
-		cmsExpected      []string
-		svcsExpected     []string
+		doc                  string
+		namespace            string
+		expectedError        string
+		skupperName          string
+		isEdge               bool
+		enableController     bool
+		enableRouterConsole  bool
+		authMode             string
+		clusterLocal         bool
+		depsExpected         []string
+		cmsExpected          []string
+		rolesExpected        []string
+		roleBindingsExpected []string
+		secretsExpected      []string
+		svcsExpected         []string
+		svcAccountsExpected  []string
 	}{
 		{
-			namespace:        "skupper",
-			expectedError:    "",
-			doc:              "test one",
-			skupperName:      "skupper1",
-			isEdge:           false,
-			enableController: true,
-			clusterLocal:     true,
-			depsExpected:     []string{"skupper-proxy-controller", "skupper-router"},
-			cmsExpected:      []string{"skupper-services"},
-			svcsExpected:     []string{"skupper-messaging", "skupper-internal"},
+			namespace:            "skupper",
+			expectedError:        "",
+			doc:                  "test one",
+			skupperName:          "skupper1",
+			isEdge:               false,
+			enableController:     true,
+			enableRouterConsole:  false,
+			authMode:             "",
+			clusterLocal:         true,
+			depsExpected:         []string{"skupper-proxy-controller", "skupper-router"},
+			cmsExpected:          []string{"skupper-site", "skupper-services"},
+			rolesExpected:        []string{"skupper-view", "skupper-edit"},
+			roleBindingsExpected: []string{"skupper-skupper-view", "skupper-proxy-controller-skupper-edit"},
+			secretsExpected: []string{"skupper-ca",
+				"skupper-internal-ca",
+				"skupper-amqps",
+				"skupper",
+				"skupper-internal"},
+			svcsExpected:        []string{"skupper-messaging", "skupper-internal", "skupper-controller"},
+			svcAccountsExpected: []string{"skupper", "skupper-proxy-controller"},
 		},
 		{
-			namespace:        "skupper",
-			expectedError:    "Failed to get LoadBalancer IP or Hostname for service skupper-internal",
-			doc:              "test two",
-			skupperName:      "skupper2",
-			isEdge:           false,
-			enableController: true,
-			clusterLocal:     false,
-			depsExpected:     []string{"skupper-router"},
-			cmsExpected:      []string{"skupper-services"},
-			svcsExpected:     []string{"skupper-messaging", "skupper-internal"},
+			namespace:            "skupper",
+			expectedError:        "Failed to get LoadBalancer IP or Hostname for service skupper-internal",
+			doc:                  "test two",
+			skupperName:          "skupper2",
+			isEdge:               false,
+			enableController:     true,
+			enableRouterConsole:  false,
+			authMode:             "",
+			clusterLocal:         false,
+			depsExpected:         []string{"skupper-router"},
+			cmsExpected:          []string{"skupper-site", "skupper-services"},
+			rolesExpected:        []string{"skupper-view"},
+			roleBindingsExpected: []string{"skupper-skupper-view"},
+			secretsExpected: []string{"skupper-ca",
+				"skupper-internal-ca",
+				"skupper-amqps",
+				"skupper"},
+			svcsExpected:        []string{"skupper-messaging", "skupper-internal"},
+			svcAccountsExpected: []string{"skupper"},
 		},
 		{
-			namespace:        "skupper",
-			expectedError:    "",
-			doc:              "test three",
-			skupperName:      "skupper3",
-			isEdge:           true,
-			enableController: true,
-			clusterLocal:     true,
-			depsExpected:     []string{"skupper-router", "skupper-proxy-controller"},
-			cmsExpected:      []string{"skupper-services"},
-			svcsExpected:     []string{"skupper-messaging"},
+			namespace:            "skupper",
+			expectedError:        "",
+			doc:                  "test three",
+			skupperName:          "skupper3",
+			isEdge:               true,
+			enableController:     true,
+			enableRouterConsole:  false,
+			authMode:             "",
+			clusterLocal:         true,
+			depsExpected:         []string{"skupper-router", "skupper-proxy-controller"},
+			cmsExpected:          []string{"skupper-site", "skupper-services"},
+			rolesExpected:        []string{"skupper-view", "skupper-edit"},
+			roleBindingsExpected: []string{"skupper-skupper-view", "skupper-proxy-controller-skupper-edit"},
+			secretsExpected: []string{"skupper-ca",
+				"skupper-amqps",
+				"skupper"},
+			svcsExpected:        []string{"skupper-messaging", "skupper-controller"},
+			svcAccountsExpected: []string{"skupper", "skupper-proxy-controller"},
 		},
 		{
-			namespace:        "skupper",
-			expectedError:    "",
-			doc:              "test four",
-			skupperName:      "skupper4",
-			isEdge:           false,
-			enableController: false,
-			clusterLocal:     true,
-			depsExpected:     []string{"skupper-router"},
-			cmsExpected:      []string{"skupper-services"},
-			svcsExpected:     []string{"skupper-messaging", "skupper-internal"},
+			namespace:            "skupper",
+			expectedError:        "",
+			doc:                  "test four",
+			skupperName:          "skupper4",
+			isEdge:               false,
+			enableController:     false,
+			enableRouterConsole:  false,
+			authMode:             "",
+			clusterLocal:         true,
+			depsExpected:         []string{"skupper-router"},
+			cmsExpected:          []string{"skupper-site", "skupper-services"},
+			rolesExpected:        []string{"skupper-view"},
+			roleBindingsExpected: []string{"skupper-skupper-view"},
+			secretsExpected: []string{"skupper-ca",
+				"skupper-internal-ca",
+				"skupper-amqps",
+				"skupper",
+				"skupper-internal"},
+			svcsExpected:        []string{"skupper-messaging", "skupper-internal"},
+			svcAccountsExpected: []string{"skupper"},
+		},
+		{
+			namespace:            "gilligan",
+			expectedError:        "",
+			doc:                  "test five",
+			skupperName:          "skupper5",
+			isEdge:               false,
+			enableController:     true,
+			enableRouterConsole:  true,
+			authMode:             "internal",
+			clusterLocal:         true,
+			depsExpected:         []string{"skupper-proxy-controller", "skupper-router"},
+			cmsExpected:          []string{"skupper-site", "skupper-services", "skupper-sasl-config"},
+			rolesExpected:        []string{"skupper-view", "skupper-edit"},
+			roleBindingsExpected: []string{"skupper-skupper-view", "skupper-proxy-controller-skupper-edit"},
+			secretsExpected: []string{"skupper-ca",
+				"skupper-internal-ca",
+				"skupper-amqps",
+				"skupper",
+				"skupper-internal",
+				"skupper-console-users"},
+			svcsExpected:        []string{"skupper-messaging", "skupper-internal", "skupper-controller", "skupper-router-console"},
+			svcAccountsExpected: []string{"skupper", "skupper-proxy-controller"},
+		},
+		{
+			namespace:            "ginger",
+			expectedError:        "",
+			doc:                  "test six",
+			skupperName:          "skupper6",
+			isEdge:               false,
+			enableController:     true,
+			enableRouterConsole:  true,
+			authMode:             "openshift",
+			clusterLocal:         true,
+			depsExpected:         []string{"skupper-proxy-controller", "skupper-router"},
+			cmsExpected:          []string{"skupper-site", "skupper-services"},
+			rolesExpected:        []string{"skupper-view", "skupper-edit"},
+			roleBindingsExpected: []string{"skupper-skupper-view", "skupper-proxy-controller-skupper-edit"},
+			secretsExpected: []string{"skupper-ca",
+				"skupper-internal-ca",
+				"skupper-amqps",
+				"skupper",
+				"skupper-internal"},
+			svcsExpected:        []string{"skupper-messaging", "skupper-internal", "skupper-controller", "skupper-router-console"},
+			svcAccountsExpected: []string{"skupper", "skupper-proxy-controller"},
 		},
 	}
 
@@ -96,7 +185,11 @@ func TestVanRouterCreateDefaults(t *testing.T) {
 
 		depsFound := []string{}
 		cmsFound := []string{}
+		rolesFound := []string{}
+		roleBindingsFound := []string{}
+		secretsFound := []string{}
 		svcsFound := []string{}
+		svcAccountsFound := []string{}
 
 		// Create the client
 		cli, err := newMockClient(c.namespace, "", "")
@@ -117,6 +210,27 @@ func TestVanRouterCreateDefaults(t *testing.T) {
 				cmsFound = append(cmsFound, cm.Name)
 			},
 		})
+		roleInformer := informers.Rbac().V1().Roles().Informer()
+		roleInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				role := obj.(*rbacv1.Role)
+				rolesFound = append(rolesFound, role.Name)
+			},
+		})
+		roleBindingInformer := informers.Rbac().V1().RoleBindings().Informer()
+		roleBindingInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				roleBinding := obj.(*rbacv1.RoleBinding)
+				roleBindingsFound = append(roleBindingsFound, roleBinding.Name)
+			},
+		})
+		secretInformer := informers.Core().V1().Secrets().Informer()
+		secretInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				secret := obj.(*corev1.Secret)
+				secretsFound = append(secretsFound, secret.Name)
+			},
+		})
 		svcInformer := informers.Core().V1().Services().Informer()
 		svcInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
@@ -124,21 +238,33 @@ func TestVanRouterCreateDefaults(t *testing.T) {
 				svcsFound = append(svcsFound, svc.Name)
 			},
 		})
+		svcAccountInformer := informers.Core().V1().ServiceAccounts().Informer()
+		svcAccountInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				svcAccount := obj.(*corev1.ServiceAccount)
+				svcAccountsFound = append(svcAccountsFound, svcAccount.Name)
+			},
+		})
 		informers.Start(ctx.Done())
 		cache.WaitForCacheSync(ctx.Done(), depInformer.HasSynced)
 		cache.WaitForCacheSync(ctx.Done(), cmInformer.HasSynced)
+		cache.WaitForCacheSync(ctx.Done(), roleInformer.HasSynced)
+		cache.WaitForCacheSync(ctx.Done(), roleBindingInformer.HasSynced)
+		cache.WaitForCacheSync(ctx.Done(), secretInformer.HasSynced)
 		cache.WaitForCacheSync(ctx.Done(), svcInformer.HasSynced)
+		cache.WaitForCacheSync(ctx.Done(), svcAccountInformer.HasSynced)
 
 		err = cli.VanRouterCreate(ctx, types.VanRouterCreateOptions{
-			SkupperName:       c.skupperName,
-			IsEdge:            c.isEdge,
-			EnableController:  c.enableController,
-			EnableServiceSync: true,
-			EnableConsole:     false,
-			AuthMode:          "",
-			User:              "",
-			Password:          "",
-			ClusterLocal:      c.clusterLocal,
+			SkupperName:         c.skupperName,
+			IsEdge:              c.isEdge,
+			EnableController:    c.enableController,
+			EnableServiceSync:   true,
+			EnableRouterConsole: c.enableRouterConsole,
+			AuthMode:            c.authMode,
+			EnableConsole:       false,
+			User:                "",
+			Password:            "",
+			ClusterLocal:        c.clusterLocal,
 		})
 
 		// TODO: make more deterministic
@@ -150,6 +276,10 @@ func TestVanRouterCreateDefaults(t *testing.T) {
 		}
 		assert.Assert(t, cmp.Equal(c.depsExpected, depsFound, trans), c.doc)
 		assert.Assert(t, cmp.Equal(c.cmsExpected, cmsFound, trans), c.doc)
+		assert.Assert(t, cmp.Equal(c.rolesExpected, rolesFound, trans), c.doc)
+		assert.Assert(t, cmp.Equal(c.roleBindingsExpected, roleBindingsFound, trans), c.doc)
+		assert.Assert(t, cmp.Equal(c.secretsExpected, secretsFound, trans), c.doc)
 		assert.Assert(t, cmp.Equal(c.svcsExpected, svcsFound, trans), c.doc)
+		assert.Assert(t, cmp.Equal(c.svcAccountsExpected, svcAccountsFound, trans), c.doc)
 	}
 }

--- a/client/van_router_remove.go
+++ b/client/van_router_remove.go
@@ -12,13 +12,13 @@ import (
 
 // VanRouterRemove delete a VAN (router and controller) deployment
 func (cli *VanClient) VanRouterRemove(ctx context.Context) error {
-	err := cli.KubeClient.AppsV1().Deployments(cli.Namespace).Delete(types.TransportDeploymentName, &metav1.DeleteOptions{})
-	if err == nil {
-		fmt.Println("Skupper is now removed from '" + cli.Namespace + "'.")
-	} else if errors.IsNotFound(err) {
-		fmt.Println("Skupper not installed in '" + cli.Namespace + "'.")
-	} else {
-		fmt.Println("Error while trying to delete:", err.Error())
+	err := cli.KubeClient.CoreV1().ConfigMaps(cli.Namespace).Delete(types.DefaultSiteName, &metav1.DeleteOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("Skupper not installed in '"+cli.Namespace+"': %s", err.Error())
+		} else {
+			return fmt.Errorf("Error while trying to delete: %w", err.Error())
+		}
 	}
-	return err
+	return nil
 }

--- a/client/van_serviceinterface_create.go
+++ b/client/van_serviceinterface_create.go
@@ -32,7 +32,7 @@ func (cli *VanClient) VanServiceInterfaceCreate(ctx context.Context, targetType 
 	} else if options.Headless && targetType != "statefulset" {
 		return fmt.Errorf("The headless option is only supported for statefulsets")
 	} else {
-		owner := kube.GetOwnerReference(current)
+		owner := kube.GetDeploymentOwnerReference(current)
 		if targetType == "deployment" {
 			target, err := cli.KubeClient.AppsV1().Deployments(cli.Namespace).Get(targetName, metav1.GetOptions{})
 			if err == nil {

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -134,7 +134,7 @@ func main() {
 			cli, _ := client.NewClient(namespace, kubeContext, kubeconfig)
 			err := cli.VanConnectorRemove(context.Background(), args[0])
 			if err == nil {
-				fmt.Println("Connection %s has been removed", args[0])
+				fmt.Println("Connection '" + args[0] + "' has been removed")
 			} else {
 				fmt.Println("Failed to remove connection: ", err.Error())
 			}

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -295,7 +295,6 @@ func main() {
 	cmdExpose.Flags().IntVar(&(vanServiceInterfaceCreateOpts.Port), "port", 0, "The port to expose on")
 	cmdExpose.Flags().IntVar(&(vanServiceInterfaceCreateOpts.TargetPort), "target-port", 0, "The port to target on pods")
 	cmdExpose.Flags().BoolVar(&(vanServiceInterfaceCreateOpts.Headless), "headless", false, "Expose through a headless service (valid only for a statefulset target)")
-	cmdExpose.Flags().StringVar(&(vanServiceInterfaceCreateOpts.Aggregate), "aggregate", "", "Aggregation strategy (one of 'json' or 'multipart').")
 
 	var unexposeAddress string
 	var cmdUnexpose = &cobra.Command{

--- a/pkg/kube/deployments.go
+++ b/pkg/kube/deployments.go
@@ -14,7 +14,7 @@ import (
 	"github.com/skupperproject/skupper/api/types"
 )
 
-func GetOwnerReference(dep *appsv1.Deployment) metav1.OwnerReference {
+func GetDeploymentOwnerReference(dep *appsv1.Deployment) metav1.OwnerReference {
 	return metav1.OwnerReference{
 		APIVersion: "apps/v1",
 		Kind:       "Deployment",
@@ -59,7 +59,7 @@ func NewProxyStatefulSet(serviceInterface types.ServiceInterface, namespace stri
 		return nil, err
 	}
 
-	ownerRef := GetOwnerReference(transportDep)
+	ownerRef := GetDeploymentOwnerReference(transportDep)
 
 	var imageName string
 	if os.Getenv("PROXY_IMAGE") != "" {
@@ -168,7 +168,7 @@ func NewProxyDeployment(serviceInterface types.ServiceInterface, namespace strin
 		return nil, err
 	}
 
-	ownerRef := GetOwnerReference(transportDep)
+	ownerRef := GetDeploymentOwnerReference(transportDep)
 
 	var imageName string
 	if os.Getenv("PROXY_IMAGE") != "" {
@@ -291,8 +291,14 @@ func NewControllerDeployment(van *types.VanRouterSpec, ownerRef metav1.OwnerRefe
 			},
 		}
 
+		for _, sc := range van.Controller.Sidecars {
+			dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers, *sc)
+		}
+
 		dep.Spec.Template.Spec.Volumes = van.Controller.Volumes
-		dep.Spec.Template.Spec.Containers[0].VolumeMounts = van.Controller.VolumeMounts
+		for i, _ := range van.Controller.VolumeMounts {
+			dep.Spec.Template.Spec.Containers[i].VolumeMounts = van.Controller.VolumeMounts[i]
+		}
 
 		created, err := deployments.Create(dep)
 		if err != nil {
@@ -307,7 +313,7 @@ func NewControllerDeployment(van *types.VanRouterSpec, ownerRef metav1.OwnerRefe
 	}
 }
 
-func NewTransportDeployment(van *types.VanRouterSpec, cli kubernetes.Interface) (*appsv1.Deployment, error) {
+func NewTransportDeployment(van *types.VanRouterSpec, owner *metav1.OwnerReference, cli kubernetes.Interface) (*appsv1.Deployment, error) {
 	deployments := cli.AppsV1().Deployments(van.Namespace)
 	existing, err := deployments.Get(types.TransportDeploymentName, metav1.GetOptions{})
 	if err == nil {
@@ -340,8 +346,19 @@ func NewTransportDeployment(van *types.VanRouterSpec, cli kubernetes.Interface) 
 			},
 		}
 
+		for _, sc := range van.Transport.Sidecars {
+			dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers, *sc)
+		}
+
+		if owner != nil {
+			dep.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+				*owner,
+			}
+		}
 		dep.Spec.Template.Spec.Volumes = van.Transport.Volumes
-		dep.Spec.Template.Spec.Containers[0].VolumeMounts = van.Transport.VolumeMounts
+		for i, _ := range van.Transport.VolumeMounts {
+			dep.Spec.Template.Spec.Containers[i].VolumeMounts = van.Transport.VolumeMounts[i]
+		}
 
 		created, err := deployments.Create(dep)
 		if err != nil {

--- a/pkg/kube/roles.go
+++ b/pkg/kube/roles.go
@@ -12,28 +12,37 @@ import (
 	"github.com/skupperproject/skupper/api/types"
 )
 
-func NewRoleWithOwner(newrole types.Role, owner metav1.OwnerReference, namespace string, kubeclient kubernetes.Interface) (*rbacv1.Role, error) {
-	role := &rbacv1.Role{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "rbac.authorization.k8s.io/v1",
-			Kind:       "Role",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            newrole.Name,
-			OwnerReferences: []metav1.OwnerReference{owner},
-		},
-		Rules: newrole.Rules,
-	}
-	actual, err := kubeclient.RbacV1().Roles(namespace).Create(role)
-	if err != nil {
-		// TODO : come up with a policy for already-exists errors.
-		if errors.IsAlreadyExists(err) {
-			fmt.Println("Role", newrole.Name, "already exists")
-			return actual, nil
-		} else {
-			return actual, fmt.Errorf("Could not create role %s: %w", newrole.Name, err)
+func NewRole(newrole types.Role, owner *metav1.OwnerReference, namespace string, kubeclient kubernetes.Interface) (*rbacv1.Role, error) {
+	roles := kubeclient.RbacV1().Roles(namespace)
+	existing, err := roles.Get(newrole.Name, metav1.GetOptions{})
+	if err == nil {
+		//TODO: already exists
+		return existing, nil
+	} else if errors.IsNotFound(err) {
+		role := &rbacv1.Role{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "rbac.authorization.k8s.io/v1",
+				Kind:       "Role",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: newrole.Name,
+			},
+			Rules: newrole.Rules,
 		}
+		if owner != nil {
+			role.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+				*owner,
+			}
+		}
+		created, err := roles.Create(role)
 
+		if err != nil {
+			return nil, fmt.Errorf("Failed to crate role: %w", err)
+		} else {
+			return created, nil
+		}
+	} else {
+		role := &rbacv1.Role{}
+		return role, fmt.Errorf("Failed to check existing config maps: %w", err)
 	}
-	return actual, nil
 }

--- a/pkg/kube/routes.go
+++ b/pkg/kube/routes.go
@@ -17,7 +17,7 @@ func GetRoute(name string, namespace string, rc *routev1client.RouteV1Client) (*
 	return current, err
 }
 
-func NewRouteWithOwner(rte types.Route, owner metav1.OwnerReference, namespace string, rc *routev1client.RouteV1Client) (*routev1.Route, error) {
+func NewRoute(rte types.Route, owner *metav1.OwnerReference, namespace string, rc *routev1client.RouteV1Client) (*routev1.Route, error) {
 	insecurePolicy := routev1.InsecureEdgeTerminationPolicyNone
 	if rte.Termination != routev1.TLSTerminationPassthrough {
 		insecurePolicy = routev1.InsecureEdgeTerminationPolicyRedirect
@@ -32,8 +32,7 @@ func NewRouteWithOwner(rte types.Route, owner metav1.OwnerReference, namespace s
 				Kind:       "Route",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            rte.Name,
-				OwnerReferences: []metav1.OwnerReference{owner},
+				Name: rte.Name,
 			},
 			Spec: routev1.RouteSpec{
 				Path: "",
@@ -50,7 +49,11 @@ func NewRouteWithOwner(rte types.Route, owner metav1.OwnerReference, namespace s
 				},
 			},
 		}
-
+		if owner != nil {
+			route.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+				*owner,
+			}
+		}
 		created, err := rc.Routes(namespace).Create(route)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to create route : %w", err)

--- a/pkg/kube/secrets.go
+++ b/pkg/kube/secrets.go
@@ -84,11 +84,10 @@ func DeleteSecret(name string, namespace string, cli kubernetes.Interface) error
 	secrets := cli.CoreV1().Secrets(namespace)
 	err := secrets.Delete(name, &metav1.DeleteOptions{})
 	if err == nil {
-		fmt.Println("Secret", name, "deleted")
+		return err
 	} else if errors.IsNotFound(err) {
 		return fmt.Errorf("Secret %s does not exist.", name)
 	} else {
 		return fmt.Errorf("Failed to delete secret: %w", err)
 	}
-	return err
 }

--- a/pkg/kube/serviceaccounts.go
+++ b/pkg/kube/serviceaccounts.go
@@ -12,27 +12,38 @@ import (
 	"github.com/skupperproject/skupper/api/types"
 )
 
-func NewServiceAccountWithOwner(sa types.ServiceAccount, owner metav1.OwnerReference, namespace string, cli kubernetes.Interface) (*corev1.ServiceAccount, error) {
-	serviceaccount := &corev1.ServiceAccount{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "ServiceAccount",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            sa.ServiceAccount,
-			OwnerReferences: []metav1.OwnerReference{owner},
-			Annotations:     sa.Annotations,
-		},
-	}
-	actual, err := cli.CoreV1().ServiceAccounts(namespace).Create(serviceaccount)
-	if err != nil {
-		// TODO : come up with a policy for already-exists errors.
-		if errors.IsAlreadyExists(err) {
-			fmt.Println("Service account", sa.ServiceAccount, "already exists")
-			return actual, nil
-		} else {
-			return actual, fmt.Errorf("Could not create service account %s : %w", sa.ServiceAccount, err)
+func NewServiceAccount(sa types.ServiceAccount, owner *metav1.OwnerReference, namespace string, cli kubernetes.Interface) (*corev1.ServiceAccount, error) {
+	serviceAccounts := cli.CoreV1().ServiceAccounts(namespace)
+	existing, err := serviceAccounts.Get(sa.ServiceAccount, metav1.GetOptions{})
+	if err == nil {
+		//TODO: already exists
+		return existing, nil
+	} else if errors.IsNotFound(err) {
+		sa := &corev1.ServiceAccount{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "ServiceAccount",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        sa.ServiceAccount,
+				Annotations: sa.Annotations,
+			},
 		}
+		if owner != nil {
+			sa.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+				*owner,
+			}
+		}
+
+		created, err := serviceAccounts.Create(sa)
+
+		if err != nil {
+			return nil, fmt.Errorf("Failed to create service account: %w", err)
+		} else {
+			return created, nil
+		}
+	} else {
+		sa := &corev1.ServiceAccount{}
+		return sa, fmt.Errorf("Failed to check service account: %w", err)
 	}
-	return actual, nil
 }

--- a/pkg/utils/configs/config.go
+++ b/pkg/utils/configs/config.go
@@ -55,6 +55,7 @@ func QdrouterdConfig(assembly *types.AssemblySpec) string {
 router {
     mode: {{.Mode}}
     id: {{.Name}}-${HOSTNAME}
+    metadata: ${SKUPPER_SITE_ID}
 }
 {{range .Listeners}}
 


### PR DESCRIPTION
This patch adds missing console server setup:
- adds skupper-site
- updates owner refs
- adds metrics resources
- adds oauth proxy 
- test updates
- etc.