### PR TITLE
Adding CI semaphore to Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Skupper
 
+[![skupper](https://circleci.com/gh/skupperproject/skupper.svg?style=shield)](https://app.circleci.com/pipelines/github/skupperproject/skupper)
+
 Skupper enables cloud communication by enabling you to create a Virtual Application Network.
 
 This application layer network decouples addressing from the underlying network infrastructure.


### PR DESCRIPTION
Idea from @fgiorgetti , adding the circle-ci semaphore in Readme.
![image](https://user-images.githubusercontent.com/13121406/90922732-d7172400-e3c2-11ea-9389-a2e33575b9b9.png)
