### PR TITLE
Add client interface definition

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -1,5 +1,11 @@
 package types
 
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
 type ConnectorCreateOptions struct {
 	SkupperNamespace string
 	Name             string
@@ -60,4 +66,31 @@ type RouterInspectResponse struct {
 	ControllerVersion string
 	ExposedServices   int
 	ConsoleUrl        string
+}
+
+type VanClientInterface interface {
+	RouterCreate(ctx context.Context, options SiteConfig) error
+	RouterInspect(ctx context.Context) (*RouterInspectResponse, error)
+	RouterRemove(ctx context.Context) error
+	ConnectorCreateFromFile(ctx context.Context, secretFile string, options ConnectorCreateOptions) (*corev1.Secret, error)
+	ConnectorCreateSecretFromFile(ctx context.Context, secretFile string, options ConnectorCreateOptions) (*corev1.Secret, error)
+	ConnectorCreate(ctx context.Context, secret *corev1.Secret, options ConnectorCreateOptions) error
+	ConnectorInspect(ctx context.Context, name string) (*ConnectorInspectResponse, error)
+	ConnectorList(ctx context.Context) ([]*Connector, error)
+	ConnectorRemove(ctx context.Context, options ConnectorRemoveOptions) error
+	ConnectorTokenCreate(ctx context.Context, subject string, namespace string) (*corev1.Secret, bool, error)
+	ConnectorTokenCreateFile(ctx context.Context, subject string, secretFile string) error
+	ServiceInterfaceCreate(ctx context.Context, service *ServiceInterface) error
+	ServiceInterfaceInspect(ctx context.Context, address string) (*ServiceInterface, error)
+	ServiceInterfaceList(ctx context.Context) ([]*ServiceInterface, error)
+	ServiceInterfaceRemove(ctx context.Context, address string) error
+	ServiceInterfaceUpdate(ctx context.Context, service *ServiceInterface) error
+	ServiceInterfaceBind(ctx context.Context, service *ServiceInterface, targetType string, targetName string, protocol string, targetPort int) error
+	GetHeadlessServiceConfiguration(targetName string, protocol string, address string, port int) (*ServiceInterface, error)
+	ServiceInterfaceUnbind(ctx context.Context, targetType string, targetName string, address string, deleteIfNoTargets bool) error
+	SiteConfigCreate(ctx context.Context, spec SiteConfigSpec) (*SiteConfig, error)
+	SiteConfigInspect(ctx context.Context, input *corev1.ConfigMap) (*SiteConfig, error)
+	SiteConfigRemove(ctx context.Context) error
+	SkupperDump(ctx context.Context, tarName string, version string, kubeConfigPath string, kubeConfigContext string) error
+	GetNamespace() string
 }

--- a/client/client.go
+++ b/client/client.go
@@ -20,6 +20,10 @@ type VanClient struct {
 	RestConfig  *restclient.Config
 }
 
+func (cli *VanClient) GetNamespace() string {
+	return cli.Namespace
+}
+
 func NewClient(namespace string, context string, kubeConfigPath string) (*VanClient, error) {
 	c := &VanClient{}
 

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -30,7 +30,7 @@ type ExposeOptions struct {
 	Headless   bool
 }
 
-func expose(cli *client.VanClient, ctx context.Context, targetType string, targetName string, options ExposeOptions) error {
+func expose(cli types.VanClientInterface, ctx context.Context, targetType string, targetName string, options ExposeOptions) error {
 	serviceName := options.Address
 	if serviceName == "" {
 		if targetType == "service" {
@@ -163,26 +163,19 @@ func NewClient(namespace string, context string, kubeConfigPath string) *client.
 	return cli
 }
 
-var rootCmd *cobra.Command
+var routerCreateOpts types.SiteConfigSpec
 
-func init() {
-	routev1.AddToScheme(scheme.Scheme)
-
-	var kubeContext string
-	var namespace string
-	var kubeconfig string
-
-	var routerCreateOpts types.SiteConfigSpec
-	var cmdInit = &cobra.Command{
+func NewCmdInit(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialise skupper installation",
 		Long: `Setup a router and other supporting objects to provide a functional skupper
 installation that can then be connected to other skupper installations`,
 		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+		RunE: func(cmd *cobra.Command, args []string) error {
 			//TODO: should cli allow init to diff ns?
-			routerCreateOpts.SkupperNamespace = cli.Namespace
+			ns := cli.GetNamespace()
+			routerCreateOpts.SkupperNamespace = ns
 			siteConfig, err := cli.SiteConfigInspect(context.Background(), nil)
 			if check(err) {
 				if siteConfig == nil {
@@ -192,76 +185,86 @@ installation that can then be connected to other skupper installations`,
 				if check(err) {
 					err = cli.RouterCreate(context.Background(), *siteConfig)
 					if check(err) {
-						fmt.Println("Skupper is now installed in namespace '" + cli.Namespace + "'.  Use 'skupper status' to get more information.")
+						fmt.Println("Skupper is now installed in namespace '" + ns + "'.  Use 'skupper status' to get more information.")
 					}
 				}
 			}
+			return nil
 		},
 	}
-	cmdInit.Flags().StringVarP(&routerCreateOpts.SkupperName, "site-name", "", "", "Provide a specific name for this skupper installation")
-	cmdInit.Flags().BoolVarP(&routerCreateOpts.IsEdge, "edge", "", false, "Configure as an edge")
-	cmdInit.Flags().BoolVarP(&routerCreateOpts.EnableController, "enable-proxy-controller", "", true, "Setup the proxy controller as well as the router")
-	cmdInit.Flags().BoolVarP(&routerCreateOpts.EnableServiceSync, "enable-service-sync", "", true, "Configure proxy controller to particiapte in service sync (not relevant if --enable-proxy-controller is false)")
-	cmdInit.Flags().BoolVarP(&routerCreateOpts.EnableRouterConsole, "enable-router-console", "", false, "Enable router console")
-	cmdInit.Flags().BoolVarP(&routerCreateOpts.EnableConsole, "enable-console", "", false, "Enable skupper console")
-	cmdInit.Flags().StringVarP(&routerCreateOpts.AuthMode, "console-auth", "", "", "Authentication mode for console(s). One of: 'openshift', 'internal', 'unsecured'")
-	cmdInit.Flags().StringVarP(&routerCreateOpts.User, "console-user", "", "", "Skupper console user. Valid only when --console-auth=internal")
-	cmdInit.Flags().StringVarP(&routerCreateOpts.Password, "console-password", "", "", "Skupper console user. Valid only when --console-auth=internal")
-	cmdInit.Flags().BoolVarP(&routerCreateOpts.ClusterLocal, "cluster-local", "", false, "Set up skupper to only accept connections from within the local cluster.")
+	cmd.Flags().StringVarP(&routerCreateOpts.SkupperName, "site-name", "", "", "Provide a specific name for this skupper installation")
+	cmd.Flags().BoolVarP(&routerCreateOpts.IsEdge, "edge", "", false, "Configure as an edge")
+	cmd.Flags().BoolVarP(&routerCreateOpts.EnableController, "enable-proxy-controller", "", true, "Setup the proxy controller as well as the router")
+	cmd.Flags().BoolVarP(&routerCreateOpts.EnableServiceSync, "enable-service-sync", "", true, "Configure proxy controller to particiapte in service sync (not relevant if --enable-proxy-controller is false)")
+	cmd.Flags().BoolVarP(&routerCreateOpts.EnableRouterConsole, "enable-router-console", "", false, "Enable router console")
+	cmd.Flags().BoolVarP(&routerCreateOpts.EnableConsole, "enable-console", "", false, "Enable skupper console")
+	cmd.Flags().StringVarP(&routerCreateOpts.AuthMode, "console-auth", "", "", "Authentication mode for console(s). One of: 'openshift', 'internal', 'unsecured'")
+	cmd.Flags().StringVarP(&routerCreateOpts.User, "console-user", "", "", "Skupper console user. Valid only when --console-auth=internal")
+	cmd.Flags().StringVarP(&routerCreateOpts.Password, "console-password", "", "", "Skupper console user. Valid only when --console-auth=internal")
+	cmd.Flags().BoolVarP(&routerCreateOpts.ClusterLocal, "cluster-local", "", false, "Set up skupper to only accept connections from within the local cluster.")
 
-	var cmdDelete = &cobra.Command{
+	return cmd
+}
+
+func NewCmdDelete(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete skupper installation",
 		Long:  `delete will delete any skupper related objects from the namespace`,
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+		RunE: func(cmd *cobra.Command, args []string) error {
 			err := cli.SiteConfigRemove(context.Background())
 			if err != nil {
 				err = cli.RouterRemove(context.Background())
 			}
 			if err != nil {
-				fmt.Println(err.Error())
-				os.Exit(1)
+				return err
 			} else {
-				fmt.Println("Skupper is now removed from '" + cli.Namespace + "'.")
+				fmt.Println("Skupper is now removed from '" + cli.GetNamespace() + "'.")
 			}
+			return nil
 		},
 	}
+	return cmd
+}
 
-	var clientIdentity string
-	var cmdConnectionToken = &cobra.Command{
+var clientIdentity string
+
+func NewCmdConnectionToken(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "connection-token <output-file>",
 		Short: "Create a connection token.  The 'connect' command uses the token to establish a connection from a remote Skupper site.",
 		Args:  requiredArg("output-file"),
-		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+		RunE: func(cmd *cobra.Command, args []string) error {
 			err := cli.ConnectorTokenCreateFile(context.Background(), clientIdentity, args[0])
 			if err != nil {
-				fmt.Println("Failed to create connection token: ", err.Error())
-				os.Exit(1)
+				return fmt.Errorf("Failed to create connection token: %w", err)
 			}
+			return nil
 		},
 	}
-	cmdConnectionToken.Flags().StringVarP(&clientIdentity, "client-identity", "i", types.DefaultVanName, "Provide a specific identity as which connecting skupper installation will be authenticated")
+	cmd.Flags().StringVarP(&clientIdentity, "client-identity", "i", types.DefaultVanName, "Provide a specific identity as which connecting skupper installation will be authenticated")
 
-	var connectorCreateOpts types.ConnectorCreateOptions
-	var cmdConnect = &cobra.Command{
+	return cmd
+}
+
+var connectorCreateOpts types.ConnectorCreateOptions
+
+func NewCmdConnect(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "connect <connection-token-file>",
 		Short: "Connect this skupper installation to that which issued the specified connectionToken",
 		Args:  requiredArg("connection-token"),
-		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+		RunE: func(cmd *cobra.Command, args []string) error {
 			siteConfig, err := cli.SiteConfigInspect(context.Background(), nil)
 			if err != nil {
-				fmt.Println("Error, unable to retrieve site config: ", err.Error())
+				fmt.Println("Unable to retrieve site config: ", err.Error())
 				os.Exit(1)
 			} else if siteConfig == nil || !siteConfig.Spec.SiteControlled {
-				connectorCreateOpts.SkupperNamespace = cli.Namespace
+				connectorCreateOpts.SkupperNamespace = cli.GetNamespace()
 				secret, err := cli.ConnectorCreateFromFile(context.Background(), args[0], connectorCreateOpts)
 				if err != nil {
-					fmt.Println("Failed to create connection: ", err.Error())
-					os.Exit(1)
+					return fmt.Errorf("Failed to create connection: %w", err)
 				} else {
 					if siteConfig.Spec.IsEdge {
 						fmt.Printf("Skupper configured to connect to %s:%s (name=%s)\n",
@@ -279,8 +282,7 @@ installation that can then be connected to other skupper installations`,
 				// create the secret, site-controller will do the rest
 				secret, err := cli.ConnectorCreateSecretFromFile(context.Background(), args[0], connectorCreateOpts)
 				if err != nil {
-					fmt.Println("Failed to create connection: ", err.Error())
-					os.Exit(1)
+					return fmt.Errorf("Failed to create connection: %w", err)
 				} else {
 					if siteConfig.Spec.IsEdge {
 						fmt.Printf("Skupper site-controller configured to connect to %s:%s (name=%s)\n",
@@ -295,37 +297,45 @@ installation that can then be connected to other skupper installations`,
 					}
 				}
 			}
+			return nil
 		},
 	}
-	cmdConnect.Flags().StringVarP(&connectorCreateOpts.Name, "connection-name", "", "", "Provide a specific name for the connection (used when removing it with disconnect)")
-	cmdConnect.Flags().Int32VarP(&connectorCreateOpts.Cost, "cost", "", 1, "Specify a cost for this connection.")
+	cmd.Flags().StringVarP(&connectorCreateOpts.Name, "connection-name", "", "", "Provide a specific name for the connection (used when removing it with disconnect)")
+	cmd.Flags().Int32VarP(&connectorCreateOpts.Cost, "cost", "", 1, "Specify a cost for this connection.")
 
-	var connectorRemoveOpts types.ConnectorRemoveOptions
-	var cmdDisconnect = &cobra.Command{
+	return cmd
+}
+
+var connectorRemoveOpts types.ConnectorRemoveOptions
+
+func NewCmdDisconnect(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "disconnect <name>",
 		Short: "Remove specified connection",
 		Args:  requiredArg("connection name"),
-		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+		RunE: func(cmd *cobra.Command, args []string) error {
 			connectorRemoveOpts.Name = args[0]
-			connectorRemoveOpts.SkupperNamespace = cli.Namespace
+			connectorRemoveOpts.SkupperNamespace = cli.GetNamespace()
 			connectorRemoveOpts.ForceCurrent = false
 			err := cli.ConnectorRemove(context.Background(), connectorRemoveOpts)
 			if err == nil {
 				fmt.Println("Connection '" + args[0] + "' has been removed")
 			} else {
-				fmt.Println("Failed to remove connection: ", err.Error())
-				os.Exit(1)
+				return fmt.Errorf("Failed to remove connection: %w", err)
 			}
+			return nil
 		},
 	}
 
-	var cmdListConnectors = &cobra.Command{
+	return cmd
+}
+
+func NewCmdListConnectors(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "list-connectors",
 		Short: "List configured outgoing connections",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+		RunE: func(cmd *cobra.Command, args []string) error {
 			connectors, err := cli.ConnectorList(context.Background())
 			if err == nil {
 				if len(connectors) == 0 {
@@ -338,22 +348,24 @@ installation that can then be connected to other skupper installations`,
 					}
 				}
 			} else if errors.IsNotFound(err) {
-				fmt.Println("Skupper is not installed in '" + cli.Namespace + "`")
-				os.Exit(1)
+				return fmt.Errorf("Skupper is not installed in '" + cli.GetNamespace() + "`")
 			} else {
-				fmt.Println("Error, unable to retrieve connections: ", err.Error())
-				os.Exit(1)
+				return fmt.Errorf("Unable to retrieve connections: %w", err)
 			}
+			return nil
 		},
 	}
+	return cmd
+}
 
-	var waitFor int
-	var cmdCheckConnection = &cobra.Command{
+var waitFor int
+
+func NewCmdCheckConnection(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "check-connection all|<connection-name>",
 		Short: "Check whether a connection to another Skupper site is active",
 		Args:  requiredArg("connection name"),
-		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var connectors []*types.ConnectorInspectResponse
 			connected := 0
 
@@ -401,27 +413,33 @@ installation that can then be connected to other skupper installations`,
 					}
 				}
 			}
+			return nil
 		},
 	}
-	cmdCheckConnection.Flags().IntVar(&waitFor, "wait", 1, "The number of seconds to wait for connections to become active")
+	cmd.Flags().IntVar(&waitFor, "wait", 1, "The number of seconds to wait for connections to become active")
 
-	var cmdStatus = &cobra.Command{
+	return cmd
+
+}
+
+func NewCmdStatus(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Report the status of the current Skupper site",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+		RunE: func(cmd *cobra.Command, args []string) error {
 			vir, err := cli.RouterInspect(context.Background())
 			if err == nil {
+				ns := cli.GetNamespace()
 				var modedesc string = " in interior mode"
 				if vir.Status.Mode == types.TransportModeEdge {
 					modedesc = " in edge mode"
 				}
 				sitename := ""
-				if vir.Status.SiteName != "" && vir.Status.SiteName != cli.Namespace {
+				if vir.Status.SiteName != "" && vir.Status.SiteName != ns {
 					sitename = fmt.Sprintf(" with site name %q", vir.Status.SiteName)
 				}
-				fmt.Printf("Skupper is enabled for namespace %q%s%s.", cli.Namespace, sitename, modedesc)
+				fmt.Printf("Skupper is enabled for namespace %q%s%s.", ns, sitename, modedesc)
 				if vir.Status.TransportReadyReplicas == 0 {
 					fmt.Printf(" Status pending...")
 				} else {
@@ -459,20 +477,22 @@ installation that can then be connected to other skupper installations`,
 					}
 				}
 			} else {
-				fmt.Println("Unable to retrieve skupper status: ", err.Error())
-				os.Exit(1)
+				return fmt.Errorf("Unable to retrieve skupper status: %w", err)
 			}
+			return nil
 		},
 	}
+	return cmd
+}
 
-	exposeOpts := ExposeOptions{}
-	var cmdExpose = &cobra.Command{
+var exposeOpts ExposeOptions
+
+func NewCmdExpose(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "expose [deployment <name>|pods <selector>|statefulset <statefulsetname>|service <name>]",
 		Short: "Expose a set of pods through a Skupper address",
 		Args:  exposeTargetArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
-
+		RunE: func(cmd *cobra.Command, args []string) error {
 			targetType := args[0]
 			var targetName string
 			if len(args) == 2 {
@@ -489,35 +509,37 @@ installation that can then be connected to other skupper installations`,
 				address := exposeOpts.Address
 				if address == "" {
 					if args[0] == "service" {
-						fmt.Printf("--address option is required for target type 'service'")
-						os.Exit(1)
+						return fmt.Errorf("--address option is required for target type 'service'")
 					} else {
 						address = targetType
 					}
 				}
 				fmt.Printf("%s %s exposed as %s\n", targetType, targetName, address)
 			} else if errors.IsNotFound(err) {
-				fmt.Println("Skupper is not installed in '" + cli.Namespace + "`")
-				os.Exit(1)
+				return fmt.Errorf("Skupper is not installed in '" + cli.GetNamespace() + "`")
 			} else {
-				fmt.Println("Error, unable to create skupper service: ", err.Error())
-				os.Exit(1)
+				return fmt.Errorf("Unable to create skupper service: %w", err)
 			}
+			return nil
 		},
 	}
-	cmdExpose.Flags().StringVar(&(exposeOpts.Protocol), "protocol", "tcp", "The protocol to proxy (tcp, http, or http2)")
-	cmdExpose.Flags().StringVar(&(exposeOpts.Address), "address", "", "The Skupper address to expose")
-	cmdExpose.Flags().IntVar(&(exposeOpts.Port), "port", 0, "The port to expose on")
-	cmdExpose.Flags().IntVar(&(exposeOpts.TargetPort), "target-port", 0, "The port to target on pods")
-	cmdExpose.Flags().BoolVar(&(exposeOpts.Headless), "headless", false, "Expose through a headless service (valid only for a statefulset target)")
+	cmd.Flags().StringVar(&(exposeOpts.Protocol), "protocol", "tcp", "The protocol to proxy (tcp, http, or http2)")
+	cmd.Flags().StringVar(&(exposeOpts.Address), "address", "", "The Skupper address to expose")
+	cmd.Flags().IntVar(&(exposeOpts.Port), "port", 0, "The port to expose on")
+	cmd.Flags().IntVar(&(exposeOpts.TargetPort), "target-port", 0, "The port to target on pods")
+	cmd.Flags().BoolVar(&(exposeOpts.Headless), "headless", false, "Expose through a headless service (valid only for a statefulset target)")
 
-	var unexposeAddress string
-	var cmdUnexpose = &cobra.Command{
+	return cmd
+}
+
+var unexposeAddress string
+
+func NewCmdUnexpose(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "unexpose [deployment <name>|pods <selector>|statefulset <statefulsetname>|service <name>]",
 		Short: "Unexpose a set of pods previously exposed through a Skupper address",
 		Args:  exposeTargetArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+		RunE: func(cmd *cobra.Command, args []string) error {
 			targetType := args[0]
 			var targetName string
 			if len(args) == 2 {
@@ -530,21 +552,23 @@ installation that can then be connected to other skupper installations`,
 			err := cli.ServiceInterfaceUnbind(context.Background(), targetType, targetName, unexposeAddress, true)
 			if err == nil {
 				fmt.Printf("%s %s unexposed\n", targetType, targetName)
-				os.Exit(1)
 			} else {
-				fmt.Println("Error, unable to skupper service: ", err.Error())
-				os.Exit(1)
+				return fmt.Errorf("Unable to unbind skupper service: %w", err)
 			}
+			return nil
 		},
 	}
-	cmdUnexpose.Flags().StringVar(&unexposeAddress, "address", "", "Skupper address the target was exposed as")
+	cmd.Flags().StringVar(&unexposeAddress, "address", "", "Skupper address the target was exposed as")
 
-	var cmdListExposed = &cobra.Command{
+	return cmd
+}
+
+func NewCmdListExposed(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "list-exposed",
 		Short: "List services exposed over the Skupper network",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+		RunE: func(cmd *cobra.Command, args []string) error {
 			vsis, err := cli.ServiceInterfaceList(context.Background())
 			if err == nil {
 				if len(vsis) == 0 {
@@ -576,23 +600,31 @@ installation that can then be connected to other skupper installations`,
 					}
 				}
 			} else {
-				fmt.Println("Could not retrieve services:", err.Error())
-				os.Exit(1)
+				return fmt.Errorf("Could not retrieve services: %w", err)
 			}
+			return nil
 		},
 	}
 
-	var cmdService = &cobra.Command{
+	return cmd
+}
+
+func NewCmdService() *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "service create <name> <port> or service delete port",
 		Short: "Manage skupper service definitions",
 	}
+	return cmd
+}
 
-	var serviceToCreate types.ServiceInterface
-	var cmdCreateService = &cobra.Command{
+var serviceToCreate types.ServiceInterface
+
+func NewCmdCreateService(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "create <name> <port>",
 		Short: "Create a skupper service",
 		Args:  createServiceArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var sPort string
 			if len(args) == 1 {
 				parts := strings.Split(args[0], ":")
@@ -604,51 +636,51 @@ installation that can then be connected to other skupper installations`,
 			}
 			servicePort, err := strconv.Atoi(sPort)
 			if err != nil {
-				fmt.Printf("%s is not a valid port.", sPort)
-				fmt.Println()
-				os.Exit(1)
+				return fmt.Errorf("%s is not a valid port", sPort)
 			} else {
 				serviceToCreate.Port = servicePort
-				cli := NewClient(namespace, kubeContext, kubeconfig)
 				err = cli.ServiceInterfaceCreate(context.Background(), &serviceToCreate)
 				if err != nil {
-					fmt.Println(err.Error())
-					os.Exit(1)
+					return fmt.Errorf("%w", err)
 				}
 			}
+			return nil
 		},
 	}
-	cmdCreateService.Flags().StringVar(&serviceToCreate.Protocol, "mapping", "tcp", "The mapping in use for this service address (currently one of tcp or http)")
-	cmdCreateService.Flags().StringVar(&serviceToCreate.Aggregate, "aggregate", "", "The aggregation strategy to use. One of 'json' or 'multipart'. If specified requests to this service will be sent to all registered implementations and the responses aggregated.")
-	cmdCreateService.Flags().BoolVar(&serviceToCreate.EventChannel, "event-channel", false, "If specified, this service will be a channel for multicast events.")
-	cmdService.AddCommand(cmdCreateService)
+	cmd.Flags().StringVar(&serviceToCreate.Protocol, "mapping", "tcp", "The mapping in use for this service address (currently one of tcp or http)")
+	cmd.Flags().StringVar(&serviceToCreate.Aggregate, "aggregate", "", "The aggregation strategy to use. One of 'json' or 'multipart'. If specified requests to this service will be sent to all registered implementations and the responses aggregated.")
+	cmd.Flags().BoolVar(&serviceToCreate.EventChannel, "event-channel", false, "If specified, this service will be a channel for multicast events.")
 
-	var cmdDeleteService = &cobra.Command{
+	return cmd
+}
+
+func NewCmdDeleteService(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "delete <name>",
 		Short: "Delete a skupper service",
 		Args:  requiredArg("service-name"),
-		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+		RunE: func(cmd *cobra.Command, args []string) error {
 			err := cli.ServiceInterfaceRemove(context.Background(), args[0])
 			if err != nil {
-				fmt.Println(err.Error())
-				os.Exit(1)
+				return fmt.Errorf("%w", err)
 			}
+			return nil
 		},
 	}
-	cmdService.AddCommand(cmdDeleteService)
+	return cmd
+}
 
-	var targetPort int
-	var protocol string
-	var cmdBind = &cobra.Command{
+var targetPort int
+var protocol string
+
+func NewCmdBind(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "bind <service-name> <target-type> <target-name>",
 		Short: "Bind a target to a service",
 		Args:  bindArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if protocol != "" && protocol != "tcp" && protocol != "http" && protocol != "http2" {
-				fmt.Printf("%s is not a valid protocol. Choose 'tcp', 'http' or 'http2'.", protocol)
-				fmt.Println()
-				os.Exit(1)
+				return fmt.Errorf("%s is not a valid protocol. Choose 'tcp', 'http' or 'http2'.", protocol)
 			} else {
 				var targetType string
 				var targetName string
@@ -660,32 +692,33 @@ installation that can then be connected to other skupper installations`,
 					targetType = args[1]
 					targetName = args[2]
 				}
-				cli := NewClient(namespace, kubeContext, kubeconfig)
 				service, err := cli.ServiceInterfaceInspect(context.Background(), args[0])
 				if err != nil {
-					fmt.Println(err.Error())
-					os.Exit(1)
+					return fmt.Errorf("%w", err)
 				} else if service == nil {
-					fmt.Printf("Service %s not found", args[0])
-					fmt.Println()
-					os.Exit(1)
+					return fmt.Errorf("Service %s not found", args[0])
 				} else {
 					err = cli.ServiceInterfaceBind(context.Background(), service, targetType, targetName, protocol, targetPort)
 					if err != nil {
-						fmt.Println(err.Error())
+						return fmt.Errorf("%w", err)
 					}
 				}
 			}
+			return nil
 		},
 	}
-	cmdBind.Flags().StringVar(&protocol, "protocol", "", "The protocol to proxy (tcp, http or http2).")
-	cmdBind.Flags().IntVar(&targetPort, "target-port", 0, "The port the target is listening on.")
+	cmd.Flags().StringVar(&protocol, "protocol", "", "The protocol to proxy (tcp, http or http2).")
+	cmd.Flags().IntVar(&targetPort, "target-port", 0, "The port the target is listening on.")
 
-	var cmdUnbind = &cobra.Command{
+	return cmd
+}
+
+func NewCmdUnbind(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "unbind <service-name> <target-type> <target-name>",
 		Short: "Unbind a target from a service",
 		Args:  bindArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var targetType string
 			var targetName string
 			if len(args) == 2 {
@@ -696,52 +729,95 @@ installation that can then be connected to other skupper installations`,
 				targetType = args[1]
 				targetName = args[2]
 			}
-			cli := NewClient(namespace, kubeContext, kubeconfig)
 			err := cli.ServiceInterfaceUnbind(context.Background(), targetType, targetName, args[0], false)
 			if err != nil {
-				fmt.Println(err.Error())
-				os.Exit(1)
+				return fmt.Errorf("%w", err)
 			}
+			return nil
 		},
 	}
+	return cmd
+}
 
+func NewCmdVersion(cli types.VanClientInterface) *cobra.Command {
 	// TODO: change to inspect
-	var cmdVersion = &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Report the version of the Skupper CLI and services",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+		RunE: func(cmd *cobra.Command, args []string) error {
 			vir, err := cli.RouterInspect(context.Background())
 			fmt.Printf("%-30s %s\n", "client version", version)
 			if err == nil {
 				fmt.Printf("%-30s %s\n", "transport version", vir.TransportVersion)
 				fmt.Printf("%-30s %s\n", "controller version", vir.ControllerVersion)
 			} else {
-				fmt.Println("Unable to retrieve skupper component versions: ", err.Error())
-				os.Exit(1)
+				return fmt.Errorf("Unable to retrieve skupper component versions: %w", err)
 			}
+			return nil
 		},
 	}
+	return cmd
+}
 
-	var cmdDebug = &cobra.Command{
+func NewCmdDebug() *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "debug dump <file> or debug action <tbd>",
 		Short: "Debug skupper installation",
 	}
+	return cmd
+}
 
-	var cmdDebugDump = &cobra.Command{
+func NewCmdDebugDump(cli types.VanClientInterface) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "dump <filename>",
 		Short: "Collect and save skupper logs, config, etc.",
 		Args:  requiredArg("save file"),
-		Run: func(cmd *cobra.Command, args []string) {
-			cli := NewClient(namespace, kubeContext, kubeconfig)
+		RunE: func(cmd *cobra.Command, args []string) error {
 			err := cli.SkupperDump(context.Background(), args[0], version, kubeconfig, kubeContext)
 			if err != nil {
-				fmt.Println("Unable to save skupper details: ", err.Error())
-				os.Exit(1)
+				return fmt.Errorf("Unable to save skupper details: %w", err)
 			}
+			return nil
 		},
 	}
+	return cmd
+}
+
+var kubeContext string
+var namespace string
+var kubeconfig string
+var rootCmd *cobra.Command
+
+func init() {
+	routev1.AddToScheme(scheme.Scheme)
+
+	cli := NewClient(namespace, kubeContext, kubeconfig)
+
+	cmdInit := NewCmdInit(cli)
+	cmdDelete := NewCmdDelete(cli)
+	cmdConnectionToken := NewCmdConnectionToken(cli)
+	cmdConnect := NewCmdConnect(cli)
+	cmdDisconnect := NewCmdDisconnect(cli)
+	cmdListConnectors := NewCmdListConnectors(cli)
+	cmdCheckConnection := NewCmdCheckConnection(cli)
+	cmdStatus := NewCmdStatus(cli)
+	cmdExpose := NewCmdExpose(cli)
+	cmdUnexpose := NewCmdUnexpose(cli)
+	cmdListExposed := NewCmdListExposed(cli)
+	cmdCreateService := NewCmdCreateService(cli)
+	cmdDeleteService := NewCmdDeleteService(cli)
+	cmdBind := NewCmdBind(cli)
+	cmdUnbind := NewCmdUnbind(cli)
+	cmdVersion := NewCmdVersion(cli)
+	cmdDebugDump := NewCmdDebugDump(cli)
+
+	// setup subcommands
+	cmdService := NewCmdService()
+	cmdService.AddCommand(cmdCreateService)
+	cmdService.AddCommand(cmdDeleteService)
+
+	cmdDebug := NewCmdDebug()
 	cmdDebug.AddCommand(cmdDebugDump)
 
 	completionLong := `
@@ -772,7 +848,10 @@ the .bash_profile. i.e.: $ source <(skupper completion)
 }
 
 func main() {
-	if rootCmd.Execute() != nil {
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -842,7 +842,7 @@ the .bash_profile. i.e.: $ source <(skupper completion)
 
 		},
 	}
-        return cmd
+	return cmd
 }
 
 type cobraFunc func(cmd *cobra.Command, args []string)
@@ -886,7 +886,7 @@ func init() {
 	cmdDebug := NewCmdDebug()
 	cmdDebug.AddCommand(cmdDebugDump)
 
-        cmdCompletion := NewCmdCompletion()
+	cmdCompletion := NewCmdCompletion()
 
 	rootCmd = &cobra.Command{Use: "skupper"}
 	rootCmd.Version = version

--- a/cmd/skupper/skupper_server_test.go
+++ b/cmd/skupper/skupper_server_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	//	"fmt"
+	//	"io/ioutil"
+	//	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	//	"gotest.tools/assert"
+)
+
+func executeCommand(cmd *cobra.Command, args ...string) (output string, err error) {
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(args)
+
+	err = cmd.ExecuteContext(context.Background())
+	return buf.String(), err
+}
+
+func checkStringContains(t *testing.T, got, expected string) {
+	if !strings.Contains(got, expected) {
+		t.Errorf("Expected to contain: \n %v\nGot:\n %v\n", expected, got)
+	}
+}
+
+func checkStringOmits(t *testing.T, got, expected string) {
+	if strings.Contains(got, expected) {
+		t.Errorf("Expected to not contain: \n %v\nGot: %v", expected, got)
+	}
+}
+func TestUnexposeCommandWithServer(t *testing.T) {
+	testcases := []struct {
+		args        []string
+		flags       []string
+		expectedOut string
+	}{
+		{
+			args:        []string{"--help"},
+			flags:       []string{},
+			expectedOut: "Unexpose a set of pods previously exposed through a Skupper address",
+		},
+		{
+			args:        []string{},
+			flags:       []string{},
+			expectedOut: "expose target and name must be specified (e.g. 'skupper expose deployment <name>'",
+		},
+		{
+			args:        []string{"deployment"},
+			flags:       []string{},
+			expectedOut: "expose target and name must be specified (e.g. 'skupper expose deployment <name>'",
+		},
+		{
+			args:        []string{"deployment", "tcp-not-deployed"},
+			flags:       []string{},
+			expectedOut: "Unable to unbind skupper service: Could not find entry for service interface tcp-not-deployed",
+		},
+		{
+			args:        []string{"deployment/tcp-not-deployed"},
+			flags:       []string{},
+			expectedOut: "Unable to unbind skupper service: Could not find entry for service interface tcp-not-deployed",
+		},
+		{
+			args:        []string{"deployent", "tcp-not-deployed"},
+			flags:       []string{},
+			expectedOut: "expose target type must be one of: [deployment, statefulset, pods, service]",
+		},
+		{
+			args:        []string{"pods", "tcp-not-deployed"},
+			flags:       []string{},
+			expectedOut: "Error: Unable to unbind skupper service: Target type for service interface not yet implemented",
+		},
+		{
+			args:        []string{"deployment", "tcp-not-deployed", "extraArg"},
+			flags:       []string{},
+			expectedOut: "Error: illegal argument: extraArg",
+		},
+		{
+			args:        []string{"deployment", "tcp-not-deployed", "extraArg", "extraExtraArg"},
+			flags:       []string{},
+			expectedOut: "Error: illegal argument: extraArg",
+		},
+	}
+
+        if !*serverRun {
+	    t.Skip("skipping test in non-server mode")
+	}
+
+	ns := "skupper"
+	cli := NewClient(ns, "", "")
+
+	for _, tc := range testcases {
+		cmd := NewCmdUnexpose(cli)
+		cmd.SilenceUsage = true
+		output, _ := executeCommand(cmd, tc.args...)
+		checkStringContains(t, output, tc.expectedOut)
+	}
+
+}

--- a/cmd/skupper/skupper_test.go
+++ b/cmd/skupper/skupper_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+        "flag"
+	"os"
 	"testing"
 
 	"gotest.tools/assert"
@@ -89,4 +91,12 @@ func Test_exposeTargetArgs(t *testing.T) {
 	for _, target := range validExposeTargets {
 		assert.Assert(t, e([]string{target, "name"}))
 	}
+}
+
+
+var serverRun = flag.Bool("use-server", false, "run tests against a configured server")
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
 }

--- a/cmd/skupper/skupper_test.go
+++ b/cmd/skupper/skupper_test.go
@@ -99,4 +99,3 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Exit(m.Run())
 }
-

--- a/cmd/skupper/skupper_test.go
+++ b/cmd/skupper/skupper_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-        "flag"
+	"flag"
 	"os"
 	"testing"
 
@@ -93,10 +93,10 @@ func Test_exposeTargetArgs(t *testing.T) {
 	}
 }
 
-
-var serverRun = flag.Bool("use-server", false, "run tests against a configured server")
+var clusterRun = flag.Bool("use-cluster", false, "run tests against a configured cluster")
 
 func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Exit(m.Run())
 }
+


### PR DESCRIPTION
This patch introduces client interface to better support cli test goals.

Also:
* Use command constructors  
* Adopt RunE to return errors
* Example unexpose cmd test against k8s mock and real cluster

