### PR TITLE
Remove origin defs after duration expiry

### DIFF
--- a/cmd/service-controller/controller.go
+++ b/cmd/service-controller/controller.go
@@ -50,6 +50,7 @@ type Controller struct {
 	Local           []types.ServiceInterface
 	byName          map[string]types.ServiceInterface
 	desiredServices map[string]types.ServiceInterface
+	heardFrom       map[string]time.Time
 
 	definitionMonitor *DefinitionMonitor
 	consoleServer     *ConsoleServer
@@ -131,6 +132,7 @@ func NewController(cli *client.VanClient, origin string, tlsConfig *tls.Config) 
 	controller.byOrigin = make(map[string]map[string]types.ServiceInterface)
 	controller.byName = make(map[string]types.ServiceInterface)
 	controller.desiredServices = make(map[string]types.ServiceInterface)
+	controller.heardFrom = make(map[string]time.Time)
 
 	log.Println("Setting up event handlers")
 	svcDefInformer.AddEventHandler(controller.newEventHandler("servicedefs", AnnotatedKey, ConfigMapResourceVersionTest))

--- a/cmd/service-controller/site_query.go
+++ b/cmd/service-controller/site_query.go
@@ -87,6 +87,7 @@ func (s *SiteQueryServer) run() {
 		utilruntime.HandleError(fmt.Errorf("Failed to create amqp connection for site query server: %s", err.Error()))
 		return
 	}
+	log.Println("Site query server connection to skupper-messaging service established")
 	defer client.Close()
 
 	session, err := client.NewSession()


### PR DESCRIPTION
This patch tracks the last service sync update heard from each origin. Entries from the origin are removed if at least 60 s goes by without and update.