### PR TITLE
skupper_cli: removed --version option

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -863,7 +863,6 @@ func init() {
 	cmdCompletion := NewCmdCompletion()
 
 	rootCmd = &cobra.Command{Use: "skupper"}
-	rootCmd.Version = version
 	rootCmd.AddCommand(cmdInit, cmdDelete, cmdConnectionToken, cmdConnect, cmdDisconnect, cmdCheckConnection, cmdStatus, cmdListConnectors, cmdExpose, cmdUnexpose, cmdListExposed,
 		cmdService, cmdBind, cmdUnbind, cmdVersion, cmdDebug, cmdCompletion)
 	rootCmd.PersistentFlags().StringVarP(&kubeConfigPath, "kubeconfig", "", "", "Path to the kubeconfig file to use")


### PR DESCRIPTION
Closes #363 
Capitalize "Skupper" in output.  Remove "version"

A couple of comments:
With this change, "$skupper --version" output changes from:

```

$ ./skupper --version
skupper version 0.4.0-5
```
to

```

$ ./skupper --version
Skupper 0.4.0-5
```

The requested change was to "also" renamte "skupper --version" to "skupper version" BUT, we also have an implementation for skupper verion:

```

$ ./skupper version
client version                 0.4.0-5
transport version              quay.io/skupper/qdrouterd:0.4 (sha256:037ec89c755a)
controller version             quay.io/skupper/service-controller:0.4 (sha256:13b10aa1250d)
```

So... not sure if the idea is to keep both, remove one or rename both