### PR TITLE
Enabling "skupper <TAB> <TAB>"

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -743,10 +743,27 @@ func init() {
 	}
 	cmdDebug.AddCommand(cmdDebugDump)
 
+	completionLong := `
+Output shell completion code for bash.
+The shell code must be evaluated to provide interactive
+completion of skupper commands.  This can be done by sourcing it from
+the .bash_profile. i.e.: $ source <(skupper completion)
+`
+	var cmdCompletion = &cobra.Command{
+		Use:   "completion",
+		Short: "Output shell completion code for bash",
+		Long:  completionLong,
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			rootCmd.GenBashCompletion(os.Stdout)
+
+		},
+	}
+
 	rootCmd = &cobra.Command{Use: "skupper"}
 	rootCmd.Version = version
 	rootCmd.AddCommand(cmdInit, cmdDelete, cmdConnectionToken, cmdConnect, cmdDisconnect, cmdCheckConnection, cmdStatus, cmdListConnectors, cmdExpose, cmdUnexpose, cmdListExposed,
-		cmdService, cmdBind, cmdUnbind, cmdVersion, cmdDebug)
+		cmdService, cmdBind, cmdUnbind, cmdVersion, cmdDebug, cmdCompletion)
 	rootCmd.PersistentFlags().StringVarP(&kubeconfig, "kubeconfig", "", "", "Path to the kubeconfig file to use")
 	rootCmd.PersistentFlags().StringVarP(&kubeContext, "context", "c", "", "The kubeconfig context to use")
 	rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "The Kubernetes namespace to use")


### PR DESCRIPTION
Example!:
```
[nbrignon@localhost skupper (nb-autocompletion)]$ skupper 
bind              completion        connection-token  disconnect        init              list-exposed      status            unexpose          
check-connection  connect           delete            expose            list-connectors   service           unbind            version
```
```
$ skupper connect --
--connection-name   --connection-name=  --context           --context=          --cost              --cost=             --kubeconfig        --kubeconfig=       --namespace         --namespace=
```

Just some notes:
- What I am doing here is exactly the same the kubectl command does, "but" without zsh support. For supporting zsh they have harcoded the bash completion script. Since cobra does not support zsh.
- as the help message says... (and as it is for enabling bash completion for any command) you need to "source" the bash completion script. 
```

[nbrignon@localhost skupper (nb-autocomplete)]$ ./skupper completion --help

Output shell completion code for bash.
The shell code must be evaluated to provide interactive
completion of skupper commands.  This can be done by sourcing it from
the .bash_profile. i.e.: $ source <(skupper completion
...
```

If you are executing skupper doing "./skupper" bash completion will not work for that, since it is only enabled for "skupper". AFAIK: For solving this you can do 2 things:
1) add $PWD to $PATH: "$ PATH=${PWD}:${PATH}" and start using "skupper" instead of "./skupper" or (more hackish) 
2) add "./skupper" also to the completion rules with: "$ complete -F __start_skupper ./skupper"

