### PR TITLE
minor change to site query logging

### DIFF
--- a/cmd/service-controller/site_query.go
+++ b/cmd/service-controller/site_query.go
@@ -125,8 +125,6 @@ func (s *SiteQueryServer) run() {
 		correlationId, ok := qdr.AsUint64(msg.Properties.CorrelationID)
 		if !ok {
 			log.Printf("WARN: Could not get correlationid from site query request: %#v (%T)", msg.Properties.CorrelationID, msg.Properties.CorrelationID)
-		} else {
-			log.Printf("Sending site query response for %v: %s", correlationId, string(bytes))
 		}
 		response := amqp.Message{
 			Properties: &amqp.MessageProperties{


### PR DESCRIPTION
The 'sending site query response' message obscures the content of the service-controller logs. 