### PR TITLE
brute forced killing of port-forwarding process

### DIFF
--- a/test/cluster/cluster_test_runner.go
+++ b/test/cluster/cluster_test_runner.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -54,41 +55,43 @@ func BuildClusterContext(t *testing.T, namespace string, configFile string) *Clu
 	return cc
 }
 
-func _exec(command string, wait bool) {
+func _exec(command string, wait bool) *exec.Cmd {
 	var output []byte
 	var err error
 	fmt.Println(command)
 	cmd := exec.Command("sh", "-c", command)
 	if wait {
 		output, err = cmd.CombinedOutput()
+		if err != nil {
+			panic(err)
+		}
+		fmt.Println(string(output))
 	} else {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
 		cmd.Start()
-		return
 	}
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(string(output))
+	return cmd
 }
 
-func (cc *ClusterContext) exec(main_command string, sub_command string, wait bool) {
-	_exec("KUBECONFIG="+cc.ClusterConfigFile+" "+main_command+" "+cc.Namespace+" "+sub_command, wait)
+func (cc *ClusterContext) exec(main_command string, sub_command string, wait bool) *exec.Cmd {
+	return _exec("KUBECONFIG="+cc.ClusterConfigFile+" "+main_command+" "+cc.Namespace+" "+sub_command, wait)
 }
 
-func (cc *ClusterContext) SkupperExec(command string) {
-	cc.exec("./skupper -n ", command, true)
+func (cc *ClusterContext) SkupperExec(command string) *exec.Cmd {
+	return cc.exec("./skupper -n ", command, true)
 }
 
-func (cc *ClusterContext) _kubectl_exec(command string, wait bool) {
-	cc.exec("kubectl -n ", command, wait)
+func (cc *ClusterContext) _kubectl_exec(command string, wait bool) *exec.Cmd {
+	return cc.exec("kubectl -n ", command, wait)
 }
 
-func (cc *ClusterContext) KubectlExec(command string) {
-	cc._kubectl_exec(command, true)
+func (cc *ClusterContext) KubectlExec(command string) *exec.Cmd {
+	return cc._kubectl_exec(command, true)
 }
 
-func (cc *ClusterContext) KubectlExecAsync(command string) {
-	cc._kubectl_exec(command, false)
+func (cc *ClusterContext) KubectlExecAsync(command string) *exec.Cmd {
+	return cc._kubectl_exec(command, false)
 }
 
 func (cc *ClusterContext) CreateNamespace() {


### PR DESCRIPTION
There is an issue with the killing, the way processes are spawned now, is creating two processes in background and the cmd.Kill() method is killing one of them (and not the other).
This pr is just a patch to  prevent port-forwarding process to remain running in the host after test run is completedt. 
In advance background process spawned needs to be redesigned.

```
circleci 27472  0.0  0.0   4460   684 pts/3    S+   01:21   0:00 sh -c KUBECONFIG=/home/circleci/.kube/config kubectl -n  public1 port-forward service/tcp-go-echo 9090:9090
circleci 27473  0.6  0.5 146188 41992 pts/3    Sl+  01:21   0:00 kubectl -n public1 port-forward service/tcp-go-echo 9090:9090
```