### PR TITLE
Deduplicating error message: when cobra returns an error, it has already printed it (along with the "usage" message)

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -730,8 +730,7 @@ func init() {
 }
 
 func main() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+	if rootCmd.Execute() != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/13121406/92252900-4271f300-eea5-11ea-8606-132e98947f58.png)
now:
![image](https://user-images.githubusercontent.com/13121406/92253363-c926d000-eea5-11ea-8803-5c80e60c070f.png)

