### PR TITLE
cli help customization poc (creating subgroups)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,5 +25,6 @@ require (
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
+	k8s.io/kubectl v0.17.0
 	k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab // indirect
 )


### PR DESCRIPTION
* Old (cobra default):

```
$ ./skupper --help
Usage:
  skupper [command]

Available Commands:
  bind             Bind a target to a service
  completion       Output shell completion code for bash
  connection-token Create a connection token.  The 'connect' command uses the token to establish a connection from a remote Skupper site.
  debug            Debug skupper installation
  delete           Delete skupper installation
  expose           Expose a set of pods through a Skupper address
  help             Help about any command
  init             Initialise skupper installation
  link             Manage skupper links definitions
  list-exposed     List services exposed over the Skupper network
  service          Manage skupper service definitions
  status           Report the status of the current Skupper site
  unbind           Unbind a target from a service
  unexpose         Unexpose a set of pods previously exposed through a Skupper address
  version          Report the version of the Skupper CLI and services

Flags:
  -c, --context string      The kubeconfig context to use
  -h, --help                help for skupper
      --kubeconfig string   Path to the kubeconfig file to use
  -n, --namespace string    The Kubernetes namespace to use
      --version             version for skupper

Use "skupper [command] --help" for more information about a command.
 ```

* New POC (details, names, etc, can be tunned):

```
$ ./skupper --help


Basic commands
  delete           Delete skupper installation
  token            Manage skupper tokens
  link             Manage skupper links definitions
  status           Report the status of the current Skupper site
  expose           Expose a set of pods through a Skupper address
  unexpose         Unexpose a set of pods previously exposed through a Skupper address
  list-exposed     List services exposed over the Skupper network
  service          Manage skupper service definitions
  bind             Bind a target to a service
  unbind           Unbind a target from a service
  version          Report the version of the Skupper CLI and services
  completion       Output shell completion code for bash

Advanced commands
  debug            Debug skupper installation

Other Commands:
  init             Initialise skupper installation

Options:
      --version=false: version for skupper

Use "skupper <command> --help" for more information about a given command.

```

Since the "template" we are using for tunning, belongs to the kubectl project, the new format is very similar to the kubectl output,
things to note:
    - missing --version (--version does not exist on kubectl, only the "version" subcommand)
    - all global flags are missing, (to see then, the kubectl has a special subcommand "kubectl options")
    - of course, all this  previous considerations may be tunned, this is just taking the "template" library, as it is, and plugging it.

Sample kubectl output (see the last part):

```
 kubectl  --help
kubectl controls the Kubernetes cluster manager.

 Find more information at: https://kubernetes.io/docs/reference/kubectl/overview/

Basic Commands (Beginner):
  create        Create a resource from a file or from stdin.
  expose        Take a replication controller, service, deployment or pod and expose it as a new Kubernetes Service
  run           Run a particular image on the cluster
  set           Set specific features on objects

Basic Commands (Intermediate):
  explain       Documentation of resources
  get           Display one or many resources
  edit          Edit a resource on the server
  delete        Delete resources by filenames, stdin, resources and names, or by resources and label selector

..... REMOVED SOME COMMAND GROUPS TO SUMMARIZE ......

Advanced Commands:
  diff          Diff live version against would-be applied version
  apply         Apply a configuration to a resource by filename or stdin
  patch         Update field(s) of a resource using strategic merge patch

Settings Commands:
  label         Update the labels on a resource
  annotate      Update the annotations on a resource
  completion    Output shell completion code for the specified shell (bash or zsh)

Other Commands:
  alpha         Commands for features in alpha
  ...

Usage:
  kubectl [flags] [options]

Use "kubectl <command> --help" for more information about a given command.
Use "kubectl options" for a list of global command-line options (applies to all commands).
```