### PR TITLE
Unittesting positional arguments verification.

### DIFF
--- a/cmd/skupper/skupper_test.go
+++ b/cmd/skupper/skupper_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func Test_requiredArg(t *testing.T) {
+	r := func(args []string) error {
+		return requiredArg("testArg")(nil, args)
+	}
+
+	assert.Error(t, r([]string{}), "testArg must be specified")
+	assert.Error(t, r([]string{"too", "many"}), "illegal argument: many")
+	assert.Error(t, r([]string{"too", "many", "more"}), "illegal argument: many")
+
+	assert.Assert(t, r([]string{"OneArgument"}))
+}
+
+func Test_bindArgs(t *testing.T) {
+	genericError := "Service name, target type and target name must all be specified (e.g. 'skupper bind <service-name> <target-type> <target-name>')"
+	b := func(args []string) error {
+		return bindArgs(nil, args)
+	}
+
+	assert.Error(t, b([]string{}), genericError)
+	assert.Error(t, b([]string{"oneArg"}), genericError)
+	assert.Error(t, b([]string{"one/Arg"}), genericError)
+	assert.Error(t, b([]string{"one", "resource"}), genericError)
+
+	//must this fail?
+	//assert.Error(t, b([]string{"one/two", "resource/name"}), genericError)
+
+	assert.Assert(t, b([]string{"one", "resource/name"}))
+	//note  illegal vs extra
+	assert.Error(t, b([]string{"one", "resource/name", "three"}), "extra argument: three")
+	assert.Error(t, b([]string{"one", "resource/name", "three", "four"}), "illegal argument: four")
+	assert.Error(t, b([]string{"one", "resource/name", "three", "four", "five"}), "illegal argument: four")
+
+	assert.Assert(t, b([]string{"one", "resource", "name"}))
+	assert.Error(t, b([]string{"one", "resource", "name", "four"}), "illegal argument: four")
+	assert.Error(t, b([]string{"one", "resource", "name", "four", "five"}), "illegal argument: four")
+}
+
+func Test_createServiceArgs(t *testing.T) {
+	c := func(args []string) error {
+		return createServiceArgs(nil, args)
+	}
+
+	assert.Error(t, c([]string{}), "Name and port must be specified")
+	assert.Error(t, c([]string{"noport"}), "Name and port must be specified")
+
+	assert.Assert(t, c([]string{"service:port"}))
+
+	assert.Error(t, c([]string{"service:port", "other"}), "extra argument: other")
+	assert.Error(t, c([]string{"service:port", "other", "arg"}), "illegal argument: arg")
+
+	assert.Assert(t, c([]string{"service", "port"}))
+	assert.Error(t, c([]string{"service", "port", "other"}), "illegal argument: other")
+	assert.Error(t, c([]string{"service", "port", "other", "arg"}), "illegal argument: other")
+}
+
+func Test_exposeTargetArgs(t *testing.T) {
+	genericError := "expose target and name must be specified (e.g. 'skupper expose deployment <name>'"
+	targetError := "expose target type must be one of: [deployment, statefulset, pods, service]"
+
+	e := func(args []string) error {
+		return exposeTargetArgs(nil, args)
+	}
+
+	assert.Error(t, e([]string{}), genericError)
+	assert.Error(t, e([]string{"depl/name"}), targetError)
+
+	assert.Error(t, e([]string{"depl/name", "two"}), "extra argument: two")
+	assert.Error(t, e([]string{"depl/name", "two", "three"}), "illegal argument: three")
+	assert.Error(t, e([]string{"depl/name", "two", "three", "four"}), "illegal argument: three")
+
+	assert.Error(t, e([]string{"depl/name"}), targetError)
+	assert.Error(t, e([]string{"anything", "name"}), targetError)
+
+	assert.Error(t, e([]string{"deployment"}), genericError)
+
+	assert.Assert(t, e([]string{"deployment", "name"}))
+
+	assert.Error(t, e([]string{"deployment", "name", "three"}), "illegal argument: three")
+	assert.Error(t, e([]string{"deployment", "name", "three", "four"}), "illegal argument: three")
+
+	for _, target := range validExposeTargets {
+		assert.Assert(t, e([]string{target, "name"}))
+	}
+}


### PR DESCRIPTION
This pr is part of #185, but it does not close it. More changes are needed.

Unittesting positional arguments verification.
related to that several minor changes:
rootCmd configuration moved to init() function. main only rootCmd.Execute() it.
This is the normal way to setup rootCmd, and it is needed, so when unit-testing the code inside init() is executed.
Some functions simplified to be just a function instead of a function that returns a function (exposeTargetArgs, bindArgs, etc).

IMO: there are some inconsistencies and a couple of things that may be improved, having the unittest it is very easy to just change the unit-test to what you want to happen and then refactor the code in order to make the test succeed (TDD!!)

i.e:
```
»·······assert.Error(t, b([]string{"one", "resource/name", "three"}), "extra argument: three")                                            
»·······assert.Error(t, b([]string{"one", "resource/name", "three", "four"}), "illegal argument: four")
```
if you call some commands with one extra argument you get an "extra argument" error, but if you call it with two, you get "illegal argument" error. This has no sense ... if I understand correctly.

moreover that, we support ":" and "/" notation but the "usage" message does not mention it.
 ```
[nbrignon@localhost skupper (nb-skupper-cli-testing-basic)]$ ./skupper bind
Error: Service name, target type and target name must all be specified (e.g. 'skupper bind <service-name> <target-type> <target-name>')
Usage:
  skupper bind <service-name> <target-type> <target-name> [flags]
```
I propose this and some other issues to be addressed in separate pr, linked to issue: #227 

