### PR TITLE
cli: cmdExpose returns error if SeriviceInterfaceInspect returns error.

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -40,6 +40,10 @@ func expose(cli *client.VanClient, ctx context.Context, targetType string, targe
 		}
 	}
 	service, err := cli.ServiceInterfaceInspect(ctx, serviceName)
+	if err != nil {
+		return err
+	}
+
 	if service == nil {
 		if options.Headless {
 			if targetType != "statefulset" {


### PR DESCRIPTION
this bug was detected when developing/executing #239  since that is in review probably for some more days (or will be refactored), pushing the bugfix isolated.