### PR TITLE
use native resource types

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -180,22 +180,21 @@ type RouterSpec struct {
 
 // DeploymentSpec for the VAN router or controller components to run within a cluster
 type DeploymentSpec struct {
-	Image           string                 `json:"image,omitempty"`
-	Replicas        int32                  `json:"replicas,omitempty"`
-	LivenessPort    int32                  `json:"livenessPort,omitempty"`
-	Labels          map[string]string      `json:"labels,omitempty"`
-	Annotations     map[string]string      `json:"annotations,omitempty"`
-	EnvVar          []corev1.EnvVar        `json:"envVar,omitempty"`
-	Ports           []corev1.ContainerPort `json:"ports,omitempty"`
-	Volumes         []corev1.Volume        `json:"volumes,omitempty"`
-	VolumeMounts    [][]corev1.VolumeMount `json:"volumeMounts,omitempty"`
-	ConfigMaps      []ConfigMap            `json:"configMaps,omitempty"`
-	Roles           []Role                 `json:"roles,omitempty"`
-	RoleBindings    []RoleBinding          `json:"roleBinding,omitempty"`
-	Routes          []Route                `json:"routes,omitempty"`
-	ServiceAccounts []ServiceAccount       `json:"serviceAccounts,omitempty"`
-	Services        []Service              `json:"services,omitempty"`
-	Sidecars        []*corev1.Container    `json:"sidecars,omitempty"`
+	Image           string                   `json:"image,omitempty"`
+	Replicas        int32                    `json:"replicas,omitempty"`
+	LivenessPort    int32                    `json:"livenessPort,omitempty"`
+	Labels          map[string]string        `json:"labels,omitempty"`
+	Annotations     map[string]string        `json:"annotations,omitempty"`
+	EnvVar          []corev1.EnvVar          `json:"envVar,omitempty"`
+	Ports           []corev1.ContainerPort   `json:"ports,omitempty"`
+	Volumes         []corev1.Volume          `json:"volumes,omitempty"`
+	VolumeMounts    [][]corev1.VolumeMount   `json:"volumeMounts,omitempty"`
+	Roles           []*rbacv1.Role           `json:"roles,omitempty"`
+	RoleBindings    []*rbacv1.RoleBinding    `json:"roleBinding,omitempty"`
+	Routes          []*routev1.Route         `json:"routes,omitempty"`
+	ServiceAccounts []*corev1.ServiceAccount `json:"serviceAccounts,omitempty"`
+	Services        []*corev1.Service        `json:"services,omitempty"`
+	Sidecars        []*corev1.Container      `json:"sidecars,omitempty"`
 }
 
 // AssemblySpec for the links and connectors that form the VAN topology
@@ -256,41 +255,6 @@ type Connector struct {
 	VerifyHostname bool   `json:"verifyHostname,omitempty"`
 	SslProfile     string `json:"sslProfile,omitempty"`
 	LinkCapacity   int32  `json:"linkCapacity,omitempty"`
-}
-
-type ConfigMap struct {
-	Name  string `json:"name,omitempty"`
-	Key   string `json:"key,omitempty"`
-	Value string `json:"value,omitempty"`
-}
-
-type Role struct {
-	Name  string              `json:"name,omitempty"`
-	Rules []rbacv1.PolicyRule `json:"rules,omitempty"`
-}
-
-type RoleBinding struct {
-	ServiceAccount string `json:"serviceAccount,omitempty"`
-	Role           string `json:"role,omitempty"`
-}
-
-type ServiceAccount struct {
-	ServiceAccount string            `json:"serviceAccount,omitempty"`
-	Annotations    map[string]string `json:"annotations,omitempty"`
-}
-
-type Route struct {
-	Name          string
-	TargetService string
-	TargetPort    string
-	Termination   routev1.TLSTerminationType
-}
-
-type Service struct {
-	Name        string
-	Type        string
-	Ports       []corev1.ServicePort
-	Annotations map[string]string
 }
 
 type Credential struct {

--- a/pkg/kube/rolebindings.go
+++ b/pkg/kube/rolebindings.go
@@ -3,56 +3,16 @@ package kube
 import (
 	"fmt"
 
-	//appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/skupperproject/skupper/api/types"
 )
 
-func NewRoleBinding(rb types.RoleBinding, owner *metav1.OwnerReference, namespace string, kubeclient kubernetes.Interface) (*rbacv1.RoleBinding, error) {
-	name := rb.ServiceAccount + "-" + rb.Role
+func CreateRoleBinding(namespace string, rb *rbacv1.RoleBinding, kubeclient kubernetes.Interface) (*rbacv1.RoleBinding, error) {
 	roleBindings := kubeclient.RbacV1().RoleBindings(namespace)
-	existing, err := roleBindings.Get(name, metav1.GetOptions{})
-	if err == nil {
-		//TODO: already exists
-		return existing, nil
-	} else if errors.IsNotFound(err) {
-		rolebinding := &rbacv1.RoleBinding{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "rbac.authorization.k8s.io/v1",
-				Kind:       "RoleBinding",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: name,
-			},
-			Subjects: []rbacv1.Subject{{
-				Kind: "ServiceAccount",
-				Name: rb.ServiceAccount,
-			}},
-			RoleRef: rbacv1.RoleRef{
-				Kind: "Role",
-				Name: rb.Role,
-			},
-		}
-		if owner != nil {
-			rolebinding.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-				*owner,
-			}
-		}
-
-		created, err := roleBindings.Create(rolebinding)
-
-		if err != nil {
-			return nil, fmt.Errorf("Failed to create role binding: %w", err)
-		} else {
-			return created, nil
-		}
+	created, err := roleBindings.Create(rb)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create role binding: %w", err)
 	} else {
-		rolebinding := &rbacv1.RoleBinding{}
-		return rolebinding, fmt.Errorf("Failed to check role binding: %w", err)
+		return created, nil
 	}
 }

--- a/pkg/kube/roles.go
+++ b/pkg/kube/roles.go
@@ -4,45 +4,15 @@ import (
 	"fmt"
 
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/skupperproject/skupper/api/types"
 )
 
-func NewRole(newrole types.Role, owner *metav1.OwnerReference, namespace string, kubeclient kubernetes.Interface) (*rbacv1.Role, error) {
+func CreateRole(namespace string, role *rbacv1.Role, kubeclient kubernetes.Interface) (*rbacv1.Role, error) {
 	roles := kubeclient.RbacV1().Roles(namespace)
-	existing, err := roles.Get(newrole.Name, metav1.GetOptions{})
-	if err == nil {
-		//TODO: already exists
-		return existing, nil
-	} else if errors.IsNotFound(err) {
-		role := &rbacv1.Role{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "rbac.authorization.k8s.io/v1",
-				Kind:       "Role",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: newrole.Name,
-			},
-			Rules: newrole.Rules,
-		}
-		if owner != nil {
-			role.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-				*owner,
-			}
-		}
-		created, err := roles.Create(role)
-
-		if err != nil {
-			return nil, fmt.Errorf("Failed to crate role: %w", err)
-		} else {
-			return created, nil
-		}
+	created, err := roles.Create(role)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create role: %w", err)
 	} else {
-		role := &rbacv1.Role{}
-		return role, fmt.Errorf("Failed to check existing config maps: %w", err)
+		return created, nil
 	}
 }

--- a/pkg/kube/routes.go
+++ b/pkg/kube/routes.go
@@ -7,9 +7,6 @@ import (
 	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
-	"github.com/skupperproject/skupper/api/types"
 )
 
 func GetRoute(name string, namespace string, rc *routev1client.RouteV1Client) (*routev1.Route, error) {
@@ -17,43 +14,11 @@ func GetRoute(name string, namespace string, rc *routev1client.RouteV1Client) (*
 	return current, err
 }
 
-func NewRoute(rte types.Route, owner *metav1.OwnerReference, namespace string, rc *routev1client.RouteV1Client) (*routev1.Route, error) {
-	insecurePolicy := routev1.InsecureEdgeTerminationPolicyNone
-	if rte.Termination != routev1.TLSTerminationPassthrough {
-		insecurePolicy = routev1.InsecureEdgeTerminationPolicyRedirect
-	}
-	current, err := rc.Routes(namespace).Get(rte.Name, metav1.GetOptions{})
+func CreateRoute(route *routev1.Route, namespace string, rc *routev1client.RouteV1Client) (*routev1.Route, error) {
+	current, err := rc.Routes(namespace).Get(route.Name, metav1.GetOptions{})
 	if err == nil {
-		return current, fmt.Errorf("Route %s already exists", rte.Name)
+		return current, fmt.Errorf("Route %s already exists", route.Name)
 	} else if errors.IsNotFound(err) {
-		route := &routev1.Route{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "Route",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: rte.Name,
-			},
-			Spec: routev1.RouteSpec{
-				Path: "",
-				Port: &routev1.RoutePort{
-					TargetPort: intstr.FromString(rte.TargetPort),
-				},
-				To: routev1.RouteTargetReference{
-					Kind: "Service",
-					Name: rte.TargetService,
-				},
-				TLS: &routev1.TLSConfig{
-					Termination:                   rte.Termination,
-					InsecureEdgeTerminationPolicy: insecurePolicy,
-				},
-			},
-		}
-		if owner != nil {
-			route.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-				*owner,
-			}
-		}
 		created, err := rc.Routes(namespace).Create(route)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to create route : %w", err)

--- a/pkg/kube/serviceaccounts.go
+++ b/pkg/kube/serviceaccounts.go
@@ -3,47 +3,16 @@ package kube
 import (
 	"fmt"
 
-	//appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/skupperproject/skupper/api/types"
 )
 
-func NewServiceAccount(sa types.ServiceAccount, owner *metav1.OwnerReference, namespace string, cli kubernetes.Interface) (*corev1.ServiceAccount, error) {
+func CreateServiceAccount(namespace string, sa *corev1.ServiceAccount, cli kubernetes.Interface) (*corev1.ServiceAccount, error) {
 	serviceAccounts := cli.CoreV1().ServiceAccounts(namespace)
-	existing, err := serviceAccounts.Get(sa.ServiceAccount, metav1.GetOptions{})
-	if err == nil {
-		//TODO: already exists
-		return existing, nil
-	} else if errors.IsNotFound(err) {
-		sa := &corev1.ServiceAccount{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "ServiceAccount",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        sa.ServiceAccount,
-				Annotations: sa.Annotations,
-			},
-		}
-		if owner != nil {
-			sa.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-				*owner,
-			}
-		}
-
-		created, err := serviceAccounts.Create(sa)
-
-		if err != nil {
-			return nil, fmt.Errorf("Failed to create service account: %w", err)
-		} else {
-			return created, nil
-		}
+	created, err := serviceAccounts.Create(sa)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create service account: %w", err)
 	} else {
-		sa := &corev1.ServiceAccount{}
-		return sa, fmt.Errorf("Failed to check service account: %w", err)
+		return created, nil
 	}
 }

--- a/pkg/kube/services.go
+++ b/pkg/kube/services.go
@@ -99,40 +99,8 @@ func createServiceFromObject(service *corev1.Service, namespace string, kubeclie
 	}
 }
 
-func NewService(svc types.Service, labels map[string]string, owner *metav1.OwnerReference, namespace string, kubeclient kubernetes.Interface) (*corev1.Service, error) {
-	services := kubeclient.CoreV1().Services(namespace)
-	existing, err := services.Get(svc.Name, metav1.GetOptions{})
-	if err == nil {
-		//TODO: already exists
-		return existing, nil
-	} else if errors.IsNotFound(err) {
-		service := &corev1.Service{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "Service",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        svc.Name,
-				Annotations: svc.Annotations,
-			},
-			Spec: corev1.ServiceSpec{
-				Selector: labels,
-				Ports:    svc.Ports,
-			},
-		}
-		if svc.Type == "LoadBalancer" {
-			service.Spec.Type = corev1.ServiceTypeLoadBalancer
-		}
-		if owner != nil {
-			service.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-				*owner,
-			}
-		}
-		return createServiceFromObject(service, namespace, kubeclient)
-	} else {
-		service := &corev1.Service{}
-		return service, fmt.Errorf("Failed to check service: %w", err)
-	}
+func CreateService(service *corev1.Service, namespace string, kubeclient kubernetes.Interface) (*corev1.Service, error) {
+	return createServiceFromObject(service, namespace, kubeclient)
 }
 
 func GetLoadBalancerHostOrIp(service *corev1.Service) string {


### PR DESCRIPTION
The re-factoring and consolidation of api/types.go (#175 ) will occur over a series of patches. 

In this patch the types that 'wrapped' native resources types in the deployment spec, etc. are removed to simplify and improve maintainability.