### PR TITLE
integration_tests: added mongodb test.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ build-tests:
 	go test -c -tags=integration -v ./test/integration/tcp_echo -o ${TEST_BINARIES_FOLDER}/tcp_echo_test
 	go test -c -tags=integration -v ./test/integration/http -o ${TEST_BINARIES_FOLDER}/http_test
 	go test -c -tags=integration -v ./test/integration/bookinfo -o ${TEST_BINARIES_FOLDER}/bookinfo_test
+	go test -c -tags=integration -v ./test/integration/mongodb -o ${TEST_BINARIES_FOLDER}/mongo_test
 
 build-cmd:
 	go build -ldflags="-X main.version=${VERSION}"  -o skupper cmd/skupper/skupper.go

--- a/test/integration/mongodb/mongo.go
+++ b/test/integration/mongodb/mongo.go
@@ -1,0 +1,85 @@
+package mongodb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/skupperproject/skupper/api/types"
+	vanClient "github.com/skupperproject/skupper/client"
+	"github.com/skupperproject/skupper/test/utils/base"
+	"github.com/skupperproject/skupper/test/utils/constants"
+	"github.com/skupperproject/skupper/test/utils/k8s"
+	"gotest.tools/assert"
+)
+
+func int32Ptr(i int32) *int32 { return &i }
+
+func RunTests(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) {
+	pubCluster1, err := r.GetPublicContext(1)
+	assert.Assert(t, err)
+
+	prvCluster1, err := r.GetPrivateContext(1)
+	assert.Assert(t, err)
+
+	_, err = k8s.WaitForSkupperServiceToBeCreatedAndReadyToUse(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, "mongo-a")
+	assert.Assert(t, err)
+	_, err = k8s.WaitForSkupperServiceToBeCreatedAndReadyToUse(prvCluster1.Namespace, prvCluster1.VanClient.KubeClient, "mongo-b")
+	assert.Assert(t, err)
+
+	_, err = prvCluster1.KubectlExec("exec deploy/mongo-a -- mongo --host 127.0.0.1:27017 --eval \"rs.initiate( {   _id : \\\"rs0\\\", members: [ { _id: 0, host: \\\"mongo-a:27017      \\\" },{ _id: 1, host: \\\"mongo-b:27017\\\" }]})\"")
+	assert.Assert(t, err)
+
+	jobName := "mongo"
+	jobCmd := []string{"/app/mongo_test", "-test.run", "Job"}
+
+	_, err = k8s.CreateTestJob(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, jobName, jobCmd)
+	assert.Assert(t, err)
+	job, err := k8s.WaitForJob(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, jobName, constants.ImagePullingAndResourceCreationTimeout)
+	assert.Assert(t, err)
+	pubCluster1.KubectlExec("logs job/" + jobName)
+
+	k8s.AssertJob(t, job)
+}
+
+func Setup(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) {
+	prv1Cluster, err := r.GetPrivateContext(1)
+	assert.Assert(t, err)
+
+	pub1Cluster, err := r.GetPublicContext(1)
+	assert.Assert(t, err)
+
+	err = base.SetupSimplePublicPrivateAndConnect(ctx, r, "mongo")
+	assert.Assert(t, err)
+
+	_, err = prv1Cluster.KubectlExec("apply -f https://raw.githubusercontent.com/skupperproject/skupper-example-mongodb-replica-set/master/deployment-mongo-a.yaml")
+	assert.Assert(t, err)
+
+	_, err = pub1Cluster.KubectlExec("apply -f https://raw.githubusercontent.com/skupperproject/skupper-example-mongodb-replica-set/master/deployment-mongo-b.yaml")
+	assert.Assert(t, err)
+
+	expose := func(name string, cli *vanClient.VanClient) {
+		t.Helper()
+		service := types.ServiceInterface{
+			Address:  name,
+			Protocol: "tcp",
+			Port:     27017,
+		}
+
+		err = cli.ServiceInterfaceCreate(ctx, &service)
+		assert.Assert(t, err)
+
+		err = cli.ServiceInterfaceBind(ctx, &service, "deployment", name, "tcp", 0)
+		assert.Assert(t, err)
+
+	}
+	expose("mongo-a", prv1Cluster.VanClient)
+	expose("mongo-b", pub1Cluster.VanClient)
+	//Just need to do load orr rs inittiate, the easiest one.
+
+}
+
+func Run(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) {
+	//defer base.TearDownSimplePublicAndPrivate(r)
+	Setup(ctx, t, r)
+	RunTests(ctx, t, r)
+}

--- a/test/integration/mongodb/mongo_test.go
+++ b/test/integration/mongodb/mongo_test.go
@@ -1,0 +1,96 @@
+// +build integration
+
+package mongodb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/skupperproject/skupper/test/utils/base"
+	"github.com/skupperproject/skupper/test/utils/k8s"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"gotest.tools/assert"
+)
+
+func TestMain(m *testing.M) {
+	base.ParseFlags()
+	os.Exit(m.Run())
+}
+
+func TestMongo(t *testing.T) {
+	needs := base.ClusterNeeds{
+		NamespaceId:     "mongo",
+		PublicClusters:  1,
+		PrivateClusters: 1,
+	}
+	testRunner := &base.ClusterTestRunnerBase{}
+	testRunner.BuildOrSkip(t, needs, nil)
+	//ctx, cancel := context.WithCancel(context.Background())
+	//base.HandleInterruptSignal(t, func(t *testing.T) {
+	//base.TearDownSimplePublicAndPrivate(&testRunner.ClusterTestRunnerBase)
+	//cancel()
+	//})
+	Run(context.Background(), t, testRunner)
+}
+
+type Post struct {
+	Title string `json:"title,omitempty"`
+	Body  string `json:"body,omitempty"`
+}
+
+func InsertPost(client *mongo.Client, title string, body string) error {
+	post := Post{title, body}
+	collection := client.Database("my_database").Collection("posts")
+	insertResult, err := collection.InsertOne(context.TODO(), post)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Inserted post with ID:", insertResult.InsertedID)
+	return nil
+}
+
+func GetPost(client *mongo.Client) (error, Post) {
+
+	collection := client.Database("my_database").Collection("posts")
+	filter := bson.D{}
+	var post Post
+
+	err := collection.FindOne(context.TODO(), filter).Decode(&post)
+	if err != nil {
+		return err, Post{}
+	}
+	return nil, post
+}
+
+func TestMongoJob(t *testing.T) {
+	k8s.SkipTestJobIfMustBeSkipped(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	getClient := func(uri string) *mongo.Client {
+		client, err := mongo.NewClient(options.Client().ApplyURI(uri))
+		assert.Assert(t, err)
+		err = client.Connect(ctx)
+		assert.Assert(t, err)
+		return client
+	}
+	client_a := getClient("mongodb://mongo-a:27017")
+	client_b := getClient("mongodb://mongo-b:27017")
+	defer client_a.Disconnect(ctx)
+	defer client_b.Disconnect(ctx)
+
+	expected := Post{Title: "TheName", Body: "TheBody"}
+
+	err := InsertPost(client_a, expected.Title, expected.Body)
+	assert.Assert(t, err)
+
+	err, post := GetPost(client_b)
+	assert.Assert(t, err)
+	assert.Assert(t, post == expected)
+}


### PR DESCRIPTION
simple integration test based on skupper examples:https://github.com/skupperproject/skupper-example-mongodb-replica-set

To verify network is working, data is loaded from one endpoint, and read from the other.