### PR TITLE
Issue 329: version 4 can't connect to version 3

### DIFF
--- a/client/connector_create.go
+++ b/client/connector_create.go
@@ -50,7 +50,9 @@ func secretFileAuthor(ctx context.Context, secretFile string) (author string, er
 	}
 	generatedBy, ok := content["skupper.io/generated-by"]
 	if !ok {
-		return "", fmt.Errorf("Can't find secret origin.")
+		// The generated-by token does not exist before Skupper version 4.0
+		// Decide at higher level whether to treat this as an error.
+		return "unknown", nil
 	}
 	return string(generatedBy), nil
 }
@@ -90,8 +92,11 @@ func (cli *VanClient) ConnectorCreateFromFile(ctx context.Context, secretFile st
 	// secrets that we have used to make connections.
 	newConnectionAuthor, err := secretFileAuthor(ctx, secretFile)
 	if err != nil {
-
 		return nil, err
+	}
+
+	if newConnectionAuthor == "unknown" {
+		// TODO -- in Skupper version 5 and beyond, warn or disallow (TBD)
 	}
 
 	secrets, err := cli.KubeClient.CoreV1().Secrets(options.SkupperNamespace).List(metav1.ListOptions{LabelSelector: "skupper.io/type=connection-token"})
@@ -102,7 +107,7 @@ func (cli *VanClient) ConnectorCreateFromFile(ctx context.Context, secretFile st
 	for _, oldSecret := range secrets.Items {
 		oldConnectionAuthor, ok := oldSecret.Annotations["skupper.io/generated-by"]
 		if !ok {
-			return nil, fmt.Errorf("A secret has no author.")
+			// TODO -- in Skupper version 5 and beyond, warn or disallow (TBD)
 		}
 		if newConnectionAuthor == oldConnectionAuthor {
 			return nil, fmt.Errorf("Already connected to \"%s\".", newConnectionAuthor)


### PR DESCRIPTION
  * When ecnountering a secret that has no
    'generated-by' annotation, detect the
    condition but do not warn or fail -- yet.
    In version 5 and beyond we will want to
    warn or fail -- TBD.