### PR TITLE
Use defer os.RemoveAll right after testPath creation.

### DIFF
--- a/client/connector_create_test.go
+++ b/client/connector_create_test.go
@@ -94,6 +94,7 @@ func TestConnectorCreateInterior(t *testing.T) {
 
 	testPath := "./tmp/"
 	os.Mkdir(testPath, 0755)
+	defer os.RemoveAll(testPath)
 
 	var namespace string = "van-connector-create-interior"
 
@@ -170,5 +171,4 @@ func TestConnectorCreateInterior(t *testing.T) {
 		}
 
 	}
-	os.RemoveAll(testPath)
 }

--- a/client/connector_inspect_test.go
+++ b/client/connector_inspect_test.go
@@ -92,6 +92,7 @@ func TestConnectorInspectDefaults(t *testing.T) {
 
 	testPath := "./tmp/"
 	os.Mkdir(testPath, 0755)
+	defer os.RemoveAll(testPath)
 
 	err = cli.RouterCreate(ctx, types.SiteConfig{
 		Spec: types.SiteConfigSpec{
@@ -124,7 +125,4 @@ func TestConnectorInspectDefaults(t *testing.T) {
 		_, err := cli.ConnectorInspect(ctx, c.connName)
 		assert.Check(t, err, "Unabled to inspect connector for "+c.connName)
 	}
-
-	os.RemoveAll(testPath)
-
 }

--- a/client/connector_list_test.go
+++ b/client/connector_list_test.go
@@ -34,6 +34,7 @@ func TestConnectorListInterior(t *testing.T) {
 
 	testPath := "./tmp/"
 	os.Mkdir(testPath, 0755)
+	defer os.RemoveAll(testPath)
 
 	err = cli.RouterCreate(ctx, types.SiteConfig{
 		Spec: types.SiteConfigSpec{
@@ -75,6 +76,4 @@ func TestConnectorListInterior(t *testing.T) {
 	if diff := cmp.Diff(connNames, actualNames, trans); diff != "" {
 		t.Errorf("TestConnectorListInterior connectors mismatch (-want +got):\n%s", diff)
 	}
-	os.RemoveAll(testPath)
-
 }

--- a/client/connector_remove_test.go
+++ b/client/connector_remove_test.go
@@ -58,6 +58,7 @@ func TestConnectorRemove(t *testing.T) {
 
 	testPath := "./tmp/"
 	os.Mkdir(testPath, 0755)
+	defer os.RemoveAll(testPath)
 
 	for _, c := range testcases {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -144,7 +145,4 @@ func TestConnectorRemove(t *testing.T) {
 		_, err = cli.ConnectorInspect(ctx, c.connName)
 		assert.Error(t, err, `secrets "`+c.connName+`" not found`, "Expect error when connector is removed")
 	}
-
-	// cleanup
-	os.RemoveAll(testPath)
 }


### PR DESCRIPTION
In all tests, we should probably use a "defer os.RemoveAll" call immediately after creation of testPath, in case the test is interrupted or fails, so it won't leave testPath hanging around to possibly mess up later tests.
