### PR TITLE
Migrating http integration test to run as kubernetes job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ all: build-cmd build-controllers build-tests
 build-tests:
 	mkdir -p ${TEST_BINARIES_FOLDER}
 	go test -c -tags=integration -v ./test/integration/tcp_echo -o ${TEST_BINARIES_FOLDER}/tcp_echo_test
+	go test -c -tags=integration -v ./test/integration/http -o ${TEST_BINARIES_FOLDER}/http_test
 
 build-cmd:
 	go build -ldflags="-X main.version=${VERSION}"  -o skupper cmd/skupper/skupper.go

--- a/test/cluster/cluster_test_runner.go
+++ b/test/cluster/cluster_test_runner.go
@@ -92,45 +92,22 @@ func BuildClusterContext(t *testing.T, namespacePrefix string, configFile string
 	return cc
 }
 
-func _exec(command string, wait bool) *exec.Cmd {
+func _exec(command string) ([]byte, error) {
 	var output []byte
 	var err error
 	fmt.Println(command)
 	cmd := exec.Command("sh", "-c", command)
-	if wait {
-		output, err = cmd.CombinedOutput()
-		fmt.Println(string(output))
-		if err != nil {
-			panic(err)
-		}
-	} else {
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Start()
-	}
-	return cmd
+	output, err = cmd.CombinedOutput()
+	fmt.Println(string(output))
+	return output, err
 }
 
-func (cc *ClusterContext) exec(main_command string, sub_command string, wait bool) *exec.Cmd {
-	return _exec("KUBECONFIG="+cc.ClusterConfigFile+" "+main_command+" "+cc.CurrentNamespace+" "+sub_command, wait)
+func (cc *ClusterContext) exec(main_command string, sub_command string) ([]byte, error) {
+	return _exec("KUBECONFIG=" + cc.ClusterConfigFile + " " + main_command + " " + cc.CurrentNamespace + " " + sub_command)
 }
 
-//TODO remove this
-func (cc *ClusterContext) SkupperExec(command string) *exec.Cmd {
-	return cc.exec("./skupper -n ", command, true)
-}
-
-func (cc *ClusterContext) _kubectl_exec(command string, wait bool) *exec.Cmd {
-	return cc.exec("kubectl -n ", command, wait)
-}
-
-//TODO return error instead of panic in case of exit code != 0
-func (cc *ClusterContext) KubectlExec(command string) *exec.Cmd {
-	return cc._kubectl_exec(command, true)
-}
-
-func (cc *ClusterContext) KubectlExecAsync(command string) *exec.Cmd {
-	return cc._kubectl_exec(command, false)
+func (cc *ClusterContext) KubectlExec(command string) ([]byte, error) {
+	return cc.exec("kubectl -n ", command)
 }
 
 func (cc *ClusterContext) getNextNamespace() string {
@@ -304,4 +281,20 @@ func (cc *ClusterContext) WaitForJob(jobName string, timeout time.Duration) (*ba
 		}
 	}
 
+}
+
+func AssertJob(t *testing.T, job *batchv1.Job) {
+	t.Helper()
+	assert.Equal(t, int(job.Status.Succeeded), 1)
+	assert.Equal(t, int(job.Status.Active), 0)
+
+	if job.Status.Failed > 0 {
+		t.Logf("WARNING! THIS JOB NEEDED RETRIES TO SUCCEED! Job.Status.Failed = %d\n", job.Status.Failed)
+	}
+}
+
+func SkipTestJobIfMustBeSkipped(t *testing.T) {
+	if os.Getenv("JOB") == "" {
+		t.Skip("JOB environment variable not defined")
+	}
 }

--- a/test/integration/http/http_test.go
+++ b/test/integration/http/http_test.go
@@ -5,6 +5,12 @@ package http
 import (
 	"context"
 	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/skupperproject/skupper/test/cluster"
+	vegeta "github.com/tsenart/vegeta/v12/lib"
+	"gotest.tools/assert"
 )
 
 func TestHttp(t *testing.T) {
@@ -13,4 +19,29 @@ func TestHttp(t *testing.T) {
 	testRunner.Build(t, "http")
 	ctx := context.Background()
 	testRunner.Run(ctx)
+}
+
+func TestHttpJob(t *testing.T) {
+	cluster.SkipTestJobIfMustBeSkipped(t)
+
+	rate := vegeta.Rate{Freq: 100, Per: time.Second}
+	duration := 4 * time.Second
+	targeter := vegeta.NewStaticTargeter(vegeta.Target{
+		Method: "GET",
+		URL:    "http://httpbin:80/",
+	})
+	attacker := vegeta.NewAttacker()
+
+	var metrics vegeta.Metrics
+	for res := range attacker.Attack(targeter, rate, duration, "Big Bang!") {
+		metrics.Add(res)
+	}
+	metrics.Close()
+
+	//this is too verbose, anyway mantaining for now until we add more
+	//assertions
+	spew.Dump(metrics)
+
+	// Success is the percentage of non-error responses.
+	assert.Assert(t, metrics.Success > 0.95, "too many errors! see the log for details.")
 }

--- a/test/integration/tcp_echo/tcp_echo.go
+++ b/test/integration/tcp_echo/tcp_echo.go
@@ -11,7 +11,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 
-	batchv1 "k8s.io/api/batch/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -87,20 +86,13 @@ func (r *TcpEchoClusterTestRunner) RunTests(ctx context.Context) {
 
 	endTime = time.Now().Add(cluster.ImagePullingAndResourceCreationTimeout)
 
-	assertJob := func(job *batchv1.Job) {
-		r.T.Helper()
-		assert.Equal(r.T, int(job.Status.Succeeded), 1)
-		assert.Equal(r.T, int(job.Status.Active), 0)
-		//assert.Equal(r.T, int(job.Status.Failed), 0)
-	}
-
 	job, err := r.Pub1Cluster.WaitForJob(jobName, endTime.Sub(time.Now()))
 	assert.Assert(r.T, err)
-	assertJob(job)
+	cluster.AssertJob(r.T, job)
 
 	job, err = r.Priv1Cluster.WaitForJob(jobName, endTime.Sub(time.Now()))
 	assert.Assert(r.T, err)
-	assertJob(job)
+	cluster.AssertJob(r.T, job)
 }
 
 func (r *TcpEchoClusterTestRunner) Setup(ctx context.Context) {

--- a/test/integration/tcp_echo/tcp_echo_test.go
+++ b/test/integration/tcp_echo/tcp_echo_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"os"
 	"strings"
 	"testing"
 
+	"github.com/skupperproject/skupper/test/cluster"
 	"gotest.tools/assert"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
@@ -61,10 +61,6 @@ func sendReceive() error {
 }
 
 func TestTcpEchoJob(t *testing.T) {
-	job := os.Getenv("JOB")
-	if job == "" {
-		t.Skip("JOB environment variable not defined")
-		return
-	}
+	cluster.SkipTestJobIfMustBeSkipped(t)
 	assert.Assert(t, sendReceive())
 }


### PR DESCRIPTION
Migrating http integration test to run as kubernetes job.
And minimal refactor and cleanup related to this migration.
kubectl port-forwarding removed.

Closes #190 