### PR TITLE
prevent selector update for headless service

### DIFF
--- a/cmd/service-controller/controller.go
+++ b/cmd/service-controller/controller.go
@@ -316,7 +316,7 @@ func (c *Controller) checkServiceFor(desired *ServiceBindings, actual *corev1.Se
 			actual.Spec.Ports[0].TargetPort = intstr.FromInt(desired.ingressPort)
 		}
 	}
-	if !equivalentSelectors(actual.Spec.Selector, kube.GetLabelsForRouter()) {
+	if desired.headless == nil && !equivalentSelectors(actual.Spec.Selector, kube.GetLabelsForRouter()) {
 		update = true
 		actual.Spec.Selector = kube.GetLabelsForRouter()
 	}

--- a/pkg/kube/services.go
+++ b/pkg/kube/services.go
@@ -52,7 +52,7 @@ func NewServiceForAddress(address string, port int, targetPort int, owner *metav
 
 func NewHeadlessServiceForAddress(address string, port int, targetPort int, owner *metav1.OwnerReference, namespace string, kubeclient kubernetes.Interface) (*corev1.Service, error) {
 	labels := map[string]string{
-		"internal.skupper.io/service": "myservice2",
+		"internal.skupper.io/service": address,
 	}
 	service := makeServiceObjectForAddress(address, port, targetPort, labels, owner)
 	service.Spec.ClusterIP = "None"


### PR DESCRIPTION
This patch inhibits the selector update for headless service. 

Verified via example https://github.com/grs/skupper-example-cockroachdb cluster formation