### PR TITLE
integration_tests_runner: remove "T *testing.T" from base struct

### DIFF
--- a/test/integration/basic/basic_test.go
+++ b/test/integration/basic/basic_test.go
@@ -24,9 +24,9 @@ func TestBasic(t *testing.T) {
 	testRunner := &BasicTestRunner{}
 	testRunner.BuildOrSkip(t, needs, nil)
 	ctx, cancel := context.WithCancel(context.Background())
-	base.HandleInterruptSignal(testRunner.T, func(t *testing.T) {
+	base.HandleInterruptSignal(t, func(t *testing.T) {
 		testRunner.TearDown(ctx)
 		cancel()
 	})
-	testRunner.Run(ctx)
+	testRunner.Run(ctx, t)
 }

--- a/test/integration/http/http_test.go
+++ b/test/integration/http/http_test.go
@@ -30,11 +30,11 @@ func TestHttp(t *testing.T) {
 	testRunner := &HttpClusterTestRunner{}
 	testRunner.BuildOrSkip(t, needs, nil)
 	ctx, cancel := context.WithCancel(context.Background())
-	base.HandleInterruptSignal(testRunner.T, func(t *testing.T) {
+	base.HandleInterruptSignal(t, func(t *testing.T) {
 		testRunner.TearDown(ctx)
 		cancel()
 	})
-	testRunner.Run(ctx)
+	testRunner.Run(ctx, t)
 }
 
 func TestHttpJob(t *testing.T) {

--- a/test/integration/tcp_echo/tcp_echo_test.go
+++ b/test/integration/tcp_echo/tcp_echo_test.go
@@ -34,11 +34,11 @@ func TestTcpEcho(t *testing.T) {
 	testRunner := &TcpEchoClusterTestRunner{}
 	testRunner.BuildOrSkip(t, needs, nil)
 	ctx, cancel := context.WithCancel(context.Background())
-	base.HandleInterruptSignal(testRunner.T, func(t *testing.T) {
+	base.HandleInterruptSignal(t, func(t *testing.T) {
 		testRunner.TearDown(ctx)
 		cancel()
 	})
-	testRunner.Run(ctx)
+	testRunner.Run(ctx, t)
 }
 
 func sendReceive() error {

--- a/test/utils/base/cluster_test_runner.go
+++ b/test/utils/base/cluster_test_runner.go
@@ -29,11 +29,11 @@ type ClusterTestRunner interface {
 	// Initialize ClusterContexts
 	BuildOrSkip(t *testing.T, needs ClusterNeeds, vanClientProvider VanClientProvider) []*ClusterContext
 	// Return a specific public context
-	GetPublicContext(id int) *ClusterContext
+	GetPublicContext(id int) (*ClusterContext, error)
 	// Return a specific private context
-	GetPrivateContext(id int) *ClusterContext
+	GetPrivateContext(id int) (*ClusterContext, error)
 	// Return a specific context
-	GetContext(private bool, id int) *ClusterContext
+	GetContext(private bool, id int) (*ClusterContext, error)
 }
 
 // ClusterTestRunnerBase is a base implementation of ClusterTestRunner
@@ -43,6 +43,8 @@ type ClusterTestRunnerBase struct {
 	vanClientProvider VanClientProvider
 	unitTestMock      bool
 }
+
+var _ ClusterTestRunner = &ClusterTestRunnerBase{}
 
 func (c *ClusterTestRunnerBase) BuildOrSkip(t *testing.T, needs ClusterNeeds, vanClientProvider VanClientProvider) []*ClusterContext {
 

--- a/test/utils/base/cluster_test_runner.go
+++ b/test/utils/base/cluster_test_runner.go
@@ -38,7 +38,6 @@ type ClusterTestRunner interface {
 
 // ClusterTestRunnerBase is a base implementation of ClusterTestRunner
 type ClusterTestRunnerBase struct {
-	T                 *testing.T
 	Needs             ClusterNeeds
 	ClusterContexts   []*ClusterContext
 	vanClientProvider VanClientProvider
@@ -48,7 +47,6 @@ type ClusterTestRunnerBase struct {
 func (c *ClusterTestRunnerBase) BuildOrSkip(t *testing.T, needs ClusterNeeds, vanClientProvider VanClientProvider) []*ClusterContext {
 
 	// Initializing internal properties
-	c.T = t
 	c.vanClientProvider = vanClientProvider
 	c.ClusterContexts = []*ClusterContext{}
 
@@ -84,24 +82,24 @@ func (c *ClusterTestRunnerBase) BuildOrSkip(t *testing.T, needs ClusterNeeds, va
 	return c.ClusterContexts
 }
 
-func (c *ClusterTestRunnerBase) GetPublicContext(id int) *ClusterContext {
+func (c *ClusterTestRunnerBase) GetPublicContext(id int) (*ClusterContext, error) {
 	return c.GetContext(false, id)
 }
 
-func (c *ClusterTestRunnerBase) GetPrivateContext(id int) *ClusterContext {
+func (c *ClusterTestRunnerBase) GetPrivateContext(id int) (*ClusterContext, error) {
 	return c.GetContext(true, id)
 }
 
-func (c *ClusterTestRunnerBase) GetContext(private bool, id int) *ClusterContext {
+func (c *ClusterTestRunnerBase) GetContext(private bool, id int) (*ClusterContext, error) {
 	if len(c.ClusterContexts) > 0 {
 		for _, cc := range c.ClusterContexts {
 			if cc.Private == private && cc.Id == id {
-				return cc
+				return cc, nil
 			}
 		}
+		return nil, fmt.Errorf("ClusterContext not found")
 	}
-	c.T.Logf("requested context does not exist - id: %d - private: %v", id, private)
-	return nil
+	return nil, fmt.Errorf("ClusterContexts list is empty!")
 }
 
 func (c *ClusterTestRunnerBase) createClusterContexts(t *testing.T, needs ClusterNeeds) {

--- a/test/utils/base/cluster_test_runner_test.go
+++ b/test/utils/base/cluster_test_runner_test.go
@@ -43,3 +43,50 @@ func TestBuild(t *testing.T) {
 		})
 	}
 }
+
+func TestGetContext(t *testing.T) {
+	notFoundError := "ClusterContext not found"
+	c := &ClusterTestRunnerBase{}
+	ccPublic := ClusterContext{
+		Private: false,
+		Id:      22,
+	}
+	ccPrivate := ClusterContext{
+		Private: true,
+		Id:      22,
+	}
+
+	cc, err := c.GetContext(true, 1)
+	assert.Error(t, err, "ClusterContexts list is empty!")
+	assert.Assert(t, cc == nil)
+
+	c.ClusterContexts = []*ClusterContext{&ccPublic}
+
+	cc, err = c.GetContext(true, 1)
+	assert.Error(t, err, notFoundError)
+
+	cc, err = c.GetContext(false, 1)
+	assert.Error(t, err, notFoundError)
+
+	cc, err = c.GetContext(true, 22)
+	assert.Error(t, err, notFoundError)
+
+	cc, err = c.GetContext(false, 22)
+	assert.Assert(t, err)
+	assert.Assert(t, &ccPublic == cc)
+
+	c.ClusterContexts = []*ClusterContext{&ccPrivate}
+
+	cc, err = c.GetContext(true, 1)
+	assert.Error(t, err, notFoundError)
+
+	cc, err = c.GetContext(false, 1)
+	assert.Error(t, err, notFoundError)
+
+	cc, err = c.GetContext(false, 22)
+	assert.Error(t, err, notFoundError)
+
+	cc, err = c.GetContext(true, 22)
+	assert.Assert(t, err)
+	assert.Assert(t, &ccPrivate == cc)
+}


### PR DESCRIPTION
* GetContext returns error instead of printing warning
* Just accomodating the rest of the code to previous changes
* Added unit-test for GetContext

TODO:

* remove "baseRunner" extentions on each integration test
(TcpEchoTestRunner, BasicTestRunner, etc), and just use functions.
* unify teardowns? for now teardown functions "looks like" duplicated, BUT,
that is because in the existing integration tests we are using one public,
and one private namespace/context, this is not necessarily a rule for all
tests.