### PR TITLE
Adding bash completion, for now only "-n" completes with available namespaces

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -30,6 +30,8 @@ __kubectl_parse_get()
     local kubectl_out
     if kubectl_out=$(__kubectl_debug_out "kubectl get $(__kubectl_override_flags) -o template --template=\"${template}\" \"$1\""); then
         COMPREPLY+=( $( compgen -W "${kubectl_out[*]}" -- "$cur" ) )
+    else kubectl_out=$(__kubectl_debug_out "oc get $(__kubectl_override_flags) -o template --template=\"${template}\" \"$1\"")
+        COMPREPLY+=( $( compgen -W "${kubectl_out[*]}" -- "$cur" ) )
     fi
 }
 


### PR DESCRIPTION
Closes #367 

based/stolen from:
https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/cmd.go#L293

It requires "kubectl" to be installed.

To give it a try just:

```
$ make build-cmd #build skupper cli
$ source <(./skupper completion) #source the autocompletion script
$ complete -F __start_skupper ./skupper #hack to make autocompletion work for "./skupper" also (normally it works for "skupper")
$ #try it!
$ ./skupper -n <tab> <tab> #autocompleting flag as first argument
default          kube-node-lease  kube-public      kube-system      private-http-1   private-mongo-1  public-http-1    public-mongo-1
$ ./skupper service -n <tab> <tab>  #autocompleting flag after calling a subcommand
default          kube-node-lease  kube-public      kube-system      private-http-1   private-mongo-1  public-http-1    public-mongo-1
$ ./skupper  <tab> <tab> #verify it is still working for normal subcommands
bind              connect           delete            init              service           unexpose          
check-connection  connection-token  disconnect        list-connectors   status            version           
completion        debug             expose            list-exposed      unbind 


```
