### PR TITLE
Supporting multiple namespaces creation and deletion

### DIFF
--- a/test/cluster/cluster_test_runner_test.go
+++ b/test/cluster/cluster_test_runner_test.go
@@ -1,0 +1,123 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/skupperproject/skupper/client"
+	"gotest.tools/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func NewMockClient(namespace string, context string, kubeConfigPath string) (*client.VanClient, error) {
+	return &client.VanClient{
+		Namespace:  namespace,
+		KubeClient: fake.NewSimpleClientset(),
+	}, nil
+}
+
+//TODO implementme
+//func verifyNamespaces(t *testing.T, ns NamespacesInterface, expected_namespaces []string)
+
+//add test of dns valid namespace
+func TestClusterContextNamespaceCreationDeletion(t *testing.T) {
+	var err error
+	ns_prefix := "ns-prefix"
+	kc := "someconfig"
+	//ctx := context.Background()
+
+	cc := BuildClusterContext(t, ns_prefix, kc, NewMockClient)
+	NamespacesClient := cc.VanClient.KubeClient.CoreV1().Namespaces()
+
+	assert.Equal(t, "", cc.CurrentNamespace)
+	assert.Equal(t, 0, len(cc.Namespaces))
+
+	err = cc.CreateNamespace()
+	t.Logf("curr namespace = %v\n", cc.CurrentNamespace)
+	assert.Equal(t, ns_prefix+"-1", cc.CurrentNamespace)
+	assert.Equal(t, 1, len(cc.Namespaces))
+	assert.Assert(t, err)
+
+	list, err := NamespacesClient.List(metav1.ListOptions{})
+	assert.Assert(t, err)
+	assert.Equal(t, 1, len(list.Items))
+	assert.Equal(t, ns_prefix+"-1", list.Items[0].Name)
+
+	err = cc.CreateNamespace()
+	assert.Equal(t, ns_prefix+"-2", cc.CurrentNamespace)
+	assert.Equal(t, 2, len(cc.Namespaces))
+	assert.Assert(t, err)
+
+	list, err = NamespacesClient.List(metav1.ListOptions{})
+	assert.Assert(t, err)
+	assert.Equal(t, 2, len(list.Items))
+	assert.Equal(t, ns_prefix+"-1", list.Items[0].Name)
+	assert.Equal(t, ns_prefix+"-2", list.Items[1].Name)
+
+	cc.DeleteNamespaces()
+	//TODO verify the namespace exists in the clientmock
+
+	assert.Equal(t, "", cc.CurrentNamespace)
+	assert.Equal(t, 0, len(cc.Namespaces))
+
+	list, err = NamespacesClient.List(metav1.ListOptions{})
+	assert.Assert(t, err)
+	assert.Equal(t, 0, len(list.Items))
+
+	NsSpec := &apiv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns_prefix + "-1"}}
+	_, err = cc.VanClient.KubeClient.CoreV1().Namespaces().Create(NsSpec)
+	assert.Assert(t, err)
+
+	err = cc.CreateNamespace()
+	assert.Error(t, err, "namespaces \"ns-prefix-1\" already exists")
+}
+
+func TestClusterContextNamespaceAlreadyExists(t *testing.T) {
+	var err error
+	ns_prefix := "ns-prefix"
+	kc := "someconfig"
+
+	cc := BuildClusterContext(t, ns_prefix, kc, NewMockClient)
+
+	NsSpec := &apiv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns_prefix + "-1"}}
+	_, err = cc.VanClient.KubeClient.CoreV1().Namespaces().Create(NsSpec)
+	assert.Assert(t, err)
+
+	err = cc.CreateNamespace()
+	assert.Error(t, err, "namespaces \"ns-prefix-1\" already exists")
+}
+
+func Test_getNextNamespace(t *testing.T) {
+	//var err error
+	prefix := "prefix"
+	cc := &ClusterContext{}
+	cc.NamespacePrefix = prefix
+
+	//getNextNamespace does not update the list, just tells you what would
+	//be the next
+	next := cc.getNextNamespace()
+	assert.Equal(t, next, prefix+"-1")
+	assert.Equal(t, cc.getNextNamespace(), prefix+"-1")
+
+	assert.Equal(t, len(cc.Namespaces), 0)
+	assert.Equal(t, cc.CurrentNamespace, "")
+}
+
+func Test_moveToNextNamespace(t *testing.T) {
+	//var err error
+	prefix := "prefix"
+	cc := BuildClusterContext(t, prefix, "someconfig", NewMockClient)
+	cc.NamespacePrefix = prefix
+
+	cc.moveToNextNamespace()
+	assert.Equal(t, cc.CurrentNamespace, prefix+"-1")
+	assert.Equal(t, len(cc.Namespaces), 1)
+	cc.Namespaces[0] = prefix + "-1"
+
+	cc.moveToNextNamespace()
+	assert.Equal(t, cc.CurrentNamespace, prefix+"-2")
+	assert.Equal(t, len(cc.Namespaces), 2)
+	cc.Namespaces[0] = prefix + "-1"
+	cc.Namespaces[1] = prefix + "-2"
+}

--- a/test/integration/tcp_echo/tcp_echo.go
+++ b/test/integration/tcp_echo/tcp_echo.go
@@ -132,20 +132,25 @@ func (r *TcpEchoClusterTestRunner) RunTests(ctx context.Context) {
 }
 
 func (r *TcpEchoClusterTestRunner) Setup(ctx context.Context) {
-	r.Pub1Cluster.CreateNamespace()
-	r.Priv1Cluster.CreateNamespace()
+	var err error
+	err = r.Pub1Cluster.CreateNamespace()
+	assert.Assert(r.T, err)
 
-	publicDeploymentsClient := r.Pub1Cluster.VanClient.KubeClient.AppsV1().Deployments(r.Pub1Cluster.Namespace)
+	err = r.Priv1Cluster.CreateNamespace()
+	assert.Assert(r.T, err)
+
+	publicDeploymentsClient := r.Pub1Cluster.VanClient.KubeClient.AppsV1().Deployments(r.Pub1Cluster.CurrentNamespace)
 
 	fmt.Println("Creating deployment...")
 	result, err := publicDeploymentsClient.Create(deployment)
-	assert.Check(r.T, err)
+	assert.Assert(r.T, err)
 
 	fmt.Printf("Created deployment %q.\n", result.GetObjectMeta().GetName())
 
-	fmt.Printf("Listing deployments in namespace %q:\n", "public")
+	//copiar de aca para listar losnamespaces!!
+	fmt.Printf("Listing deployments in namespace %q:\n", r.Pub1Cluster.CurrentNamespace)
 	list, err := publicDeploymentsClient.List(metav1.ListOptions{})
-	assert.Check(r.T, err)
+	assert.Assert(r.T, err)
 
 	for _, d := range list.Items {
 		fmt.Printf(" * %s (%d replicas)\n", d.Name, *d.Spec.Replicas)
@@ -174,13 +179,13 @@ func (r *TcpEchoClusterTestRunner) Setup(ctx context.Context) {
 		Port:     9090,
 	}
 	err = r.Pub1Cluster.VanClient.VanServiceInterfaceCreate(ctx, &service)
-	assert.Check(r.T, err)
+	assert.Assert(r.T, err)
 
 	err = r.Pub1Cluster.VanClient.VanServiceInterfaceBind(ctx, &service, "deployment", "tcp-go-echo", "tcp", 0)
-	assert.Check(r.T, err)
+	assert.Assert(r.T, err)
 
 	err = r.Pub1Cluster.VanClient.VanConnectorTokenCreateFile(ctx, types.DefaultVanName, "/tmp/public_secret.yaml")
-	assert.Check(r.T, err)
+	assert.Assert(r.T, err)
 
 	err = r.Priv1Cluster.VanClient.VanRouterCreate(ctx, vanRouterCreateOpts)
 

--- a/test/integration/tcp_echo/tcp_echo_test.go
+++ b/test/integration/tcp_echo/tcp_echo_test.go
@@ -4,27 +4,13 @@ package tcp_echo
 
 import (
 	"context"
-	"os"
-	"path"
 	"testing"
-
-	"gotest.tools/assert"
 )
 
 func TestTcpEcho(t *testing.T) {
 	testRunner := &TcpEchoClusterTestRunner{}
 
-	kubeconfig := os.Getenv("KUBECONFIG")
-	if kubeconfig == "" {
-		homedir, err := os.UserHomeDir()
-		assert.Check(t, err)
-		kubeconfig = path.Join(homedir, ".kube/config")
-	}
-
-	//TODO: accept 4 different kubeconfigs
-	//For now for simplicity we use the same single kubeconfig. Multicluster
-	//support can be enabled easily whe needed.
-	testRunner.Build(t, kubeconfig, kubeconfig, kubeconfig, kubeconfig)
+	testRunner.Build(t)
 	ctx := context.Background()
 	testRunner.Run(ctx)
 }


### PR DESCRIPTION
With this change it will be easy to handle namespaces. Just creating as many as them as you whish, and cleaning with a simple "DeleteNamespaces()" call.
It was originally part of https://github.com/skupperproject/skupper/pull/49, now pushed as a separate change.