### PR TITLE
Test in kubernetes job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,10 @@ parameters:
     default: quay.io/nicob87/site-controller:${CIRCLE_SHA1}
     type: string
 
+  ci_test_image:
+    default: quay.io/nicob87/skupper-tests:${CIRCLE_SHA1}
+    type: string
+
 executors:
   local_cluster_test_executor:
     machine:
@@ -58,6 +62,7 @@ commands:
             echo 'export PATH=$GOPATH/bin:$GOROOT/bin:$PATH' >> $BASH_ENV
             echo 'export SKUPPER_SERVICE_CONTROLLER_IMAGE=<< pipeline.parameters.ci_service_controller_image >>' >> $BASH_ENV
             echo 'export SKUPPER_SITE_CONTROLLER_IMAGE=<< pipeline.parameters.ci_site_controller_image >>' >> $BASH_ENV
+            echo 'export TEST_IMAGE=<< pipeline.parameters.ci_test_image >>' >> $BASH_ENV
             source $BASH_ENV
       - checkout
       - run:
@@ -174,6 +179,7 @@ jobs:
           command: |
             echo 'export SERVICE_CONTROLLER_IMAGE=<< pipeline.parameters.ci_service_controller_image >>' >> $BASH_ENV
             echo 'export SITE_CONTROLLER_IMAGE=<< pipeline.parameters.ci_site_controller_image >>' >> $BASH_ENV
+            echo 'export TEST_IMAGE=<< pipeline.parameters.ci_test_image >>' >> $BASH_ENV
             source $BASH_ENV
       - setup_remote_docker
       - go/mod-download-cached
@@ -195,6 +201,7 @@ jobs:
       - run: go get github.com/genuinetools/reg
       - run: reg rm << pipeline.parameters.ci_service_controller_image >>
       - run: reg rm << pipeline.parameters.ci_site_controller_image >>
+      - run: reg rm << pipeline.parameters.ci_test_image >>
 
   build-all:
     executor:

--- a/Dockerfile.ci-test
+++ b/Dockerfile.ci-test
@@ -1,0 +1,18 @@
+FROM golang:1.13 AS builder
+
+WORKDIR /go/src/app
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+RUN make build-tests
+
+#TODO look for a smaller base image
+FROM golang:1.13
+
+WORKDIR /go/src/app
+COPY --from=builder /go/src/app/tcp_echo_test .
+
+CMD ["ls"]

--- a/test/cluster/cluster_test_runner.go
+++ b/test/cluster/cluster_test_runner.go
@@ -93,6 +93,7 @@ func (cc *ClusterContext) exec(main_command string, sub_command string, wait boo
 	return _exec("KUBECONFIG="+cc.ClusterConfigFile+" "+main_command+" "+cc.CurrentNamespace+" "+sub_command, wait)
 }
 
+//TODO remove this
 func (cc *ClusterContext) SkupperExec(command string) *exec.Cmd {
 	return cc.exec("./skupper -n ", command, true)
 }
@@ -101,6 +102,7 @@ func (cc *ClusterContext) _kubectl_exec(command string, wait bool) *exec.Cmd {
 	return cc.exec("kubectl -n ", command, wait)
 }
 
+//TODO return error instead of panic in case of exit code != 0
 func (cc *ClusterContext) KubectlExec(command string) *exec.Cmd {
 	return cc._kubectl_exec(command, true)
 }

--- a/test/cluster/cluster_test_runner.go
+++ b/test/cluster/cluster_test_runner.go
@@ -75,10 +75,10 @@ func _exec(command string, wait bool) *exec.Cmd {
 	cmd := exec.Command("sh", "-c", command)
 	if wait {
 		output, err = cmd.CombinedOutput()
+		fmt.Println(string(output))
 		if err != nil {
 			panic(err)
 		}
-		fmt.Println(string(output))
 	} else {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/test/integration/tcp_echo/tcp_echo_test.go
+++ b/test/integration/tcp_echo/tcp_echo_test.go
@@ -4,7 +4,15 @@ package tcp_echo
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strings"
 	"testing"
+
+	"gotest.tools/assert"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 func TestTcpEcho(t *testing.T) {
@@ -13,4 +21,50 @@ func TestTcpEcho(t *testing.T) {
 	testRunner.Build(t, "tcp-echo")
 	ctx := context.Background()
 	testRunner.Run(ctx)
+}
+
+func sendReceive() error {
+	servAddr := "tcp-go-echo:9090"
+
+	strEcho := "Halo"
+	tcpAddr, err := net.ResolveTCPAddr("tcp", servAddr)
+	if err != nil {
+		return fmt.Errorf("ResolveTCPAddr failed: %s\n", err.Error())
+	}
+
+	conn, err := net.DialTCP("tcp", nil, tcpAddr)
+	if err != nil {
+		return fmt.Errorf("Dial failed: %s\n", err.Error())
+	}
+	defer conn.Close()
+
+	_, err = conn.Write([]byte(strEcho))
+	if err != nil {
+		return fmt.Errorf("Write to server failed: %s\n", err.Error())
+	}
+
+	reply := make([]byte, 1024)
+
+	_, err = conn.Read(reply)
+	if err != nil {
+		return fmt.Errorf("Read from server failed: %s\n", err.Error())
+	}
+
+	log.Println("Sent to server = ", strEcho)
+	log.Println("Reply from server = ", string(reply))
+
+	if !strings.Contains(string(reply), strings.ToUpper(strEcho)) {
+		return fmt.Errorf("Response from server different that expected: %s\n", string(reply))
+	}
+
+	return nil
+}
+
+func TestTcpEchoJob(t *testing.T) {
+	job := os.Getenv("JOB")
+	if job == "" {
+		t.Skip("JOB environment variable not defined")
+		return
+	}
+	assert.Assert(t, sendReceive())
 }


### PR DESCRIPTION
This PR attempts to create a new way of running an integration test.
The main issue we were having is that we need to execute the skupper setup code in the host, because we need to support to interact with several clusters in the same test.
But for executing the test itself it is useful to have access to the cluster network. To solve this previously we were using the "kubectl port-forwarding" hack, with this we just run the code that we want inside the cluster.

Taking advantage  of the go feature that allows to compile go tests into a binary, and execute the binary later...
The idea is to maintain only one single "TEST_IMAGE" that contains all needed test binaries.


TODO:
- migrate http, and basic test to this new format and remove the "port-forwarding" black magic.