### PR TITLE
simplify get version

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 type ConnectorCreateOptions struct {
@@ -94,5 +93,5 @@ type VanClientInterface interface {
 	SiteConfigRemove(ctx context.Context) error
 	SkupperDump(ctx context.Context, tarName string, version string, kubeConfigPath string, kubeConfigContext string) error
 	GetNamespace() string
-	GetKubeClient() kubernetes.Interface
+	GetVersion(component string, name string) string
 }

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 type ConnectorCreateOptions struct {
@@ -93,4 +94,5 @@ type VanClientInterface interface {
 	SiteConfigRemove(ctx context.Context) error
 	SkupperDump(ctx context.Context, tarName string, version string, kubeConfigPath string, kubeConfigContext string) error
 	GetNamespace() string
+	GetKubeClient() kubernetes.Interface
 }

--- a/client/client.go
+++ b/client/client.go
@@ -26,6 +26,10 @@ func (cli *VanClient) GetNamespace() string {
 	return cli.Namespace
 }
 
+func (cli *VanClient) GetKubeClient() kubernetes.Interface {
+	return cli.KubeClient
+}
+
 func NewClient(namespace string, context string, kubeConfigPath string) (*VanClient, error) {
 	c := &VanClient{}
 

--- a/client/client.go
+++ b/client/client.go
@@ -10,6 +10,8 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/skupperproject/skupper/pkg/kube"
 )
 
 var Version = "undefined"
@@ -28,6 +30,10 @@ func (cli *VanClient) GetNamespace() string {
 
 func (cli *VanClient) GetKubeClient() kubernetes.Interface {
 	return cli.KubeClient
+}
+
+func (cli *VanClient) GetVersion(component string, name string) string {
+	return kube.GetComponentVersion(cli.Namespace, cli.KubeClient, component, name)
 }
 
 func NewClient(namespace string, context string, kubeConfigPath string) (*VanClient, error) {

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/client"
+	"github.com/skupperproject/skupper/pkg/kube"
 )
 
 type ExposeOptions struct {
@@ -756,14 +757,14 @@ func NewCmdVersion(newClient cobraFunc) *cobra.Command {
 		PreRun: newClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			silenceCobra(cmd)
-			vir, err := cli.RouterInspect(context.Background())
+
+			ns := cli.GetNamespace()
+			kc := cli.GetKubeClient()
+
 			fmt.Printf("%-30s %s\n", "client version", client.Version)
-			if err == nil {
-				fmt.Printf("%-30s %s\n", "transport version", vir.TransportVersion)
-				fmt.Printf("%-30s %s\n", "controller version", vir.ControllerVersion)
-			} else {
-				return fmt.Errorf("Unable to retrieve skupper component versions: %w", err)
-			}
+			fmt.Printf("%-30s %s\n", "transport version", kube.GetComponentVersion(ns, kc, types.TransportComponentName, types.TransportContainerName))
+			fmt.Printf("%-30s %s\n", "controller version", kube.GetComponentVersion(ns, kc, types.ControllerComponentName, types.ControllerContainerName))
+
 			return nil
 		},
 	}

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/client"
-	"github.com/skupperproject/skupper/pkg/kube"
 )
 
 type ExposeOptions struct {
@@ -758,12 +757,9 @@ func NewCmdVersion(newClient cobraFunc) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			silenceCobra(cmd)
 
-			ns := cli.GetNamespace()
-			kc := cli.GetKubeClient()
-
 			fmt.Printf("%-30s %s\n", "client version", client.Version)
-			fmt.Printf("%-30s %s\n", "transport version", kube.GetComponentVersion(ns, kc, types.TransportComponentName, types.TransportContainerName))
-			fmt.Printf("%-30s %s\n", "controller version", kube.GetComponentVersion(ns, kc, types.ControllerComponentName, types.ControllerContainerName))
+			fmt.Printf("%-30s %s\n", "transport version", cli.GetVersion(types.TransportComponentName, types.TransportContainerName))
+			fmt.Printf("%-30s %s\n", "controller version", cli.GetVersion(types.ControllerComponentName, types.ControllerContainerName))
 
 			return nil
 		},

--- a/cmd/skupper/skupper_mock_test.go
+++ b/cmd/skupper/skupper_mock_test.go
@@ -200,6 +200,10 @@ func (cli *vanClientMock) GetNamespace() string {
 	return "MockNamespace"
 }
 
+func (cli *vanClientMock) GetVersion(component string, name string) string {
+	return "not-found"
+}
+
 func TestCmdUnexposeRun(t *testing.T) {
 	cmd := NewCmdUnexpose(nil)
 	test := func(targetType, targetName, address string) {


### PR DESCRIPTION
A full RouterInspect is not needed for getting version and errors could be confusing to users expecting a simple version check. 