### PR TITLE
CI: using "--parallel 1" (ci vm has only 1 core anyway), and we see the live output during test execution.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,8 @@ commands:
       - run:
           name: Run Integration Tests
           no_output_timeout: 30m
-          command: go test -tags=integration -timeout=30m -v ./test/integration/...
+          command: |
+            go test -tags=integration -v -p 1 ./test/integration/...
       - run:
           name: Run client tests in real cluster
           command: go test -v -count=1 ./client -use-cluster


### PR DESCRIPTION
By default "go test" when executed for multiple packages, paralellizes
each package test execution, that is why it only prints the test output
when package test execution has finished.
Otherwise it would print interleaved messages.
Since the CI vm has only 1 core, test execution is not paralellized. But
it prints no output, as it would be parallelized.