### PR TITLE
New deprecated flags

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -792,7 +792,6 @@ func init() {
 	cmdCompletion := NewCmdCompletion()
 
 	rootCmd = &cobra.Command{Use: "skupper"}
-	rootCmd.Version = client.Version
 	rootCmd.AddCommand(cmdInit,
 		cmdDelete,
 		cmdUpdate,

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -475,8 +475,14 @@ func NewCmdUnexpose(newClient cobraFunc) *cobra.Command {
 }
 
 func NewCmdListExposed(newClient cobraFunc) *cobra.Command {
+	cmd := NewCmdServiceStatus(newClient)
+	cmd.Use = "list-exposed"
+	return cmd
+}
+
+func NewCmdServiceStatus(newClient cobraFunc) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "list-exposed",
+		Use:    "status",
 		Short:  "List services exposed over the Skupper network",
 		Args:   cobra.NoArgs,
 		PreRun: newClient,
@@ -737,6 +743,7 @@ func init() {
 	cmdListExposed := NewCmdListExposed(newClient)
 	cmdCreateService := NewCmdCreateService(newClient)
 	cmdDeleteService := NewCmdDeleteService(newClient)
+	cmdStatusService := NewCmdServiceStatus(newClient)
 	cmdBind := NewCmdBind(newClient)
 	cmdUnbind := NewCmdUnbind(newClient)
 	cmdVersion := NewCmdVersion(newClient)
@@ -771,12 +778,16 @@ func init() {
 	cmdConnectionToken.Hidden = true
 	cmdConnectionToken.Deprecated = "please use 'skupper token create' instead."
 
+	cmdListExposed.Hidden = true
+	cmdListExposed.Deprecated = "please use 'skupper service status' instead."
+
 	// setup subcommands
 	cmdService := NewCmdService()
 	cmdService.AddCommand(cmdCreateService)
 	cmdService.AddCommand(cmdDeleteService)
 	cmdService.AddCommand(NewCmdBind(newClient))
 	cmdService.AddCommand(NewCmdUnbind(newClient))
+	cmdService.AddCommand(cmdStatusService)
 
 	cmdDebug := NewCmdDebug()
 	cmdDebug.AddCommand(cmdDebugDump)

--- a/cmd/skupper/skupper_mock_test.go
+++ b/cmd/skupper/skupper_mock_test.go
@@ -285,7 +285,7 @@ func TestCmdInit(t *testing.T) {
 		func(t *testing.T) {
 			resetCli()
 			lcli.injectedReturns.siteConfigInspect.err = fmt.Errorf("some error")
-			err := cmd.RunE(&cobra.Command{}, args)
+			err := cmd.RunE(cmd, args)
 			assert.Error(t, err, "some error")
 			assert.Assert(t, lcli.siteConfigInspectCalledWith[0] == nil)
 		})
@@ -294,7 +294,7 @@ func TestCmdInit(t *testing.T) {
 		func(t *testing.T) {
 			resetCli()
 			lcli.injectedReturns.siteConfigCreate.err = fmt.Errorf("some error")
-			err := cmd.RunE(&cobra.Command{}, args)
+			err := cmd.RunE(cmd, args)
 			assert.Error(t, err, "some error")
 			assert.Assert(t, lcli.siteConfigCreateCalledWith[0] == routerCreateOpts)
 		})
@@ -310,7 +310,7 @@ func TestCmdInit(t *testing.T) {
 			}
 			lcli.injectedReturns.siteConfigInspect.siteConfig = &siteConfig
 			lcli.injectedReturns.routerCreate = fmt.Errorf("a error")
-			err := cmd.RunE(&cobra.Command{}, args)
+			err := cmd.RunE(cmd, args)
 			assert.Error(t, err, "a error")
 			assert.Assert(t, cmp.Equal(lcli.routerCreateCalledWith[0], siteConfig))
 		})
@@ -319,7 +319,7 @@ func TestCmdInit(t *testing.T) {
 		func(t *testing.T) {
 			resetCli()
 			lcli.injectedReturns.siteConfigInspect.siteConfig = &types.SiteConfig{}
-			err := cmd.RunE(&cobra.Command{}, args)
+			err := cmd.RunE(cmd, args)
 			assert.Assert(t, err)
 			assert.Assert(t, len(lcli.siteConfigInspectCalledWith) == 1)
 			assert.Assert(t, len(lcli.siteConfigCreateCalledWith) == 0)


### PR DESCRIPTION
Closes #366 
Closes #363
Closes #364

skupper-cli update: 
remove --version flag
remove --enable-proxy-controller flag
added --router-mode [interior|edge] and deprecated "--edge"