### PR TITLE
CI flakyness improved

### DIFF
--- a/test/cluster/wait_for_skupper_service_test.go
+++ b/test/cluster/wait_for_skupper_service_test.go
@@ -1,0 +1,114 @@
+package cluster
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type ClusterContextMock struct {
+	calledWithService string
+	calledWithRetryFn func() (*apiv1.Service, error)
+}
+
+const (
+	expectedError string = "some error"
+)
+
+var (
+	mockSucceeds bool
+	mockService  *apiv1.Service = &apiv1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			//Name: "mockName",
+		},
+	}
+	defaultDuration = 10 * time.Millisecond
+)
+
+func (cc *ClusterContextMock) waitForSkupperServiceToBeCreated(name string, retryFn func() (*apiv1.Service, error), backoff wait.Backoff) (*apiv1.Service, error) {
+	cc.calledWithService = name
+	cc.calledWithRetryFn = retryFn
+
+	mockService.Name = name
+	if mockSucceeds {
+		return mockService, nil
+	}
+	return nil, fmt.Errorf(expectedError)
+
+}
+
+func TestWaitForSkupperServiceToBeCreatedAndReadyToUse(t *testing.T) {
+	cc := &ClusterContextMock{}
+
+	endTimeIfDelays := time.Now().Add(defaultDuration)
+	mockSucceeds = true
+	service, err := waitForSkupperServiceToBeCreatedAndReadyToUse(cc, "serviceA", defaultDuration)
+	assert.Assert(t, time.Now().Sub(endTimeIfDelays) >= 0)
+	assert.Assert(t, err)
+	assert.Equal(t, service.Name, "serviceA")
+	assert.Equal(t, cc.calledWithService, "serviceA")
+
+	assert.Assert(t, cc.calledWithRetryFn == nil)
+
+	endTimeIfDelays = time.Now().Add(defaultDuration)
+	mockSucceeds = false
+
+	service, err = waitForSkupperServiceToBeCreatedAndReadyToUse(cc, "serviceB", defaultDuration)
+	assert.Assert(t, time.Now().Sub(endTimeIfDelays) < 0)
+	assert.Error(t, err, expectedError)
+	assert.Equal(t, cc.calledWithService, "serviceB")
+	assert.Assert(t, service == nil)
+	assert.Assert(t, cc.calledWithRetryFn == nil)
+}
+
+func TestWaitForSkupperServiceToBeCreated(t *testing.T) {
+
+	cc := &ClusterContext{}
+	var count int
+	retryFnSuccedsInTheThirdCall := func() (*apiv1.Service, error) {
+		count = count + 1
+		if count == 3 {
+			return mockService, nil
+		}
+		return nil, fmt.Errorf("some error")
+	}
+
+	testRetry := wait.Backoff{
+		Steps:    1,
+		Duration: defaultDuration,
+	}
+	count = 0
+
+	endTimeIfDelays := time.Now().Add(defaultDuration)
+	service, err := cc.waitForSkupperServiceToBeCreated("SomeService", retryFnSuccedsInTheThirdCall, testRetry)
+	assert.Assert(t, time.Now().Sub(endTimeIfDelays) < 0) //1 retry means no delay!
+	assert.Error(t, err, "some error")
+	assert.Equal(t, count, 1)
+	assert.Assert(t, service == nil)
+
+	testRetry.Steps = 3
+
+	//3 retries means 2 sleeps: try,sleep,try,sleep,try
+	endTimeIfDelays = time.Now().Add(time.Duration(testRetry.Steps-1) * defaultDuration)
+
+	count = 0
+	service, err = cc.waitForSkupperServiceToBeCreated("SomeService", retryFnSuccedsInTheThirdCall, testRetry)
+	assert.Assert(t, time.Now().Sub(endTimeIfDelays) >= 0) //1 retry means no delay!
+	assert.Assert(t, err)
+	assert.Equal(t, count, 3)
+	assert.Assert(t, service == mockService)
+
+	//adding a call with 0 steps to show what we get if we call with Steps=0
+	//result is, no errors, function not called. which is "logical?)...
+	testRetry.Steps = 0
+	count = 0
+	service, err = cc.waitForSkupperServiceToBeCreated("SomeService", retryFnSuccedsInTheThirdCall, testRetry)
+	assert.Assert(t, err)
+	assert.Assert(t, service == nil)
+
+}

--- a/test/integration/basic/basic.go
+++ b/test/integration/basic/basic.go
@@ -16,9 +16,9 @@ type BasicTestRunner struct {
 
 func (r *BasicTestRunner) RunTests(ctx context.Context) {
 
-	tick := time.Tick(5 * time.Second)
+	tick := time.Tick(cluster.DefaultTick)
+	timeout := time.After(cluster.ImagePullingAndResourceCreationTimeout)
 	wait_for_conn := func(cc *cluster.ClusterContext) {
-		timeout := time.After(120 * time.Second)
 		for {
 			select {
 			case <-timeout:

--- a/test/integration/http/http.go
+++ b/test/integration/http/http.go
@@ -24,8 +24,6 @@ type HttpClusterTestRunner struct {
 
 func int32Ptr(i int32) *int32 { return &i }
 
-const minute time.Duration = 60
-
 var httpbinDep *appsv1.Deployment = &appsv1.Deployment{
 	TypeMeta: metav1.TypeMeta{
 		APIVersion: "apps/v1",
@@ -76,8 +74,8 @@ func (r *HttpClusterTestRunner) RunTests(ctx context.Context) {
 	//for tcp_echo test, since in case of reducing test may fail
 	//intermitently
 
-	r.Pub1Cluster.GetService("httpbin", 3*minute)
-	time.Sleep(20 * time.Second) //TODO XXX What is the right condition to wait for?
+	_, err := cluster.WaitForSkupperServiceToBeCreatedAndReadyToUse(r.Pub1Cluster, "httpbin")
+	assert.Assert(r.T, err)
 
 	r.Pub1Cluster.KubectlExecAsync(fmt.Sprintf("port-forward service/httpbin 8080:80"))
 	defer exec.Command("pkill", "kubectl").Run()


### PR DESCRIPTION
- All common delays are now globally defined in test/cluster package.
- Some tuning on wait condition values.
- Using client-go retryier also for waiting for skupper-exposed services to show up.
- WaitForSkupperServiceToBeCreatedAndReadyToUse and waitForSkupperServiceToBeCreated fully unit-tested.

Closes: #95 
 
