### PR TITLE
Change console build to use yarn install so yarn.lock is honored

### DIFF
--- a/Dockerfile.service-controller
+++ b/Dockerfile.service-controller
@@ -14,7 +14,7 @@ WORKDIR /skupper-console/
 ADD https://github.com/skupperproject/gilligan/archive/master.tar.gz .
 RUN tar -zxf master.tar.gz
 WORKDIR ./gilligan-master
-RUN npm yarn && yarn build
+RUN yarn install && yarn build
 
 FROM registry.access.redhat.com/ubi8-minimal
 

--- a/Dockerfile.service-controller
+++ b/Dockerfile.service-controller
@@ -14,7 +14,7 @@ WORKDIR /skupper-console/
 ADD https://github.com/skupperproject/gilligan/archive/master.tar.gz .
 RUN tar -zxf master.tar.gz
 WORKDIR ./gilligan-master
-RUN npm install && yarn build
+RUN npm yarn && yarn build
 
 FROM registry.access.redhat.com/ubi8-minimal
 


### PR DESCRIPTION
The current console install uses 'npm install' to crate the node_modules directory. This ignores the yarn.lock file that is present and retrieves the latest version of all dependencies. This is not what we want. We want to honour the yarn.lock file to ensure the build is reproducible. 

This PR changes the 'npm install' into 'yarn install'. Yarn will then use the yarn.lock file to get the versions of the dependencies that have been tested.