### PR TITLE
building the binary inside a docker host instead of depending on the host os/arch

### DIFF
--- a/Dockerfile.service-controller
+++ b/Dockerfile.service-controller
@@ -1,5 +1,15 @@
+FROM golang:1.13 AS builder
+
+WORKDIR /go/src/app
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . .
+
+RUN make build-service-controller
+
 FROM registry.access.redhat.com/ubi8-minimal
 
 WORKDIR /app
-COPY service-controller /app
+COPY --from=builder /go/src/app/service-controller .
 CMD ["/app/service-controller"]

--- a/Dockerfile.site-controller
+++ b/Dockerfile.site-controller
@@ -1,5 +1,17 @@
+FROM golang:1.13 AS builder
+
+WORKDIR /go/src/app
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+RUN make build-site-controller
+
+
 FROM registry.access.redhat.com/ubi8-minimal
 
 WORKDIR /app
-COPY site-controller /app
+COPY --from=builder /go/src/app/site-controller .
 CMD ["/app/site-controller"]

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build-site-controller:
 
 build-controllers: build-site-controller build-service-controller
 
-docker-build: build-controllers
+docker-build:
 	${DOCKER} build -t ${SERVICE_CONTROLLER_IMAGE} -f Dockerfile.service-controller .
 	${DOCKER} build -t ${SITE_CONTROLLER_IMAGE} -f Dockerfile.site-controller .
 


### PR DESCRIPTION
Basically I have stolen Andy's idea about using multi stage docker build.
https://docs.docker.com/develop/develop-images/multistage-build/

I think what we need here is exactly the use case for multistage builds, and as it is expected, the size of the base image is only increased by the size of the binary added to it (no overhead):
```

registry.access.redhat.com/ubi8-minimal   latest              c58d4cf08dc2        8 days ago          142MB
quay.io/nicob87/service-controller        multi               1ae6453d76df        36 seconds ago      183MB

$ docker run quay.io/nicob87/service-controller:multi ls -lh service-controller
-rwxr-xr-x. 1 root root 39M Jun 30 17:47 service-controller
```



