### PR TITLE
modifying cmd init msg

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -172,8 +172,9 @@ func init() {
 	var cmdInit = &cobra.Command{
 		Use:   "init",
 		Short: "Initialise skupper installation",
-		Long:  `init will setup a router and other supporting objects to provide a functional skupper installation that can then be connected to other skupper installations`,
-		Args:  cobra.NoArgs,
+		Long: `init will setup a router and other supporting objects to provide a functional skupper
+installation that can then be connected to other skupper installations`,
+		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			cli := NewClient(namespace, kubeContext, kubeconfig)
 			//TODO: should cli allow init to diff ns?

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -172,7 +172,7 @@ func init() {
 	var cmdInit = &cobra.Command{
 		Use:   "init",
 		Short: "Initialise skupper installation",
-		Long: `init will setup a router and other supporting objects to provide a functional skupper
+		Long: `Setup a router and other supporting objects to provide a functional skupper
 installation that can then be connected to other skupper installations`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Cosmetic:
```

$ ./skupper init --help | head -n 2
Setup a router and other supporting objects to provide a functional skupper
installation that can then be connected to other skupper installations
```
Modified with the idea to match kubectl, i.e:
```

$ kubectl annotate --help | head -n 2
Update the annotations on one or more resources
```