### PR TITLE
Using cobra helper for positional single arg.

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -89,18 +89,6 @@ func expose(cli types.VanClientInterface, ctx context.Context, targetType string
 	return cli.ServiceInterfaceBind(ctx, service, targetType, targetName, options.Protocol, options.TargetPort)
 }
 
-func requiredArg(name string) func(*cobra.Command, []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return fmt.Errorf("%s must be specified", name)
-		}
-		if len(args) > 1 {
-			return fmt.Errorf("illegal argument: %s", args[1])
-		}
-		return nil
-	}
-}
-
 func stringSliceContains(s []string, e string) bool {
 	for _, a := range s {
 		if a == e {
@@ -258,7 +246,7 @@ func NewCmdConnectionToken(newClient cobraFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "connection-token <output-file>",
 		Short:  "Create a connection token.  The 'connect' command uses the token to establish a connection from a remote Skupper site.",
-		Args:   requiredArg("output-file"),
+		Args:   cobra.ExactArgs(1),
 		PreRun: newClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			silenceCobra(cmd)
@@ -280,7 +268,7 @@ func NewCmdConnect(newClient cobraFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "connect <connection-token-file>",
 		Short:  "Connect this skupper installation to that which issued the specified connectionToken",
-		Args:   requiredArg("connection-token"),
+		Args:   cobra.ExactArgs(1),
 		PreRun: newClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			silenceCobra(cmd)
@@ -340,7 +328,7 @@ func NewCmdDisconnect(newClient cobraFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "disconnect <name>",
 		Short:  "Remove specified connection",
-		Args:   requiredArg("connection name"),
+		Args:   cobra.ExactArgs(1),
 		PreRun: newClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			silenceCobra(cmd)
@@ -396,7 +384,7 @@ func NewCmdCheckConnection(newClient cobraFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "check-connection all|<connection-name>",
 		Short:  "Check whether a connection to another Skupper site is active",
-		Args:   requiredArg("connection name"),
+		Args:   cobra.ExactArgs(1),
 		PreRun: newClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			silenceCobra(cmd)
@@ -690,7 +678,7 @@ func NewCmdDeleteService(newClient cobraFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "delete <name>",
 		Short:  "Delete a skupper service",
-		Args:   requiredArg("service-name"),
+		Args:   cobra.ExactArgs(1),
 		PreRun: newClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			silenceCobra(cmd)
@@ -798,7 +786,7 @@ func NewCmdDebugDump(newClient cobraFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "dump <filename>",
 		Short:  "Collect and save skupper logs, config, etc.",
-		Args:   requiredArg("save file"),
+		Args:   cobra.ExactArgs(1),
 		PreRun: newClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			silenceCobra(cmd)

--- a/cmd/skupper/skupper_test.go
+++ b/cmd/skupper/skupper_test.go
@@ -8,18 +8,6 @@ import (
 	"gotest.tools/assert"
 )
 
-func Test_requiredArg(t *testing.T) {
-	r := func(args []string) error {
-		return requiredArg("testArg")(nil, args)
-	}
-
-	assert.Error(t, r([]string{}), "testArg must be specified")
-	assert.Error(t, r([]string{"too", "many"}), "illegal argument: many")
-	assert.Error(t, r([]string{"too", "many", "more"}), "illegal argument: many")
-
-	assert.Assert(t, r([]string{"OneArgument"}))
-}
-
 func Test_parseTargetTypeAndName(t *testing.T) {
 	targetType, targetName := parseTargetTypeAndName([]string{"type", "name"})
 	assert.Equal(t, targetType, "type")


### PR DESCRIPTION
Specific information about command "usage" is provided by the usage message itself. that is printed right below the positional argument error:

```

$ ./skupper connection-token
Error: accepts 1 arg(s), received 0
Usage:
  skupper connection-token <output-file> [flags]

```

TODO:
evaluate the other cases bind/unbind expose/unexpose serviceCreate... etc, the fact that we support ":" and "/" notations add a little bit of complexity to reusing cobra helpers... probably take a look to how kubectl handles that is a good idea.

related to #227 

