### PR TITLE
add console url to inspect response

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -59,4 +59,5 @@ type RouterInspectResponse struct {
 	TransportVersion  string
 	ControllerVersion string
 	ExposedServices   int
+	ConsoleUrl        string
 }

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -450,6 +450,12 @@ func main() {
 				fmt.Println()
 				if vir.ConsoleUrl != "" {
 					fmt.Println("The site console url is: ", vir.ConsoleUrl)
+					siteConfig, err := cli.SiteConfigInspect(context.Background(), nil)
+					if check(err) {
+						if siteConfig.Spec.AuthMode == "internal" {
+							fmt.Println("The credentials for internal console-auth mode are held in secret: 'skupper-users'")
+						}
+					}
 				}
 			} else {
 				fmt.Println("Unable to retrieve skupper status: ", err.Error())

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -448,6 +448,9 @@ func main() {
 					fmt.Printf(" It has %d exposed services.", vir.ExposedServices)
 				}
 				fmt.Println()
+				if vir.ConsoleUrl != "" {
+					fmt.Println("The site console url is: ", vir.ConsoleUrl)
+				}
 			} else {
 				fmt.Println("Unable to retrieve skupper status: ", err.Error())
 				os.Exit(1)


### PR DESCRIPTION
In the spirit of #147, adding url to inspect makes it simpler to access the console. 