### PR TITLE
Add cli connect with site-controller

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -252,8 +252,8 @@ type Connector struct {
 
 type ConfigMap struct {
 	Name  string `json:"name,omitempty"`
-	Key   string `json:"name,omitempty"`
-	Value string `json:"name,omitempty"`
+	Key   string `json:"key,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 type Role struct {

--- a/client/van_connector_create_test.go
+++ b/client/van_connector_create_test.go
@@ -23,7 +23,7 @@ func TestConnectorCreateError(t *testing.T) {
 	// Create the client
 	cli, err := newMockClient("skupper", "", "")
 
-	err = cli.VanConnectorCreateFromFile(ctx, "./somefile.yaml", types.VanConnectorCreateOptions{
+	_, err = cli.VanConnectorCreateFromFile(ctx, "./somefile.yaml", types.VanConnectorCreateOptions{
 		Name: "",
 		Cost: 1,
 	})
@@ -101,7 +101,7 @@ func TestConnectorCreateInterior(t *testing.T) {
 		err = cli.VanConnectorTokenCreateFile(ctx, c.connName, testPath+c.connName+".yaml")
 		assert.Check(t, err, "Unable to create token")
 
-		err = cli.VanConnectorCreateFromFile(ctx, testPath+c.connName+".yaml", types.VanConnectorCreateOptions{
+		_, err = cli.VanConnectorCreateFromFile(ctx, testPath+c.connName+".yaml", types.VanConnectorCreateOptions{
 			Name: c.connName,
 			Cost: 1,
 		})

--- a/client/van_connector_inspect_test.go
+++ b/client/van_connector_inspect_test.go
@@ -113,7 +113,7 @@ func TestConnectorInspectDefaults(t *testing.T) {
 		assert.Check(t, err, "Unable to create connector token "+c.connName)
 	}
 	for _, c := range testcases {
-		err = cli.VanConnectorCreateFromFile(ctx, testPath+c.connName+".yaml", types.VanConnectorCreateOptions{
+		_, err = cli.VanConnectorCreateFromFile(ctx, testPath+c.connName+".yaml", types.VanConnectorCreateOptions{
 			Name: c.connName,
 			Cost: 1,
 		})

--- a/client/van_connector_remove_test.go
+++ b/client/van_connector_remove_test.go
@@ -91,7 +91,7 @@ func TestConnectorRemove(t *testing.T) {
 		assert.Check(t, err, "Unable to create connector token "+c.connName)
 
 		if c.createConn {
-			err = cli.VanConnectorCreateFromFile(ctx, testPath+c.connName+".yaml", types.VanConnectorCreateOptions{
+			_, err = cli.VanConnectorCreateFromFile(ctx, testPath+c.connName+".yaml", types.VanConnectorCreateOptions{
 				Name: c.connName,
 				Cost: 1,
 			})


### PR DESCRIPTION
This patch enables the creation of a connection via cli when site-controller is deployed.
(Also: error formatting updates, update tests, removal of prints, etc.)