### PR TITLE
Annotated resources integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Test binary, built with `go test -c`
 *.test
+/test/**/tmp
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out

--- a/test/integration/annotation/README.md
+++ b/test/integration/annotation/README.md
@@ -1,0 +1,104 @@
+# Test how Skupper handles annotated resources
+
+# Description
+The "TestAnnotatedResources" test validates how Skupper reacts when supported
+resources (Service and Deployment) are updated with Skupper related
+annotations.
+
+It uses an nginx server, as the target component for the exposed services,
+created by Skupper, from an annotated Deployment and two annotated services
+(one uses a target address while the other does not).
+
+Each test case, from the test table, runs a different scenario, performing
+modifications to the initially annotated resources.
+
+The final validation, for all test cases, is the same.
+
+They all validate:
+
+* From http://skupper-controller:8080/DATA:
+  * The number of connected sites
+  * The final list of services 
+    * Number of services
+    * The exposed service list and their respective protocol
+* Each exposed service should be accessible
+    * Return code is 200
+    * Response body is not empty
+    
+# Pre-requisites
+
+* At least one cluster must be available, through:
+  * KUBECONFIG environment variable (defaults to: `${USER}/.kube/config`)
+  * Or specifying one or two clusters through:
+    * `--kubeconfig`
+    * `--edgekubeconfig`
+* Test will create two namespaces
+  * `annotation-1`
+  * `annotation-2`
+  * ***Note:** If using 2 clusters, each one will be created in a distinct cluster*
+
+# Setup and TearDown
+
+The Setup creates the namespaces, deploys the initial set of
+resources (Deployment and Services) and creates the Skupper
+network between the two namespaces (or clusters). This happens
+only once for all test cases.
+
+The TearDown is executed when test finishes or is interrupted,
+and it deletes the created namespaces (if namespace creation fails,
+it does not delete anything).
+
+# Test steps and validations (common for all test cases)
+
+1. Run the modification function (if any provided)
+1. Retrieve services list from http://skupper-controller:8080/DATA
+1. Validate number of sites
+1. Validate exposed list of services and their protocols
+1. Communicate with all exposed services from both clusters
+   1. Expects HTTP status code to be 200
+   1. Response body cannot be empty
+
+# Test cases
+
+## services-pre-annotated
+
+First iteration to run. It creates an nginx deployment and two services on
+each cluster/ns. They are created with Skupper annotations, before Skupper
+is deployed to the clusters, to validate if Skupper is detecting the existing
+services and exposing them as per the annotations.
+
+Here are the annotations on each:
+
+* **Cluster1**
+  * nginx (Deployment)
+    * skupper.io/proxy = tcp
+    * skupper.io/address = nginx-1-dep-web
+  * nginx-1-svc-exp-notarget (Service)
+    * skupper.io/proxy = tcp
+  * nginx-1-svc-target (Service)
+    * skupper.io/proxy = http
+    * skupper.io/address = nginx-1-svc-exp-target
+  
+* **Cluster2**
+  * nginx (Deployment)
+    * skupper.io/proxy = tcp
+    * skupper.io/address = nginx-2-dep-web
+  * nginx-2-svc-exp-notarget (Service)
+    * skupper.io/proxy = tcp
+  * nginx-2-svc-target (Service)
+    * skupper.io/proxy = http
+    * skupper.io/address = nginx-2-svc-exp-target
+
+## services-protocol-switch
+
+Switches the protocols for all exposed resources. If resource is using
+TCP, it will set the protocol to HTTP and vice-versa.
+
+## services-annotation-removed
+
+Removes all Skupper annotations from previously annotated resources.
+
+## services-annotated
+
+Adds the annotations back to the initial resources (now with Skupper already
+running) and validate that it has been restored to the initial state.

--- a/test/integration/annotation/annotated_resource_setup.go
+++ b/test/integration/annotation/annotated_resource_setup.go
@@ -21,7 +21,7 @@ const (
 	nsCluster1 = "annotation-1"
 	nsCluster2 = "annotation-2"
 	timeout    = 120 * time.Second
-	interval   = 10 * time.Second
+	interval   = 20 * time.Second
 )
 
 var (

--- a/test/integration/annotation/annotated_resource_setup.go
+++ b/test/integration/annotation/annotated_resource_setup.go
@@ -1,0 +1,318 @@
+package annotation
+
+import (
+	"context"
+	"fmt"
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/client"
+	"github.com/skupperproject/skupper/pkg/kube"
+	"github.com/skupperproject/skupper/pkg/utils"
+	"github.com/skupperproject/skupper/test/utils/k8s"
+	"gotest.tools/assert"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"testing"
+	"time"
+)
+
+const (
+	nsCluster1 = "annotation-1"
+	nsCluster2 = "annotation-2"
+	timeout    = 120 * time.Second
+	interval   = 10 * time.Second
+)
+
+var (
+	clusters           int = 1
+	ctx                    = context.Background()
+	kubeConfigCluster1 string
+	kubeConfigCluster2 string
+	cluster1           *client.VanClient
+	cluster2           *client.VanClient
+	// teardownClusters prevents deleting an existing namespace
+	teardownClusters []*client.VanClient
+)
+
+// test allows defining the matrix to run the test table
+type test struct {
+	name                  string
+	doc                   string
+	modification          func(*testing.T)
+	expectedSites         int
+	expectedServicesProto map[string]string
+}
+
+// Setup simply creates the namespaces using a single
+// cluster by default, or using two clusters if at
+// least two kubeconfig files have been provided. It
+// also initializes the cluster1 and cluster2 variables.
+func Setup(t *testing.T) {
+	var err error
+
+	// Need at least one public (or a default) cluster
+	pubClusters := k8s.KubeConfigFilesCount(t, false, true)
+	if pubClusters == 0 {
+		t.Skip("no public clusters available")
+	}
+	if k8s.KubeConfigFilesCount(t, true, true) > 1 {
+		clusters = 2
+	}
+	t.Logf("Setup - using %d clusters", clusters)
+
+	// Initializing clients
+	t.Log("Initializing clients")
+
+	// cluster1 will be used as public (connection token will be generated from it)
+	kubeConfigCluster1 = k8s.KubeConfigFiles(t, false, true)[0]
+	// cluster2 will connect to cluster1 (can be either an edge, a public or the default)
+	kubeConfigCluster2 = k8s.KubeConfigFiles(t, true, true)[0]
+	cluster1, err = client.NewClient(nsCluster1, "", kubeConfigCluster1)
+	assert.Assert(t, err)
+	cluster2, err = client.NewClient(nsCluster2, "", kubeConfigCluster2)
+	assert.Assert(t, err)
+
+	// Creating namespaces (or failing if already exists or other error occurs)
+	t.Log("Creating namespaces")
+	_, err = kube.NewNamespace(nsCluster1, cluster1.KubeClient)
+	assert.Assert(t, err)
+	teardownClusters = append(teardownClusters, cluster1)
+	_, err = kube.NewNamespace(nsCluster2, cluster2.KubeClient)
+	assert.Assert(t, err)
+	teardownClusters = append(teardownClusters, cluster2)
+}
+
+// Teardown ensures all resources are removed
+// when test completes
+func TearDown(t *testing.T) {
+	t.Logf("Tearding down - using %d clusters", clusters)
+	t.Log("Deleting namespaces")
+	for _, cluster := range teardownClusters {
+		err := kube.DeleteNamespace(cluster.Namespace, cluster.KubeClient)
+		assert.Assert(t, err)
+	}
+}
+
+// DeployResources provides common setup for kicking off all annotated
+// resource tests. It deploys a static set of resources:
+// - Deployments
+// - Services.
+//
+// And it also includes static annotations to the deployed resources.
+//
+// The default resources and annotations (if true) that will
+// be added to both cluster1 and cluster2 are:
+// deployment/nginx  ## to both clusters
+//   annotations:
+//     skupper.io/proxy: tcp
+// service/nginx-1-svc-exp-notarget  ## cluster1
+//   annotations:
+//     skupper.io/proxy: tcp
+// service/nginx-1-svc-target  ## cluster1
+//   annotations:
+//     skupper.io/proxy: http
+//     skupper.io/address: nginx-1-svc-exp-target
+// service/nginx-2-svc-exp-notarget  ## cluster2
+//   annotations:
+//     skupper.io/proxy: tcp
+// service/nginx-2-svc-target  ## cluster2
+//   annotations:
+//     skupper.io/proxy: http
+//     skupper.io/address: nginx-1-svc-exp-target
+//
+func DeployResources(t *testing.T) {
+	// Deploys a static set of resources
+	t.Logf("Deploying resources - using %d clusters", clusters)
+
+	// Deploys the same set of resources against both clusters
+	// resources will have index (1 or 2), depending on the
+	// cluster they are being deployed to
+	for i, cluster := range []*client.VanClient{cluster1, cluster2} {
+		clusterIdx := i + 1
+
+		// Annotations (optional) to deployment and services
+		depAnnotations := map[string]string{}
+		svcNoTargetAnnotations := map[string]string{}
+		svcTargetAnnotations := map[string]string{}
+		populateAnnotations(clusterIdx, depAnnotations, svcNoTargetAnnotations, svcTargetAnnotations)
+
+		// One single deployment will be created (for the nginx http server)
+		createDeployment(t, cluster, depAnnotations)
+
+		// Now create two services. One that does not have a target address,
+		// and another that provides a target address.
+		createService(t, cluster, fmt.Sprintf("nginx-%d-svc-exp-notarget", clusterIdx), svcNoTargetAnnotations)
+		// This service with the target should not be exposed (only the target service will be)
+		createService(t, cluster, fmt.Sprintf("nginx-%d-svc-target", clusterIdx), svcTargetAnnotations)
+	}
+
+	// Wait for pods to be running
+	for _, cluster := range []*client.VanClient{cluster1, cluster2} {
+		t.Logf("waiting on pods to be running on %s", cluster.Namespace)
+		// Get all pod names
+		podList, err := cluster.KubeClient.CoreV1().Pods(cluster.Namespace).List(metav1.ListOptions{})
+		assert.Assert(t, err)
+		assert.Assert(t, len(podList.Items) > 0)
+
+		for _, pod := range podList.Items {
+
+			_, err := kube.WaitForPodStatus(cluster.Namespace, cluster.KubeClient, pod.Name, corev1.PodRunning, timeout, interval)
+			assert.Assert(t, err)
+		}
+	}
+}
+
+// populateAnnotations annotates the provide maps with static
+// annotations for the deployment, and for each of the services
+func populateAnnotations(clusterIdx int, depAnnotations map[string]string, svcNoTargetAnnotations map[string]string, svcTargetAnnotations map[string]string) {
+	// Define a static set of annotations to the deployment
+	depAnnotations[types.ProxyQualifier] = "tcp"
+	depAnnotations[types.AddressQualifier] = fmt.Sprintf("nginx-%d-dep-web", clusterIdx)
+
+	// Set annotations to the service with no target address
+	svcNoTargetAnnotations[types.ProxyQualifier] = "tcp"
+
+	// Set annotations to the service with target address
+	svcTargetAnnotations[types.ProxyQualifier] = "http"
+	svcTargetAnnotations[types.AddressQualifier] = fmt.Sprintf("nginx-%d-svc-exp-target", clusterIdx)
+}
+
+// CreateVan deploys Skupper to both clusters then generates a
+// connection token on cluster1 and connects cluster2 to cluster1
+// waiting for the network to be formed (or failing otherwise)
+func CreateVan(t *testing.T) {
+	var err error
+	t.Logf("Creating VAN - using %d clusters", clusters)
+
+	siteConfig := types.SiteConfig{
+		Spec: types.SiteConfigSpec{
+			EnableController:  true,
+			EnableServiceSync: true,
+			User:              "admin",
+			Password:          "admin",
+			ClusterLocal:      false,
+		},
+	}
+
+	// If using only 1 cluster, set ClusterLocal to True
+	if clusters == 1 {
+		siteConfig.Spec.ClusterLocal = true
+	}
+	t.Logf("setting siteConfig to run with ClusterLocal=%v", siteConfig.Spec.ClusterLocal)
+
+	// Creating the router on cluster1
+	err = cluster1.RouterCreate(ctx, siteConfig)
+	assert.Assert(t, err, "error creating router on cluster1")
+
+	// Creating the router on cluster2
+	err = cluster2.RouterCreate(ctx, siteConfig)
+	assert.Assert(t, err, "error creating router on cluster2")
+
+	// Creating a local directory for storing the token
+	testPath := "./tmp/"
+	os.Mkdir(testPath, 0755)
+
+	// Creating token and connecting sites
+	tokenFile := testPath + "cluster1.yaml"
+	err = cluster1.ConnectorTokenCreateFile(ctx, "cluster1", tokenFile)
+	assert.Assert(t, err, "unable to create token to cluster1")
+
+	// Connecting cluster2 to cluster1
+	secret, err := cluster2.ConnectorCreateFromFile(ctx, tokenFile, types.ConnectorCreateOptions{SkupperNamespace: cluster2.Namespace})
+	assert.Assert(t, err, "unable to create connection to cluster1")
+	assert.Assert(t, secret != nil)
+
+	// Waiting till skupper is running on both clusters
+	for _, c := range []*client.VanClient{cluster1, cluster2} {
+		t.Logf("waiting for Skupper sites to be connected at: %s", c.Namespace)
+		err = utils.Retry(interval, 20, func() (bool, error) {
+			rir, _ := c.RouterInspect(ctx)
+			connected := 0
+			if rir != nil {
+				connected = rir.Status.ConnectedSites.Total
+			}
+			return connected == 1, nil
+		})
+		assert.Assert(t, err, "timed out waiting on Skupper sites to connect at: %s", c.Namespace)
+	}
+}
+
+// createDeployment creates a pre-defined nginx Deployment at the given
+// cluster and namespace. Reason for using it is that it is a tiny image
+// and allows tests to validate traffic flowing using both http and tcp bridges.
+func createDeployment(t *testing.T, cluster *client.VanClient, annotations map[string]string) *v1.Deployment {
+	name := "nginx"
+	replicas := int32(1)
+	dep := &v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   cluster.Namespace,
+			Annotations: annotations,
+			Labels: map[string]string{
+				"app": name,
+			},
+		},
+		Spec: v1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": name,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": name,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "nginx", Image: "nginxinc/nginx-unprivileged:stable-alpine", Ports: []corev1.ContainerPort{{Name: "web", ContainerPort: 8080}}, ImagePullPolicy: corev1.PullIfNotPresent},
+					},
+					RestartPolicy: corev1.RestartPolicyAlways,
+				},
+			},
+		},
+	}
+
+	// Deploying resource
+	dep, err := cluster.KubeClient.AppsV1().Deployments(cluster.Namespace).Create(dep)
+	assert.Assert(t, err)
+
+	// Wait for deployment to be ready
+	dep, err = kube.WaitDeploymentReadyReplicas(dep.Name, cluster.Namespace, 1, cluster.KubeClient, timeout, interval)
+	assert.Assert(t, err)
+
+	return dep
+}
+
+// createService creates a new service at the provided cluster/namespace
+// the generated service uses a static selector pointing to the "nginx" pods
+func createService(t *testing.T, cluster *client.VanClient, name string, annotations map[string]string) *corev1.Service {
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"app": "nginx",
+			},
+			Annotations: annotations,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "web", Port: 8080},
+			},
+			Selector: map[string]string{
+				"app": "nginx",
+			},
+			Type: corev1.ServiceTypeLoadBalancer,
+		},
+	}
+
+	// Creating the new service
+	svc, err := cluster.KubeClient.CoreV1().Services(cluster.Namespace).Create(svc)
+	assert.Assert(t, err)
+
+	return svc
+}

--- a/test/integration/annotation/annotated_resource_test.go
+++ b/test/integration/annotation/annotated_resource_test.go
@@ -1,0 +1,190 @@
+// +build integration annotated
+
+package annotation
+
+import (
+	"encoding/json"
+	"fmt"
+	vanClient "github.com/skupperproject/skupper/client"
+	"github.com/skupperproject/skupper/pkg/utils"
+	"github.com/skupperproject/skupper/test/utils/base"
+	"github.com/skupperproject/skupper/test/utils/tools"
+	"gotest.tools/assert"
+	"reflect"
+	"testing"
+)
+
+const (
+	// runs inside skupper-controller's pod
+	dataEndpoint = "http://127.0.0.1:8080/DATA"
+)
+
+var (
+	curlOpts = tools.CurlOpts{
+		Silent:   true,
+		Username: "admin",
+		Password: "admin",
+		Timeout:  10,
+	}
+)
+
+// TestMain initializes flag parsing
+func TestMain(m *testing.M) {
+	base.ParseFlags(m)
+}
+
+// TestAnnotatedResources deploy resources with Skupper annotations before
+// Skupper is available in the respective namespaces. Then we run a test
+// table that starts verifying initial state and then applies modifications
+// to validate if Skupper is reacting as expected.
+func TestAnnotatedResources(t *testing.T) {
+
+	testTable := []test{
+		{
+			name:          "services-pre-annotated",
+			doc:           "Services are pre-annotated before Skupper is deployed and exposed service list matches",
+			modification:  nil,
+			expectedSites: 2,
+			expectedServicesProto: map[string]string{
+				"nginx-1-dep-web":          "tcp",
+				"nginx-2-dep-web":          "tcp",
+				"nginx-1-svc-exp-notarget": "tcp",
+				"nginx-2-svc-exp-notarget": "tcp",
+				"nginx-1-svc-exp-target":   "http",
+				"nginx-2-svc-exp-target":   "http",
+			},
+		},
+		{
+			name:          "services-protocol-switch",
+			doc:           "Switches the protocol for all services and deployment and validate updated service list",
+			modification:  switchProtocols,
+			expectedSites: 2,
+			expectedServicesProto: map[string]string{
+				"nginx-1-dep-web":          "http",
+				"nginx-2-dep-web":          "http",
+				"nginx-1-svc-exp-notarget": "http",
+				"nginx-2-svc-exp-notarget": "http",
+				"nginx-1-svc-exp-target":   "tcp",
+				"nginx-2-svc-exp-target":   "tcp",
+			},
+		},
+		{
+			name:                  "services-annotation-removed",
+			doc:                   "Remove Skupper annotations from services and deployment and validate available service list",
+			modification:          removeAnnotation,
+			expectedSites:         2,
+			expectedServicesProto: map[string]string{},
+		},
+		{
+			name:          "services-annotated",
+			doc:           "Services are annotated after Skupper is deployed and exposed service list matches",
+			modification:  addAnnotation,
+			expectedSites: 2,
+			expectedServicesProto: map[string]string{
+				"nginx-1-dep-web":          "tcp",
+				"nginx-2-dep-web":          "tcp",
+				"nginx-1-svc-exp-notarget": "tcp",
+				"nginx-2-svc-exp-notarget": "tcp",
+				"nginx-1-svc-exp-target":   "http",
+				"nginx-2-svc-exp-target":   "http",
+			},
+		},
+	}
+
+	// Test flow
+	defer TearDown(t)
+	base.HandleInterruptSignal(t, TearDown)
+
+	// 1. Initialize Namespaces
+	Setup(t)
+
+	// 2. Deploying the Pre-annotated resources
+	DeployResources(t)
+
+	// 3. Deploys Skupper and create a VAN between both clusters
+	CreateVan(t)
+
+	// 4. Iterate through test table and run each test
+	for _, test := range testTable {
+		t.Run(test.name, func(t *testing.T) {
+			var err error
+
+			// 4.1. If test expects modifications to be performed, run them
+			if test.modification != nil {
+				test.modification(t)
+			}
+
+			// 4.2 Validate services from DATA endpoint (with retries)
+			var resp *tools.CurlResponse
+			var consoleData ConsoleData
+			err = utils.Retry(interval, 10, func() (bool, error) {
+				resp, err = tools.Curl(cluster1.KubeClient, cluster1.RestConfig, cluster1.Namespace, "", dataEndpoint, curlOpts)
+				if err != nil {
+					return false, nil
+				}
+
+				// 4.2.1. Parsing ConsoleData response
+				if err = json.Unmarshal([]byte(resp.Body), &consoleData); err != nil {
+					return false, nil
+				}
+
+				// 4.2.2. retry till expected amount of sites and services match
+				if test.expectedSites != len(consoleData.Sites) || len(test.expectedServicesProto) != len(consoleData.Services) {
+					return false, nil
+				}
+
+				// 4.2.3. populating map of services/protocols returned
+				servicesFound := map[string]string{}
+				for _, svc := range consoleData.Services {
+					svcMap, ok := svc.(map[string]interface{})
+					assert.Assert(t, ok)
+					address, ok := svcMap["address"].(string)
+					assert.Assert(t, ok)
+					protocol, ok := svcMap["protocol"].(string)
+					assert.Assert(t, ok)
+					servicesFound[address] = protocol
+				}
+
+				// 4.2.4. only consider as done if all match (otherwise it will timeout)
+				res := reflect.DeepEqual(test.expectedServicesProto, servicesFound)
+				return res, nil
+			})
+			assert.Assert(t, err, "timed out waiting for expected services/protocol list to match")
+
+			// 4.3. Validating all exposed services are reachable across clusters
+			for _, cluster := range []*vanClient.VanClient{cluster1, cluster2} {
+				for svc, _ := range test.expectedServicesProto {
+					t.Logf("validating communication with service %s through %s", svc, cluster.Namespace)
+					// reaching service through proxy-controller's pod (with some attempts to make sure bridge is connected)
+					err = utils.Retry(interval, 10, func() (bool, error) {
+						endpoint := fmt.Sprintf("http://%s:8080", svc)
+						resp, err = tools.Curl(cluster.KubeClient, cluster.RestConfig, cluster.Namespace, "", endpoint, tools.CurlOpts{})
+						if err != nil {
+							return false, nil
+						}
+						return true, nil
+					})
+					assert.Assert(t, err, "unable to reach service %s through %s", svc, cluster.Namespace)
+					assert.Equal(t, resp.StatusCode, 200, "bad response received from service %s through %s", svc, cluster.Namespace)
+					assert.Assert(t, resp.Body != "", "empty response body received from service %s through %s", svc, cluster.Namespace)
+				}
+			}
+		})
+	}
+}
+
+// TODO ConsoleData and Site here for now but ideally those types
+//      should be moved from main to a separate package (see: issue #203)
+type ConsoleData struct {
+	Sites    []Site        `json:"sites"`
+	Services []interface{} `json:"services"`
+}
+
+type Site struct {
+	SiteName  string   `json:"site_name"`
+	SiteId    string   `json:"site_id"`
+	Connected []string `json:"connected"`
+	Namespace string   `json:"namespace"`
+	Url       string   `json:"url"`
+	Edge      bool     `json:"edge"`
+}

--- a/test/integration/annotation/modification_functions.go
+++ b/test/integration/annotation/modification_functions.go
@@ -1,0 +1,133 @@
+package annotation
+
+import (
+	"fmt"
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/client"
+	"gotest.tools/assert"
+	v12 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+//
+// Modification functions to be used within the test tables
+//
+
+// switchProtocols switches the annotated resources protocols
+// from http to tcp and vice versa
+func switchProtocols(t *testing.T) {
+
+	switchTcpHttp := func(annotations map[string]string) bool {
+		if protocol, ok := annotations[types.ProxyQualifier]; ok {
+			if protocol == "tcp" {
+				annotations[types.ProxyQualifier] = "http"
+			} else {
+				annotations[types.ProxyQualifier] = "tcp"
+			}
+			return true
+		}
+		return false
+	}
+
+	for _, cluster := range []*client.VanClient{cluster1, cluster2} {
+
+		// Retrieving the deployment
+		dep, err := cluster.KubeClient.AppsV1().Deployments(cluster.Namespace).Get("nginx", v1.GetOptions{})
+		assert.Assert(t, err)
+
+		// Retrieving services
+		svcList, err := cluster.KubeClient.CoreV1().Services(cluster.Namespace).List(v1.ListOptions{
+			LabelSelector: "app=nginx",
+		})
+		assert.Assert(t, err)
+
+		// Switching protocol
+		updateDeployment := switchTcpHttp(dep.Annotations)
+
+		// Iterate through services with the annotation and switch
+		svcUpdateList := []v12.Service{}
+		for _, svc := range svcList.Items {
+			if ok := switchTcpHttp(svc.Annotations); ok {
+				svcUpdateList = append(svcUpdateList, svc)
+			}
+		}
+
+		// Performing updates
+		if updateDeployment {
+			_, err = cluster.KubeClient.AppsV1().Deployments(cluster.Namespace).Update(dep)
+			assert.Assert(t, err)
+		}
+
+		for _, svc := range svcUpdateList {
+			_, err := cluster.KubeClient.CoreV1().Services(cluster.Namespace).Update(&svc)
+			assert.Assert(t, err)
+		}
+
+	}
+
+}
+
+// removeAnnotation will remove annotation from the nginx deployment as
+// well as from all services with the label "app=nginx"
+func removeAnnotation(t *testing.T) {
+	for _, cluster := range []*client.VanClient{cluster1, cluster2} {
+		// Retrieving the deployment
+		dep, err := cluster.KubeClient.AppsV1().Deployments(cluster.Namespace).Get("nginx", v1.GetOptions{})
+		assert.Assert(t, err)
+
+		// Removing annotations and updating
+		dep.Annotations = map[string]string{}
+		_, err = cluster.KubeClient.AppsV1().Deployments(cluster.Namespace).Update(dep)
+		assert.Assert(t, err)
+
+		// Retrieving services
+		svcList, err := cluster.KubeClient.CoreV1().Services(cluster.Namespace).List(v1.ListOptions{
+			LabelSelector: "app=nginx",
+		})
+		assert.Assert(t, err)
+
+		// Iterate through services removing annotation and performing the udpate
+		for _, svc := range svcList.Items {
+			svc.Annotations = map[string]string{}
+			_, err := cluster.KubeClient.CoreV1().Services(cluster.Namespace).Update(&svc)
+			assert.Assert(t, err)
+		}
+	}
+}
+
+// addAnnotation adds the default annotations to the nginx deployment
+// as well as for the two services (the one without target and the other
+// that uses a target address).
+// For more info, see: DeployResources
+func addAnnotation(t *testing.T) {
+	for i, cluster := range []*client.VanClient{cluster1, cluster2} {
+		clusterIdx := i + 1
+
+		// Retrieving the deployment
+		dep, err := cluster.KubeClient.AppsV1().Deployments(cluster.Namespace).Get("nginx", v1.GetOptions{})
+		assert.Assert(t, err)
+		dep.Annotations = map[string]string{}
+
+		// Retrieving services
+		svcNoTarget, err := cluster.KubeClient.CoreV1().Services(cluster.Namespace).Get(fmt.Sprintf("nginx-%d-svc-exp-notarget", clusterIdx), v1.GetOptions{})
+		assert.Assert(t, err)
+		svcNoTarget.Annotations = map[string]string{}
+		svcTarget, err := cluster.KubeClient.CoreV1().Services(cluster.Namespace).Get(fmt.Sprintf("nginx-%d-svc-target", clusterIdx), v1.GetOptions{})
+		assert.Assert(t, err)
+		svcTarget.Annotations = map[string]string{}
+
+		// Populating default annotations
+		populateAnnotations(clusterIdx, dep.Annotations, svcNoTarget.Annotations, svcTarget.Annotations)
+
+		// Updating deployment
+		_, err = cluster.KubeClient.AppsV1().Deployments(cluster.Namespace).Update(dep)
+		assert.Assert(t, err)
+
+		// Updating services
+		_, err = cluster.KubeClient.CoreV1().Services(cluster.Namespace).Update(svcNoTarget)
+		assert.Assert(t, err)
+		_, err = cluster.KubeClient.CoreV1().Services(cluster.Namespace).Update(svcTarget)
+		assert.Assert(t, err)
+	}
+}

--- a/test/utils/base/flag.go
+++ b/test/utils/base/flag.go
@@ -1,0 +1,57 @@
+package base
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+// TestFlags holds the common command line arguments
+// needed for running tests. The goal is to keep it
+// minimal. If tests allow custom configurations, it
+// is better to define them through environment
+// variables.
+type testFlags struct {
+	KubeConfigs     kubeConfigs
+	EdgeKubeConfigs kubeConfigs
+}
+
+// Special type to allow multiple kubeconfig files to be provided
+type kubeConfigs []string
+
+// String returns string representing the provided contexts
+func (k *kubeConfigs) String() string {
+	var rep, sep string
+	for _, name := range *k {
+		rep += sep + name
+		sep = ", "
+	}
+	return rep
+}
+
+// Set stores the provided kubeconfig entries into KubeConfigs
+func (k *kubeConfigs) Set(file string) error {
+	// validate if the provided file exists
+	if _, err := os.Stat(file); err != nil {
+		return err
+	}
+	// if file exists then use it
+	*k = append(*k, file)
+	return nil
+}
+
+var (
+	TestFlags testFlags
+)
+
+func ParseFlags(m *testing.M) {
+	// Registering flags to be parsed
+	flag.Var(&TestFlags.KubeConfigs, "kubeconfig", "KUBECONFIG files to be used. You can provide the --kubeconfig flag multiple times.")
+	flag.Var(&TestFlags.EdgeKubeConfigs, "edgekubeconfig", "Edge KUBECONFIG files to be used (other sites cannot connect to this cluster). You can provide the --edgekubeconfig flag multiple times.")
+
+	// Parsing
+	flag.Parse()
+
+	// Running tests
+	os.Exit(m.Run())
+}

--- a/test/utils/base/interrupt_handler.go
+++ b/test/utils/base/interrupt_handler.go
@@ -1,0 +1,21 @@
+package base
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"testing"
+)
+
+// HandleInterruptSignal runs the given fn in case
+// test execution was interrupted
+func HandleInterruptSignal(t *testing.T, fn func(*testing.T)) {
+	sigChannel := make(chan os.Signal, 1)
+	signal.Notify(sigChannel, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigChannel
+		t.Logf("interrupt signal received")
+		fn(t)
+		t.FailNow()
+	}()
+}

--- a/test/utils/k8s/execute.go
+++ b/test/utils/k8s/execute.go
@@ -1,0 +1,54 @@
+package k8s
+
+import (
+	"bytes"
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// Execute helps executing commands on a given pod, using the k8s rest api
+// returning stdout, stderr, err
+// This function is nil safe and so stdout and stderr are always returned
+func Execute(kubeClient kubernetes.Interface, config *rest.Config, ns string, pod, container string, command []string) (bytes.Buffer, bytes.Buffer, error) {
+	// nil safe
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	restClient, err := rest.RESTClientFor(config)
+	if err != nil {
+		return stdout, stderr, err
+	}
+
+	// k8s request to be executed as a remote command
+	request := restClient.Post().
+		Resource("pods").
+		Namespace(ns).
+		Name(pod).
+		SubResource("exec")
+	request.VersionedParams(&v1.PodExecOptions{
+		Container: container,
+		Command:   command,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, scheme.ParameterCodec)
+
+	// Executing
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", request.URL())
+	if err != nil {
+		return stdout, stderr, err
+	}
+
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  nil,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+
+	// Returning
+	return stdout, stderr, err
+}

--- a/test/utils/k8s/kubeconfig.go
+++ b/test/utils/k8s/kubeconfig.go
@@ -1,0 +1,63 @@
+package k8s
+
+import (
+	"github.com/skupperproject/skupper/test/utils/base"
+	"gotest.tools/assert"
+	"os"
+	"path"
+	"testing"
+)
+
+// KubeConfigFiles return the available kubeconfig files
+// based on provided --kubeconfig, --edgekubeconfig or the
+// default KUBECONFIG environment variable (only if no flag
+// has been provided)
+func KubeConfigFiles(t *testing.T, includeEdge, includePublic bool) []string {
+	kubeConfigFiles := []string{}
+	edgeConfigs := len(base.TestFlags.EdgeKubeConfigs)
+	pubConfigs := len(base.TestFlags.KubeConfigs)
+
+	// If should include edge and --edgekubeconfig flag has been provided
+	// edge should be processed before public as public can be used as
+	// edge but not otherwise
+	if includeEdge && edgeConfigs > 0 {
+		kubeConfigFiles = append(kubeConfigFiles, base.TestFlags.EdgeKubeConfigs...)
+	}
+
+	// If should include public and kubeconfig flag has been provided
+	if includePublic && pubConfigs > 0 {
+		kubeConfigFiles = append(kubeConfigFiles, base.TestFlags.KubeConfigs...)
+	}
+
+	// Only try to include the default config if no flag provided
+	if pubConfigs == 0 && edgeConfigs == 0 {
+		kubeConfigFiles = []string{KubeConfigDefault(t)}
+	}
+
+	return kubeConfigFiles
+}
+
+// KubeConfigDefault returns the "default" KUBECONFIG
+// filename if one exists
+func KubeConfigDefault(t *testing.T) string {
+	// Otherwise use the default
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		homedir, err := os.UserHomeDir()
+		assert.Assert(t, err)
+		kubeconfig = path.Join(homedir, ".kube/config")
+	}
+
+	// Validate that it exists
+	_, err := os.Stat(kubeconfig)
+	assert.Assert(t, err, "KUBECONFIG file could not be determined")
+
+	return kubeconfig
+}
+
+// KubeConfigFilesCount returns total amount of kubeconfig
+// files provided (using --kubeconfig or --edgekubeconfig)
+// or 1 if no flags provided and the default exists
+func KubeConfigFilesCount(t *testing.T, includeEdge, includePublic bool) int {
+	return len(KubeConfigFiles(t, includeEdge, includePublic))
+}

--- a/test/utils/k8s/kubeconfig.go
+++ b/test/utils/k8s/kubeconfig.go
@@ -13,7 +13,7 @@ import (
 // default KUBECONFIG environment variable (only if no flag
 // has been provided)
 func KubeConfigFiles(t *testing.T, includeEdge, includePublic bool) []string {
-	kubeConfigFiles := []string{}
+	var kubeConfigFiles []string
 	edgeConfigs := len(base.TestFlags.EdgeKubeConfigs)
 	pubConfigs := len(base.TestFlags.KubeConfigs)
 

--- a/test/utils/tools/curl.go
+++ b/test/utils/tools/curl.go
@@ -1,0 +1,182 @@
+package tools
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/skupperproject/skupper/test/utils/k8s"
+	"io"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"log"
+	"strconv"
+	"strings"
+)
+
+// CurlOpts allows specifying arguments to run curl on a pod
+type CurlOpts struct {
+	Silent   bool
+	Username string
+	Password string
+	Timeout  int
+}
+
+// ToParams returns curl options serialized as a string slice
+func (c *CurlOpts) ToParams() []string {
+	params := []string{}
+	if c.Silent {
+		params = append(params, "-s")
+	}
+	if c.Username != "" && c.Password != "" {
+		params = append(params, "-u", fmt.Sprintf("%s:%s", c.Username, c.Password))
+	}
+	if c.Timeout > 0 {
+		params = append(params, "--max-time", strconv.Itoa(c.Timeout))
+		params = append(params, "--connect-timeout", strconv.Itoa(c.Timeout))
+	}
+	return params
+}
+
+// CurlResponse wraps a response for a curl execution
+type CurlResponse struct {
+	HttpVersion  string
+	StatusCode   int
+	ReasonPhrase string
+	Headers      map[string]string
+	Body         string
+	Output       string
+}
+
+// Curl runs curl on a given pod (or if empty, it will try to find
+// the proxy-controller pod and run against it).
+func Curl(kubeClient kubernetes.Interface, config *restclient.Config, ns, podName, url string, opts CurlOpts) (*CurlResponse, error) {
+	var pod *v1.Pod
+	var err error
+
+	// Initializing the response
+	response := &CurlResponse{
+		Headers: map[string]string{},
+	}
+
+	if podName == "" {
+		// If podName not provided try running against the skupper-controller podName
+		podList, err := kubeClient.CoreV1().Pods(ns).List(metav1.ListOptions{
+			LabelSelector: "skupper.io/component=proxy-controller",
+			Limit:         1,
+		})
+		if err != nil {
+			log.Println("error retrieving pod list")
+			return response, err
+		}
+		if len(podList.Items) != 1 {
+			log.Println("no pods to run curl")
+			return response, fmt.Errorf("no pods to run curl")
+		}
+		pod = &podList.Items[0]
+	} else {
+		// Retrieving the given pod
+		pod, err = kubeClient.CoreV1().Pods(ns).Get(podName, metav1.GetOptions{})
+		if err != nil {
+			log.Printf("unable to find pod: %s", podName)
+			return response, err
+		}
+	}
+
+	suffix, _ := uuid.NewUUID()
+	headersFile := fmt.Sprintf("/tmp/curl.Headers.%s", suffix.String())
+	bodyFile := fmt.Sprintf("/tmp/curl.Body.%s", suffix.String())
+
+	// Preparing command to run
+	command := []string{"curl", "-D", headersFile, "-o", bodyFile}
+	command = append(command, opts.ToParams()...)
+	command = append(command, url)
+
+	// Executing through the API
+	_, stderr, err := k8s.Execute(kubeClient, config, ns, pod.Name, pod.Spec.Containers[0].Name, command)
+
+	// Curl's Output (not the Body, but regular Output or errors)
+	response.Output = stderr.String()
+
+	if err != nil {
+		log.Printf("error executing curl")
+		return response, err
+	}
+
+	// Reading response Body
+	stdout, stderr, err := k8s.Execute(kubeClient, config, ns, pod.Name, pod.Spec.Containers[0].Name, []string{"cat", bodyFile})
+	if err != nil {
+		log.Printf("error retrieving response Body - %s", stderr.String())
+		return nil, err
+	}
+	response.Body = stdout.String()
+
+	// Reading header file
+	stdout, stderr, err = k8s.Execute(kubeClient, config, ns, pod.Name, pod.Spec.Containers[0].Name, []string{"cat", headersFile})
+	if err != nil {
+		log.Printf("error retrieving Output Headers - %s", stderr.String())
+		return nil, err
+	}
+
+	// Parsing Headers
+	statusLine := true
+	for {
+		line, err := stdout.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+
+		// Parsing the HTTP status line
+		if statusLine {
+			statusLine = false
+			httpStatusLine := strings.Split(line, " ")
+			if len(httpStatusLine) != 3 {
+				return nil, fmt.Errorf("error parsing HTTP status line - not enough elements [%d] - expected 3"+
+					" - line: %s", len(httpStatusLine), httpStatusLine)
+			}
+			response.HttpVersion = httpStatusLine[0]
+			response.StatusCode, err = strconv.Atoi(httpStatusLine[1])
+			if err != nil {
+				return nil, fmt.Errorf("error parsing HTTP status code '%s' - error: %s", httpStatusLine[1], err)
+			}
+			response.ReasonPhrase = httpStatusLine[2]
+			continue
+		}
+
+		// Processing Headers
+		header := strings.Split(line, ":")
+		if line == "" || len(header) != 2 {
+			continue
+		}
+		response.Headers[header[0]] = header[1]
+	}
+
+	// Removing the Output files
+	_, stderr, err = k8s.Execute(kubeClient, config, ns, pod.Name, pod.Spec.Containers[0].Name, []string{"rm", headersFile, bodyFile})
+	if err != nil {
+		log.Printf("error removing Headers and Body files - %s", stderr.String())
+		return nil, err
+	}
+
+	// All seems good
+	return response, nil
+}
+
+// DeployCurl helps deploying a Pod that provides "curl"
+// you must wait for it to be ready
+func DeployCurl(kubeClient kubernetes.Interface, ns, pod string) (*v1.Pod, error) {
+	terminationPeriodSecs := int64(30)
+	return kubeClient.CoreV1().Pods(ns).Create(&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   pod,
+			Labels: map[string]string{"app": "curl"},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: "curl", Image: "curlimages/curl", Command: strings.Split("tail -f /dev/null", " ")},
+			},
+			RestartPolicy:                 v1.RestartPolicyAlways,
+			TerminationGracePeriodSeconds: &terminationPeriodSecs,
+		},
+	})
+}


### PR DESCRIPTION
* TestAnnodatedResources new integration test added
* General flags to be used --kubeconfig and --edgekubeconfig
* Interruption handler to enforce TearDown on CTRL C
* Curl wrapper (to run curl on existing pods and avoid extra images and deployments)

Resolves #130 #196 