### PR TITLE
Simplify clusterTestRunner.

### DIFF
--- a/test/integration/basic/basic_test.go
+++ b/test/integration/basic/basic_test.go
@@ -4,16 +4,15 @@ package basic
 
 import (
 	"context"
-	"github.com/skupperproject/skupper/test/utils/base"
+	"os"
 	"testing"
-)
 
-var (
-	testRunner BasicTestRunner
+	"github.com/skupperproject/skupper/test/utils/base"
 )
 
 func TestMain(m *testing.M) {
-	testRunner.Initialize(m)
+	base.ParseFlags()
+	os.Exit(m.Run())
 }
 
 func TestBasic(t *testing.T) {
@@ -22,7 +21,8 @@ func TestBasic(t *testing.T) {
 		PublicClusters:  1,
 		PrivateClusters: 1,
 	}
-	testRunner.Build(t, needs, nil)
+	testRunner := &BasicTestRunner{}
+	testRunner.BuildOrSkip(t, needs, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	base.HandleInterruptSignal(testRunner.T, func(t *testing.T) {
 		testRunner.TearDown(ctx)

--- a/test/integration/http/http_test.go
+++ b/test/integration/http/http_test.go
@@ -4,22 +4,21 @@ package http
 
 import (
 	"context"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/skupperproject/skupper/test/utils/base"
 	"github.com/skupperproject/skupper/test/utils/k8s"
 	"gotest.tools/assert"
-	"testing"
-	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 )
 
-var (
-	testRunner = &HttpClusterTestRunner{}
-)
-
 func TestMain(m *testing.M) {
-	testRunner.Initialize(m)
+	base.ParseFlags()
+	os.Exit(m.Run())
 }
 
 func TestHttp(t *testing.T) {
@@ -28,7 +27,8 @@ func TestHttp(t *testing.T) {
 		PublicClusters:  1,
 		PrivateClusters: 1,
 	}
-	testRunner.Build(t, needs, nil)
+	testRunner := &HttpClusterTestRunner{}
+	testRunner.BuildOrSkip(t, needs, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	base.HandleInterruptSignal(testRunner.T, func(t *testing.T) {
 		testRunner.TearDown(ctx)

--- a/test/integration/tcp_echo/tcp_echo_test.go
+++ b/test/integration/tcp_echo/tcp_echo_test.go
@@ -5,24 +5,23 @@ package tcp_echo
 import (
 	"context"
 	"fmt"
-	"github.com/skupperproject/skupper/test/utils/base"
-	"github.com/skupperproject/skupper/test/utils/k8s"
 	"log"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/skupperproject/skupper/test/utils/base"
+	"github.com/skupperproject/skupper/test/utils/k8s"
 
 	"gotest.tools/assert"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
-var (
-	testRunner = &TcpEchoClusterTestRunner{}
-)
-
 func TestMain(m *testing.M) {
-	testRunner.Initialize(m)
+	base.ParseFlags()
+	os.Exit(m.Run())
 }
 
 func TestTcpEcho(t *testing.T) {
@@ -32,7 +31,8 @@ func TestTcpEcho(t *testing.T) {
 		PublicClusters:  1,
 		PrivateClusters: 1,
 	}
-	testRunner.Build(t, needs, nil)
+	testRunner := &TcpEchoClusterTestRunner{}
+	testRunner.BuildOrSkip(t, needs, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	base.HandleInterruptSignal(testRunner.T, func(t *testing.T) {
 		testRunner.TearDown(ctx)

--- a/test/utils/base/cluster_test_runner.go
+++ b/test/utils/base/cluster_test_runner.go
@@ -2,10 +2,10 @@ package base
 
 import (
 	"fmt"
+	"testing"
+
 	vanClient "github.com/skupperproject/skupper/client"
 	"gotest.tools/assert"
-	"os"
-	"testing"
 )
 
 // ClusterNeeds enable customization of expected number of
@@ -26,10 +26,8 @@ type VanClientProvider func(namespace string, context string, kubeConfigPath str
 // ClusterTestRunner defines a common interface to initialize and prepare
 // tests for running against an external cluster
 type ClusterTestRunner interface {
-	// Initialize parses flags
-	Initialize(m *testing.M)
 	// Initialize ClusterContexts
-	Build(t *testing.T, needs ClusterNeeds, vanClientProvider VanClientProvider) []*ClusterContext
+	BuildOrSkip(t *testing.T, needs ClusterNeeds, vanClientProvider VanClientProvider) []*ClusterContext
 	// Return a specific public context
 	GetPublicContext(id int) *ClusterContext
 	// Return a specific private context
@@ -47,15 +45,7 @@ type ClusterTestRunnerBase struct {
 	unitTestMock      bool
 }
 
-// Initialize parses the command line arguments
-func (c *ClusterTestRunnerBase) Initialize(m *testing.M) {
-	// Parsing flags
-	ParseFlags(m)
-	// Running tests
-	os.Exit(m.Run())
-}
-
-func (c *ClusterTestRunnerBase) Build(t *testing.T, needs ClusterNeeds, vanClientProvider VanClientProvider) []*ClusterContext {
+func (c *ClusterTestRunnerBase) BuildOrSkip(t *testing.T, needs ClusterNeeds, vanClientProvider VanClientProvider) []*ClusterContext {
 
 	// Initializing internal properties
 	c.T = t

--- a/test/utils/base/cluster_test_runner_test.go
+++ b/test/utils/base/cluster_test_runner_test.go
@@ -1,17 +1,17 @@
 package base
 
 import (
+	"testing"
+
 	"github.com/skupperproject/skupper/client"
 	"gotest.tools/assert"
 	"k8s.io/client-go/kubernetes/fake"
-	"testing"
 )
 
 func TestBuild(t *testing.T) {
-	var runner ClusterTestRunner
-	runner = &ClusterTestRunnerBase{}
+	runner := &ClusterTestRunnerBase{}
 	// only set this to true when running unit test
-	runner.(*ClusterTestRunnerBase).unitTestMock = true
+	runner.unitTestMock = true
 
 	tcs := []struct {
 		name             string
@@ -29,7 +29,7 @@ func TestBuild(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			setUnitTestFlags(tc.public, tc.private)
-			contexts := runner.Build(t, ClusterNeeds{
+			contexts := runner.BuildOrSkip(t, ClusterNeeds{
 				NamespaceId:     "unit-test",
 				PublicClusters:  tc.publicNeeded,
 				PrivateClusters: tc.privateNeeded,

--- a/test/utils/base/flag.go
+++ b/test/utils/base/flag.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"testing"
 )
 
 // TestFlags holds the common command line arguments
@@ -42,10 +41,11 @@ func (k *kubeConfigs) Set(file string) error {
 }
 
 var (
-	TestFlags testFlags
+	TestFlags   testFlags
+	FlagsParsed bool = false
 )
 
-func ParseFlags(m *testing.M) {
+func ParseFlags() {
 	// Registering flags to be parsed
 	flag.Var(&TestFlags.KubeConfigs, "kubeconfig", "KUBECONFIG files to be used. You can provide the --kubeconfig flag multiple times.")
 	flag.Var(&TestFlags.EdgeKubeConfigs, "edgekubeconfig", "Edge KUBECONFIG files to be used (other sites cannot connect to this cluster). You can provide the --edgekubeconfig flag multiple times.")


### PR DESCRIPTION
* testRunner.Initialize: removed
* testRunner object does not need to be global anymore
* Build renamed to BuildOrSkip since that is what it does