### PR TITLE
skupper_cli: bind and unbind, are now subcommands

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -853,7 +853,10 @@ func init() {
 	cmdDebugDump := NewCmdDebugDump(newClient)
 
 	//backwards compatibility commands hidden
+	deprecatedMessage := "please use 'skupper service [bind|unbind]' instead"
 	cmdBind.Hidden = true
+	cmdBind.Deprecated = deprecatedMessage
+	cmdUnbind.Deprecated = deprecatedMessage
 	cmdUnbind.Hidden = true
 
 	// setup subcommands

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -852,10 +852,16 @@ func init() {
 	cmdVersion := NewCmdVersion(newClient)
 	cmdDebugDump := NewCmdDebugDump(newClient)
 
+	//backwards compatibility commands hidden
+	cmdBind.Hidden = true
+	cmdUnbind.Hidden = true
+
 	// setup subcommands
 	cmdService := NewCmdService()
 	cmdService.AddCommand(cmdCreateService)
 	cmdService.AddCommand(cmdDeleteService)
+	cmdService.AddCommand(NewCmdBind(newClient))
+	cmdService.AddCommand(NewCmdUnbind(newClient))
 
 	cmdDebug := NewCmdDebug()
 	cmdDebug.AddCommand(cmdDebugDump)


### PR DESCRIPTION
Old top level commands are keeped for backward compatibility.

```
$ ./skupper bind --help
Command "bind" is deprecated, please use 'skupper service [bind|unbind]' instead
Bind a target to a service

Usage:
  skupper bind <service-name> <target-type> <target-name> [flags]
...
```