### PR TITLE
Use siteID to prevent self-connection

### DIFF
--- a/client/connector_token_create.go
+++ b/client/connector_token_create.go
@@ -110,35 +110,40 @@ func (cli *VanClient) ConnectorTokenCreate(ctx context.Context, subject string, 
 	// verify that the local deployment is interior mode
 	current, err := kube.GetDeployment(types.TransportDeploymentName, namespace, cli.KubeClient)
 	// TODO: return error message for all the paths
-	if err == nil {
-		if qdr.IsInterior(current) {
-			//TODO: creat const for ca
-			caSecret, err := cli.KubeClient.CoreV1().Secrets(namespace).Get("skupper-internal-ca", metav1.GetOptions{})
-			if err == nil {
-				//get the host and port for inter-router and edge
-				var hostPorts RouterHostPorts
-				if configureHostPorts(&hostPorts, cli, namespace) {
-					secret := certs.GenerateSecret(subject, subject, hostPorts.Hosts, caSecret)
-					annotateConnectionToken(&secret, "inter-router", hostPorts.InterRouter.Host, hostPorts.InterRouter.Port)
-					annotateConnectionToken(&secret, "edge", hostPorts.Edge.Host, hostPorts.Edge.Port)
-					if secret.ObjectMeta.Labels == nil {
-						secret.ObjectMeta.Labels = map[string]string{}
-					}
-					secret.ObjectMeta.Labels[types.SkupperTypeQualifier] = types.TypeToken
-					return &secret, hostPorts.LocalOnly, nil
-				} else {
-					//TODO: return the actual error
-					return nil, false, fmt.Errorf("Could not determine host/ports for token")
-				}
-			} else {
-				return nil, false, err
-			}
-		} else {
-			return nil, false, fmt.Errorf("Edge configuration cannot accept connections")
-		}
-	} else {
+	if err != nil {
 		return nil, false, fmt.Errorf("Could not find skupper router in %q: %s", namespace, err)
 	}
+	if !qdr.IsInterior(current) {
+		return nil, false, fmt.Errorf("Edge configuration cannot accept connections")
+	}
+	//TODO: creat const for ca
+	caSecret, err := cli.KubeClient.CoreV1().Secrets(namespace).Get("skupper-internal-ca", metav1.GetOptions{})
+	if err != nil {
+		return nil, false, err
+	}
+	//get the host and port for inter-router and edge
+	var hostPorts RouterHostPorts
+	if !configureHostPorts(&hostPorts, cli, namespace) {
+		//TODO: return the actual error
+		return nil, false, fmt.Errorf("Could not determine host/ports for token")
+	}
+	secret := certs.GenerateSecret(subject, subject, hostPorts.Hosts, caSecret)
+	annotateConnectionToken(&secret, "inter-router", hostPorts.InterRouter.Host, hostPorts.InterRouter.Port)
+	annotateConnectionToken(&secret, "edge", hostPorts.Edge.Host, hostPorts.Edge.Port)
+	if secret.ObjectMeta.Labels == nil {
+		secret.ObjectMeta.Labels = map[string]string{}
+	}
+	secret.ObjectMeta.Labels[types.SkupperTypeQualifier] = types.TypeToken
+	// Store our siteID in the token, to prevent later self-connection.
+	siteConfig, err := cli.SiteConfigInspect(ctx, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	if siteConfig != nil {
+		secret.ObjectMeta.Annotations[types.TokenGeneratedBy] = siteConfig.Reference.UID
+
+	}
+	return &secret, hostPorts.LocalOnly, nil
 }
 
 func (cli *VanClient) ConnectorTokenCreateFile(ctx context.Context, subject string, secretFile string) error {

--- a/client/self_connect_test.go
+++ b/client/self_connect_test.go
@@ -1,0 +1,91 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/pkg/kube"
+	"gotest.tools/assert"
+)
+
+type Test struct {
+	namespaces []string
+}
+
+// var fp = fmt.Fprintf
+
+func TestSelfConnect(t *testing.T) {
+
+	if !*clusterRun {
+		var red string = "\033[1;31m"
+		var resetColor string = "\033[0m"
+		t.Skip(fmt.Sprintf("%sSkipping: This test only works in real clusters.%s", string(red), string(resetColor)))
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if !*clusterRun {
+		lightRed := "\033[1;31m"
+		resetColor := "\033[0m"
+		t.Skip(fmt.Sprintf("%sSkipping: This test only works in real clusters.%s", string(lightRed), string(resetColor)))
+		return
+	}
+
+	var publicClient *VanClient
+	var err error
+
+	// Set up Public namespace ----------------------
+	publicNamespace := "public"
+	publicClient, err = NewClient(publicNamespace, "", "")
+	assert.Check(t, err, publicNamespace)
+
+	_, err = kube.NewNamespace(publicNamespace, publicClient.KubeClient)
+	assert.Check(t, err, publicNamespace)
+	defer kube.DeleteNamespace(publicNamespace, publicClient.KubeClient)
+
+	// Configure the site.
+	// It needs to be done this -- by calling SiteConfigCreate() --
+	// when using a real cluster, because that function has a side-effect
+	// of creating the config map with the K8S API.
+	routerCreateOpts := types.SiteConfigSpec{
+		SkupperName:       publicNamespace,
+		IsEdge:            false,
+		EnableController:  true,
+		EnableServiceSync: true,
+		EnableConsole:     false,
+		AuthMode:          "",
+		User:              "",
+		Password:          "",
+		ClusterLocal:      true,
+	}
+	siteConfig, err := publicClient.SiteConfigCreate(context.Background(), routerCreateOpts)
+
+	// Create Public Router: interior. ----------------------
+	err = publicClient.RouterCreate(ctx, *siteConfig)
+	assert.Check(t, err, "Unable to create public router")
+
+	// Here's where we will put the connection token.
+	testPath := "./tmp/"
+	os.Mkdir(testPath, 0755)
+	defer os.RemoveAll(testPath)
+
+	// Create the connection token for Public ---------------------------------
+	connectionName := "conn1"
+	secretFileName := testPath + connectionName + ".yaml"
+	err = publicClient.ConnectorTokenCreateFile(ctx, connectionName, secretFileName)
+	assert.Assert(t, err, "Unable to create token")
+
+	// And now try to use it ... to connect to Public!
+	// This attempt at self-connection should fail.
+	_, err = publicClient.ConnectorCreateFromFile(ctx, secretFileName, types.ConnectorCreateOptions{
+		Name:             connectionName,
+		SkupperNamespace: publicNamespace,
+		Cost:             1,
+	})
+	assert.Assert(t, err != nil, "Self-connection should fail.")
+}

--- a/client/serviceinterface_create_test.go
+++ b/client/serviceinterface_create_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -18,8 +17,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 )
-
-var fp = fmt.Fprintf
 
 // If this function detects a difference between the expected and observed
 // results, it asserts a test failure.


### PR DESCRIPTION
* Store siteID in connection token at token creation time.
  The siteID is a UID that should be globally unique.

* When asked to create a connection using a token, compare the token's
  siteID against this client's own siteID. If they are equal, we are
  being asked to make a self-connection. Refuse it.

* Add a convenience function isOwnToken to simplify code.

* cleanup: In ConnectorTokenCreate(), reduce nesting in code by
  handling error cases first.