### PR TITLE
Fix panic when checking token #293

### DIFF
--- a/client/connector_create.go
+++ b/client/connector_create.go
@@ -60,6 +60,11 @@ func (cli *VanClient) isOwnToken(ctx context.Context, secretFile string) (bool, 
 }
 
 func (cli *VanClient) ConnectorCreateFromFile(ctx context.Context, secretFile string, options types.ConnectorCreateOptions) (*corev1.Secret, error) {
+	// Before doing any checks, make sure that Skupper is running.
+	if _, err := kube.GetDeployment(types.TransportDeploymentName, options.SkupperNamespace, cli.KubeClient); err != nil {
+		return nil, err
+	}
+
 	// Disallow self-connection: make sure this token does not belong to this Skupper router.
 	ownToken, err := cli.isOwnToken(ctx, secretFile)
 	if err != nil {

--- a/client/connector_create_test.go
+++ b/client/connector_create_test.go
@@ -29,6 +29,12 @@ func TestConnectorCreateError(t *testing.T) {
 	var cli *VanClient
 	var err error
 	ns := "namespace-for-testconnectorcreateerror"
+	if *clusterRun {
+		cli, err = NewClient(ns, "", "")
+	} else {
+		cli, err = newMockClient(ns, "", "")
+	}
+	assert.Assert(t, err)
 	cli, err = NewClient(ns, "", "")
 	assert.Check(t, err, ns)
 

--- a/client/connector_create_test.go
+++ b/client/connector_create_test.go
@@ -35,8 +35,6 @@ func TestConnectorCreateError(t *testing.T) {
 		cli, err = newMockClient(ns, "", "")
 	}
 	assert.Assert(t, err)
-	cli, err = NewClient(ns, "", "")
-	assert.Check(t, err, ns)
 
 	_, err = kube.NewNamespace(ns, cli.KubeClient)
 	assert.Check(t, err, ns)


### PR DESCRIPTION
  * Make sure that Skupper is running before
    checking token.

  * Make connector create test use real cluster
    so it gets expected error instead of "no router"
    error.

  * Unique the results in TestConnectorCreateInterior
    to avoid errors caused by multiple reports of
    same connector.