### PR TITLE
Skupper cli testing unexpose

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -730,8 +730,7 @@ func init() {
 }
 
 func main() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+	if rootCmd.Execute() != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -30,6 +30,14 @@ type ExposeOptions struct {
 	Headless   bool
 }
 
+type Options struct {
+	//all subCommands options will be moved to this struct when refactor is
+	//complete.
+	unexposeAddress string
+}
+
+var options Options
+
 func expose(cli *client.VanClient, ctx context.Context, targetType string, targetName string, options ExposeOptions) error {
 	serviceName := options.Address
 	if serviceName == "" {
@@ -150,16 +158,50 @@ func check(err error) bool {
 	}
 }
 
-func NewClient(namespace string, context string, kubeConfigPath string) *client.VanClient {
+//this function remains since os.Exit(1), is still used, once the all commands
+//are migrated, this function is not needed anymore.
+func NewClient(namespace string, context string, kubeConfigPath string) (*client.VanClient, error) {
 	cli, err := client.NewClient(namespace, context, kubeConfigPath)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
-	return cli
+	return cli, nil
 }
 
 var rootCmd *cobra.Command
+
+func silenceCobra() {
+	rootCmd.SilenceErrors = true
+	rootCmd.SilenceUsage = true
+}
+
+type vanClientInterface interface {
+	//all required methods will be added here while unit-testing all
+	//subcommands (for now, for testing unexpose we only need this one)
+	ServiceInterfaceUnbind(ctx context.Context, targetType string, targetName string, address string, deleteIfNoTargets bool) error
+}
+
+func unexposeRun(cmd *cobra.Command, args []string, options Options, cli vanClientInterface) error {
+	targetType := args[0]
+	var targetName string
+	if len(args) == 2 {
+		targetName = args[1]
+	} else {
+		parts := strings.Split(args[0], "/")
+		targetType = parts[0]
+		targetName = parts[1]
+	}
+	err := cli.ServiceInterfaceUnbind(context.Background(), targetType, targetName, options.unexposeAddress, true)
+	if err != nil {
+		return fmt.Errorf("Error, unable to skupper service: %s", err.Error())
+	}
+
+	fmt.Printf("%s %s unexposed\n", targetType, targetName)
+	return nil
+}
+
+type clientCommandFunc func(cmd *cobra.Command, args []string, options Options, cli vanClientInterface) error
 
 func init() {
 	routev1.AddToScheme(scheme.Scheme)
@@ -168,6 +210,18 @@ func init() {
 	var namespace string
 	var kubeconfig string
 
+	ClientCommand := func(run clientCommandFunc) func(cmd *cobra.Command, args []string) error {
+		return func(cmd *cobra.Command, args []string) error {
+			silenceCobra() //if needed this may be optional
+			cli, err := NewClient(namespace, kubeContext, kubeconfig)
+			if err != nil {
+				return err
+			}
+			err = run(cmd, args, options, cli)
+			return nil
+		}
+	}
+
 	var routerCreateOpts types.SiteConfigSpec
 	var cmdInit = &cobra.Command{
 		Use:   "init",
@@ -175,7 +229,7 @@ func init() {
 		Long:  `init will setup a router and other supporting objects to provide a functional skupper installation that can then be connected to other skupper installations`,
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+			cli, _ := NewClient(namespace, kubeContext, kubeconfig)
 			//TODO: should cli allow init to diff ns?
 			routerCreateOpts.SkupperNamespace = cli.Namespace
 			siteConfig, err := cli.SiteConfigInspect(context.Background(), nil)
@@ -210,7 +264,7 @@ func init() {
 		Long:  `delete will delete any skupper related objects from the namespace`,
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+			cli, _ := NewClient(namespace, kubeContext, kubeconfig)
 			err := cli.SiteConfigRemove(context.Background())
 			if err != nil {
 				err = cli.RouterRemove(context.Background())
@@ -230,7 +284,7 @@ func init() {
 		Short: "Create a connection token.  The 'connect' command uses the token to establish a connection from a remote Skupper site.",
 		Args:  requiredArg("output-file"),
 		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+			cli, _ := NewClient(namespace, kubeContext, kubeconfig)
 			err := cli.ConnectorTokenCreateFile(context.Background(), clientIdentity, args[0])
 			if err != nil {
 				fmt.Println("Failed to create connection token: ", err.Error())
@@ -246,7 +300,7 @@ func init() {
 		Short: "Connect this skupper installation to that which issued the specified connectionToken",
 		Args:  requiredArg("connection-token"),
 		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+			cli, _ := NewClient(namespace, kubeContext, kubeconfig)
 			siteConfig, err := cli.SiteConfigInspect(context.Background(), nil)
 			if err != nil {
 				fmt.Println("Error, unable to retrieve site config: ", err.Error())
@@ -301,7 +355,7 @@ func init() {
 		Short: "Remove specified connection",
 		Args:  requiredArg("connection name"),
 		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+			cli, _ := NewClient(namespace, kubeContext, kubeconfig)
 			connectorRemoveOpts.Name = args[0]
 			connectorRemoveOpts.SkupperNamespace = cli.Namespace
 			connectorRemoveOpts.ForceCurrent = false
@@ -320,7 +374,7 @@ func init() {
 		Short: "List configured outgoing connections",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+			cli, _ := NewClient(namespace, kubeContext, kubeconfig)
 			connectors, err := cli.ConnectorList(context.Background())
 			if err == nil {
 				if len(connectors) == 0 {
@@ -348,7 +402,7 @@ func init() {
 		Short: "Check whether a connection to another Skupper site is active",
 		Args:  requiredArg("connection name"),
 		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+			cli, _ := NewClient(namespace, kubeContext, kubeconfig)
 			var connectors []*types.ConnectorInspectResponse
 			connected := 0
 
@@ -405,7 +459,7 @@ func init() {
 		Short: "Report the status of the current Skupper site",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+			cli, _ := NewClient(namespace, kubeContext, kubeconfig)
 			vir, err := cli.RouterInspect(context.Background())
 			if err == nil {
 				var modedesc string = " in interior mode"
@@ -466,7 +520,7 @@ func init() {
 		Short: "Expose a set of pods through a Skupper address",
 		Args:  exposeTargetArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+			cli, _ := NewClient(namespace, kubeContext, kubeconfig)
 
 			targetType := args[0]
 			var targetName string
@@ -506,40 +560,20 @@ func init() {
 	cmdExpose.Flags().IntVar(&(exposeOpts.TargetPort), "target-port", 0, "The port to target on pods")
 	cmdExpose.Flags().BoolVar(&(exposeOpts.Headless), "headless", false, "Expose through a headless service (valid only for a statefulset target)")
 
-	var unexposeAddress string
 	var cmdUnexpose = &cobra.Command{
 		Use:   "unexpose [deployment <name>|pods <selector>|statefulset <statefulsetname>|service <name>]",
 		Short: "Unexpose a set of pods previously exposed through a Skupper address",
 		Args:  exposeTargetArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
-			targetType := args[0]
-			var targetName string
-			if len(args) == 2 {
-				targetName = args[1]
-			} else {
-				parts := strings.Split(args[0], "/")
-				targetType = parts[0]
-				targetName = parts[1]
-			}
-			err := cli.ServiceInterfaceUnbind(context.Background(), targetType, targetName, unexposeAddress, true)
-			if err == nil {
-				fmt.Printf("%s %s unexposed\n", targetType, targetName)
-				os.Exit(1)
-			} else {
-				fmt.Println("Error, unable to skupper service: ", err.Error())
-				os.Exit(1)
-			}
-		},
+		RunE:  ClientCommand(unexposeRun),
 	}
-	cmdUnexpose.Flags().StringVar(&unexposeAddress, "address", "", "Skupper address the target was exposed as")
+	cmdUnexpose.Flags().StringVar(&options.unexposeAddress, "address", "", "Skupper address the target was exposed as")
 
 	var cmdListExposed = &cobra.Command{
 		Use:   "list-exposed",
 		Short: "List services exposed over the Skupper network",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+			cli, _ := NewClient(namespace, kubeContext, kubeconfig)
 			vsis, err := cli.ServiceInterfaceList(context.Background())
 			if err == nil {
 				if len(vsis) == 0 {
@@ -604,7 +638,7 @@ func init() {
 				os.Exit(1)
 			} else {
 				serviceToCreate.Port = servicePort
-				cli := NewClient(namespace, kubeContext, kubeconfig)
+				cli, _ := NewClient(namespace, kubeContext, kubeconfig)
 				err = cli.ServiceInterfaceCreate(context.Background(), &serviceToCreate)
 				if err != nil {
 					fmt.Println(err.Error())
@@ -623,7 +657,7 @@ func init() {
 		Short: "Delete a skupper service",
 		Args:  requiredArg("service-name"),
 		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+			cli, _ := NewClient(namespace, kubeContext, kubeconfig)
 			err := cli.ServiceInterfaceRemove(context.Background(), args[0])
 			if err != nil {
 				fmt.Println(err.Error())
@@ -655,7 +689,7 @@ func init() {
 					targetType = args[1]
 					targetName = args[2]
 				}
-				cli := NewClient(namespace, kubeContext, kubeconfig)
+				cli, _ := NewClient(namespace, kubeContext, kubeconfig)
 				service, err := cli.ServiceInterfaceInspect(context.Background(), args[0])
 				if err != nil {
 					fmt.Println(err.Error())
@@ -691,7 +725,7 @@ func init() {
 				targetType = args[1]
 				targetName = args[2]
 			}
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+			cli, _ := NewClient(namespace, kubeContext, kubeconfig)
 			err := cli.ServiceInterfaceUnbind(context.Background(), targetType, targetName, args[0], false)
 			if err != nil {
 				fmt.Println(err.Error())
@@ -706,7 +740,7 @@ func init() {
 		Short: "Report the version of the Skupper CLI and services",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+			cli, _ := NewClient(namespace, kubeContext, kubeconfig)
 			vir, err := cli.RouterInspect(context.Background())
 			fmt.Printf("%-30s %s\n", "client version", version)
 			if err == nil {

--- a/cmd/skupper/skupper_test.go
+++ b/cmd/skupper/skupper_test.go
@@ -179,3 +179,22 @@ func Test_cmdUnexpose(t *testing.T) {
 	testError("depl", "Name", "theService:8080", "some error")
 	testError("depl/Name", "", "theService:8080", "other error")
 }
+
+func Test_cmdUnexposeParseArgs(t *testing.T) {
+	cmd_args := []string{"unexpose", "deployment/name", "--address", "theAddress"}
+	expected_subcmd_args := cmd_args[1:]
+	command, subcommand_args, err := rootCmd.Find(cmd_args)
+	assert.Assert(t, err)
+	assert.Assert(t, cmp.Equal(expected_subcmd_args, subcommand_args))
+
+	assert.Assert(t, command.ParseFlags([]string{}))
+	assert.Equal(t, options.unexposeAddress, "")
+
+	assert.Assert(t, command.ParseFlags(expected_subcmd_args))
+	assert.Equal(t, options.unexposeAddress, "theAddress")
+
+	//Probably this is excessive testing, as we are testing the cobra library
+	//itself, but, it is free!
+	assert.Error(t, command.ParseFlags([]string{"--address"}),
+		"flag needs an argument: --address")
+}

--- a/cmd/skupper/skupper_test.go
+++ b/cmd/skupper/skupper_test.go
@@ -1,10 +1,20 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"gotest.tools/assert"
 )
+
+func TestMain(m *testing.M) {
+	silenceCobra()
+	os.Exit(m.Run())
+}
 
 func Test_requiredArg(t *testing.T) {
 	r := func(args []string) error {
@@ -89,4 +99,83 @@ func Test_exposeTargetArgs(t *testing.T) {
 	for _, target := range validExposeTargets {
 		assert.Assert(t, e([]string{target, "name"}))
 	}
+}
+
+type serviceInterfaceUnbindCallArgs struct {
+	targetType, targetName, address string
+	deleteIfNoTargets               bool
+}
+
+type vanClientMock struct {
+	serviceInterfaceUnbindCalledWith   []serviceInterfaceUnbindCallArgs
+	serviceInterfaceUnbindReturnsError string
+}
+
+func (v *vanClientMock) ServiceInterfaceUnbind(ctx context.Context, targetType string, targetName string, address string, deleteIfNoTargets bool) error {
+	var calledWith = serviceInterfaceUnbindCallArgs{
+		targetType:        targetType,
+		targetName:        targetName,
+		address:           address,
+		deleteIfNoTargets: deleteIfNoTargets,
+	}
+	v.serviceInterfaceUnbindCalledWith = append(v.serviceInterfaceUnbindCalledWith, calledWith)
+
+	if v.serviceInterfaceUnbindReturnsError != "" {
+		return fmt.Errorf("%s", v.serviceInterfaceUnbindReturnsError)
+	}
+
+	return nil
+}
+
+func Test_cmdUnexpose(t *testing.T) {
+	test := func(targetType, targetName, address string, injectedError string) {
+		options := Options{
+			unexposeAddress: address,
+		}
+		cli := vanClientMock{}
+		cli.serviceInterfaceUnbindReturnsError = injectedError
+
+		args := []string{targetType}
+
+		//supporting "targetType TargetName" and "targetType/targetName" notations
+		if targetName != "" {
+			args = append(args, targetName)
+		} else {
+			parts := strings.Split(targetType, "/")
+			targetType = parts[0]
+			targetName = parts[1]
+		}
+
+		err := unexposeRun(nil, args, options, &cli)
+
+		if injectedError != "" {
+			assert.Error(t, err, "Error, unable to skupper service: "+injectedError)
+		} else {
+			assert.Assert(t, err)
+		}
+
+		assert.Equal(t, len(cli.serviceInterfaceUnbindCalledWith), 1)
+
+		expected := serviceInterfaceUnbindCallArgs{
+			targetType:        targetType,
+			targetName:        targetName,
+			address:           address,
+			deleteIfNoTargets: true}
+
+		assert.Assert(t, cmp.Equal(cli.serviceInterfaceUnbindCalledWith[0], expected, cmp.AllowUnexported(serviceInterfaceUnbindCallArgs{})))
+	}
+
+	testSuccess := func(targetType, targetName, address string) {
+		test(targetType, targetName, address, "")
+	}
+
+	testError := func(targetType, targetName, address string, errorString string) {
+		test(targetType, targetName, address, errorString)
+	}
+
+	testSuccess("depl", "Name", "theService:8080")
+	testSuccess("depl/Name", "", "theService:8080")
+
+	testError("depl", "Name", "theService:8080", "some error")
+	testError("depl/Name", "", "theService:8080", "other error")
 }


### PR DESCRIPTION
Just picking any command to do the first POC,  I am testing here the "unexpose" command.
For each command, we can test the "flags" parsing, and also the "run".

Using RunE: allows to centralize the "exit" point.

Choosing weather you want to print the "usage" message on error (or not) is easy now just calling "slienceCobra".

A Cli interface was created, so we can create our mock cli, with simple implementations of the methods that the run command should use. So for now the mocked interface only has the "ServiceInterfaceUnbind" method.

For the same reason and for centralizing options. the global Options type is created, when all commands are migrated, this "Options" struct must contain all options.

Probably some details will show up when migrating other options but I think with this pattern we should be able to test all comands.

part of: #185 




