### PR TITLE
unit-tets for bind command

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -106,6 +106,14 @@ func stringSliceContains(s []string, e string) bool {
 
 var validExposeTargets = []string{"deployment", "statefulset", "pods", "service"}
 
+func verifyTargetTypeFromArgs(args []string) error {
+	targetType, _ := parseTargetTypeAndName(args)
+	if !stringSliceContains(validExposeTargets, targetType) {
+		return fmt.Errorf("target type must be one of: [%s]", strings.Join(validExposeTargets, ", "))
+	}
+	return nil
+}
+
 func exposeTargetArgs(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 || (!strings.Contains(args[0], "/") && len(args) < 2) {
 		return fmt.Errorf("expose target and name must be specified (e.g. 'skupper expose deployment <name>'")
@@ -116,15 +124,7 @@ func exposeTargetArgs(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 && strings.Contains(args[0], "/") {
 		return fmt.Errorf("extra argument: %s", args[1])
 	}
-	targetType := args[0]
-	if strings.Contains(args[0], "/") {
-		parts := strings.Split(args[0], "/")
-		targetType = parts[0]
-	}
-	if !stringSliceContains(validExposeTargets, targetType) {
-		return fmt.Errorf("expose target type must be one of: [%s]", strings.Join(validExposeTargets, ", "))
-	}
-	return nil
+	return verifyTargetTypeFromArgs(args)
 }
 
 func createServiceArgs(cmd *cobra.Command, args []string) error {
@@ -150,7 +150,7 @@ func bindArgs(cmd *cobra.Command, args []string) error {
 	if len(args) > 2 && strings.Contains(args[1], "/") {
 		return fmt.Errorf("extra argument: %s", args[2])
 	}
-	return nil
+	return verifyTargetTypeFromArgs(args[1:])
 }
 
 func silenceCobra(cmd *cobra.Command) {

--- a/cmd/skupper/skupper_test.go
+++ b/cmd/skupper/skupper_test.go
@@ -32,13 +32,16 @@ func Test_bindArgs(t *testing.T) {
 	//must this fail?
 	//assert.Error(t, b([]string{"one/two", "resource/name"}), genericError)
 
-	assert.Assert(t, b([]string{"one", "resource/name"}))
+	assert.Error(t, b([]string{"one", "resource/name"}), "target type must be one of: [deployment, statefulset, pods, service]")
+
+	assert.Assert(t, b([]string{"one", "pods/name"}))
+	assert.Assert(t, b([]string{"one", "pods", "name"}))
+
 	//note  illegal vs extra
 	assert.Error(t, b([]string{"one", "resource/name", "three"}), "extra argument: three")
 	assert.Error(t, b([]string{"one", "resource/name", "three", "four"}), "illegal argument: four")
 	assert.Error(t, b([]string{"one", "resource/name", "three", "four", "five"}), "illegal argument: four")
 
-	assert.Assert(t, b([]string{"one", "resource", "name"}))
 	assert.Error(t, b([]string{"one", "resource", "name", "four"}), "illegal argument: four")
 	assert.Error(t, b([]string{"one", "resource", "name", "four", "five"}), "illegal argument: four")
 }
@@ -63,7 +66,7 @@ func Test_createServiceArgs(t *testing.T) {
 
 func Test_exposeTargetArgs(t *testing.T) {
 	genericError := "expose target and name must be specified (e.g. 'skupper expose deployment <name>'"
-	targetError := "expose target type must be one of: [deployment, statefulset, pods, service]"
+	targetError := "target type must be one of: [deployment, statefulset, pods, service]"
 
 	e := func(args []string) error {
 		return exposeTargetArgs(nil, args)

--- a/cmd/skupper/skupper_unexpose_cluster_test.go
+++ b/cmd/skupper/skupper_unexpose_cluster_test.go
@@ -89,7 +89,7 @@ func TestUnexposeWithCluster(t *testing.T) {
 		{
 			args:        []string{"deployent", "tcp-not-deployed"},
 			flags:       []string{},
-			expectedErr: "expose target type must be one of: [deployment, statefulset, pods, service]",
+			expectedErr: "target type must be one of: [deployment, statefulset, pods, service]",
 		},
 		{
 			args:        []string{"pods", "tcp-not-deployed"},


### PR DESCRIPTION
Also added verification for "bind" command "Args" function, so in case of user calling invalid type, error is returned instantaneously.