### PR TITLE
Prevent self connection 2

### DIFF
--- a/client/connector_token_create.go
+++ b/client/connector_token_create.go
@@ -112,11 +112,11 @@ func (cli *VanClient) ConnectorTokenCreate(ctx context.Context, subject string) 
 					secret := certs.GenerateSecret(subject, subject, hostPorts.Hosts, caSecret)
 					annotateConnectionToken(&secret, "inter-router", hostPorts.InterRouter.Host, hostPorts.InterRouter.Port)
 					annotateConnectionToken(&secret, "edge", hostPorts.Edge.Host, hostPorts.Edge.Port)
+                                        secret.ObjectMeta.Annotations["originating-namespace"] = cli.Namespace
 					if secret.ObjectMeta.Labels == nil {
 						secret.ObjectMeta.Labels = map[string]string{}
 					}
 					secret.ObjectMeta.Labels[types.SkupperTypeQualifier] = types.TypeToken
-                                        secret.ObjectMeta.Labels["originating-namespace"] = cli.Namespace
 					return &secret, hostPorts.LocalOnly, nil
 				} else {
 					//TODO: return the actual error

--- a/client/connector_token_create.go
+++ b/client/connector_token_create.go
@@ -116,6 +116,7 @@ func (cli *VanClient) ConnectorTokenCreate(ctx context.Context, subject string) 
 						secret.ObjectMeta.Labels = map[string]string{}
 					}
 					secret.ObjectMeta.Labels[types.SkupperTypeQualifier] = types.TypeToken
+                                        secret.ObjectMeta.Labels["originating-namespace"] = cli.Namespace
 					return &secret, hostPorts.LocalOnly, nil
 				} else {
 					//TODO: return the actual error

--- a/client/self_connect_test.go
+++ b/client/self_connect_test.go
@@ -1,0 +1,104 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/pkg/kube"
+	"gotest.tools/assert"
+)
+
+type Test struct {
+	namespaces []string
+}
+
+// var fp = fmt.Fprintf
+
+func TestSelfConnect(t *testing.T) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if !*clusterRun {
+		lightRed := "\033[1;31m"
+		resetColor := "\033[0m"
+		t.Skip(fmt.Sprintf("%sSkipping: This test only works in real clusters.%s", string(lightRed), string(resetColor)))
+		return
+	}
+
+	var public_client, private_client *VanClient
+	var err error
+
+	// Set up Public namespace ----------------------
+	public_Namespace := "public"
+	public_client, err = NewClient(public_Namespace, "", "")
+	assert.Check(t, err, public_Namespace)
+
+	_, err = kube.NewNamespace(public_Namespace, public_client.KubeClient)
+	assert.Check(t, err, public_Namespace)
+	defer kube.DeleteNamespace(public_Namespace, public_client.KubeClient)
+
+	// Set up Private namespace ----------------------
+	privateNamespace := "private"
+	private_client, err = NewClient(privateNamespace, "", "")
+	assert.Check(t, err, privateNamespace)
+
+	_, err = kube.NewNamespace(privateNamespace, private_client.KubeClient)
+	assert.Check(t, err, privateNamespace)
+	defer kube.DeleteNamespace(privateNamespace, private_client.KubeClient)
+
+	// Create Public Router: interior. ----------------------
+	err = public_client.RouterCreate(ctx, types.SiteConfig{
+		Spec: types.SiteConfigSpec{
+			SkupperName:       public_Namespace,
+			IsEdge:            false,
+			EnableController:  true,
+			EnableServiceSync: true,
+			EnableConsole:     false,
+			AuthMode:          "",
+			User:              "",
+			Password:          "",
+			ClusterLocal:      true,
+		},
+	})
+	assert.Check(t, err, "Unable to create public router")
+
+	// Create Private Router: edge. ----------------------
+	err = private_client.RouterCreate(ctx, types.SiteConfig{
+		Spec: types.SiteConfigSpec{
+			SkupperName:       privateNamespace,
+			IsEdge:            true,
+			EnableController:  true,
+			EnableServiceSync: true,
+			EnableConsole:     false,
+			AuthMode:          "",
+			User:              "",
+			Password:          "",
+			ClusterLocal:      true,
+		},
+	})
+	assert.Check(t, err, "Unable to create private router")
+
+	// Here's where we will put the connection token.
+	testPath := "./tmp/"
+	os.Mkdir(testPath, 0755)
+	defer os.RemoveAll(testPath)
+
+	// Create the connection token for Public ---------------------------------
+	connectionName := "conn1"
+	secretFileName := testPath + connectionName + ".yaml"
+	err = public_client.ConnectorTokenCreateFile(ctx, connectionName, secretFileName)
+	assert.Assert(t, err, "Unable to create token")
+
+	// And now try to use it ... to connect to Public!
+	// This attempt at self-connection should fail.
+	_, err = public_client.ConnectorCreateFromFile(ctx, secretFileName, types.ConnectorCreateOptions{
+		Name:             connectionName,
+		SkupperNamespace: public_Namespace,
+		Cost:             1,
+	})
+	assert.Assert(t, err != nil, "Self-connection should fail.")
+}

--- a/client/serviceinterface_create_test.go
+++ b/client/serviceinterface_create_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -18,8 +17,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 )
-
-var fp = fmt.Fprintf
 
 // If this function detects a difference between the expected and observed
 // results, it asserts a test failure.

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -20,7 +20,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"fmt"
+        "fmt"
 	"io/ioutil"
 	"log"
 	"math/big"
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
 )
+
 
 func publicKey(priv interface{}) interface{} {
 	switch k := priv.(type) {

--- a/pkg/kube/secrets.go
+++ b/pkg/kube/secrets.go
@@ -13,6 +13,7 @@ import (
 	"github.com/skupperproject/skupper/pkg/utils/configs"
 )
 
+
 func NewCertAuthority(ca types.CertAuthority, owner *metav1.OwnerReference, namespace string, cli kubernetes.Interface) (*corev1.Secret, error) {
 
 	existing, err := cli.CoreV1().Secrets(namespace).Get(ca.Name, metav1.GetOptions{})


### PR DESCRIPTION
Store information in the token file to disallow self-connection.
Tested from CLI as well as unit tests.

