### PR TITLE
Fix and refactoring for console server

### DIFF
--- a/cmd/service-controller/console_server.go
+++ b/cmd/service-controller/console_server.go
@@ -13,18 +13,17 @@ import (
 	"strings"
 
 	"github.com/skupperproject/skupper/client"
+	"github.com/skupperproject/skupper/pkg/data"
 	"github.com/skupperproject/skupper/pkg/qdr"
 )
 
 type ConsoleServer struct {
 	agentPool *qdr.AgentPool
-	iplookup  *IpLookup
 }
 
 func newConsoleServer(cli *client.VanClient, config *tls.Config) *ConsoleServer {
 	return &ConsoleServer{
 		agentPool: qdr.NewAgentPool("amqps://skupper-messaging:5671", config),
-		iplookup:  NewIpLookup(cli),
 	}
 }
 
@@ -107,7 +106,7 @@ func (server *ConsoleServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Could not get management agent : %s", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
-	data, err := getConsoleData(agent, server.iplookup)
+	data, err := getConsoleData(agent)
 	server.agentPool.Put(agent)
 	if err != nil {
 		log.Printf("Error retrieving console data: %s", err)
@@ -124,9 +123,8 @@ func (server *ConsoleServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (server *ConsoleServer) start(stopCh <-chan struct{}) error {
-	err := server.iplookup.start(stopCh)
 	go server.listen()
-	return err
+	return nil
 }
 
 func (server *ConsoleServer) listen() {
@@ -144,530 +142,71 @@ func (server *ConsoleServer) listen() {
 	log.Fatal(http.ListenAndServe(addr, nil))
 }
 
-type ServiceStats struct {
-	Address  string          `json:"address"`
-	Protocol string          `json:"protocol"`
-	Targets  []ServiceTarget `json:"targets"`
-}
-
-type ServiceTarget struct {
-	Name   string `json:"name"`
-	Target string `json:"target"`
-	SiteId string `json:"site_id"`
-}
-
-type HttpRequestsHandledList []HttpRequestsHandled
-type HttpRequestsReceivedList []HttpRequestsReceived
-
-type HttpServiceStats struct {
-	ServiceStats
-	RequestsReceived HttpRequestsReceivedList `json:"requests_received"`
-	RequestsHandled  HttpRequestsHandledList  `json:"requests_handled"`
-}
-
-type HttpRequestsReceived struct {
-	SiteId   string                      `json:"site_id"`
-	ByClient map[string]HttpRequestStats `json:"by_client,omitempty"`
-}
-
-type HttpRequestsHandled struct {
-	SiteId            string                      `json:"site_id"`
-	ByServer          map[string]HttpRequestStats `json:"by_server,omitempty"`
-	ByOriginatingSite map[string]HttpRequestStats `json:"by_originating_site,omitempty"`
-}
-
-type HttpRequestStats struct {
-	Requests       int                         `json:"requests"`
-	BytesIn        int                         `json:"bytes_in"`
-	BytesOut       int                         `json:"bytes_out"`
-	Details        map[string]int              `json:"details"`
-	LatencyMax     int                         `json:"latency_max"`
-	ByHandlingSite map[string]HttpRequestStats `json:"by_handling_site,omitempty"`
-}
-
-type TcpServiceStats struct {
-	ServiceStats
-	ConnectionsIngress SiteConnectionsList `json:"connections_ingress,omitempty"`
-	ConnectionsEgress  SiteConnectionsList `json:"connections_egress,omitempty"`
-}
-
-type SiteConnectionsList []SiteConnections
-
-type SiteConnections struct {
-	SiteId      string                     `json:"site_id"`
-	Connections map[string]ConnectionStats `json:"connections"`
-}
-
-type ConnectionStats struct {
-	Id        string `json:"id"`
-	StartTime uint64 `json:"start_time"`
-	LastOut   uint64 `json:"last_out"`
-	LastIn    uint64 `json:"last_in"`
-	BytesIn   int    `json:"bytes_in"`
-	BytesOut  int    `json:"bytes_out"`
-	Client    string `json:"client,omitempty"`
-	Server    string `json:"server,omitempty"`
-}
-
-type TcpServiceStatsMap map[string]TcpServiceStats
-type HttpServiceStatsMap map[string]HttpServiceStats
-
-func getHttpRequestDetails(in qdr.Record) map[string]int {
-	out := map[string]int{}
-	for k, v := range in {
-		i, ok := qdr.AsInt(v)
-		if ok {
-			out[k] = i
-		}
+func set(m map[string]map[string]bool, k1 string, k2 string) {
+	log.Printf("CONNECTED %s %s", k1, k2)
+	m2, ok := m[k1]
+	if !ok {
+		m2 = map[string]bool{}
 	}
-	return out
+	m2[k2] = true
+	m[k1] = m2
 }
 
-func max(a int, b int) int {
-	if b > a {
-		return b
-	} else {
-		return a
-	}
-}
-
-func mergeCounts(a map[string]int, b map[string]int) {
-	for k, v := range b {
-		if s, ok := a[k]; ok {
-			a[k] = s + v
-		} else {
-			a[k] = v
-		}
-	}
-}
-
-func (a *HttpRequestStats) merge(b *HttpRequestStats) {
-	a.Requests += b.Requests
-	a.BytesIn += b.BytesIn
-	a.BytesOut += b.BytesOut
-	a.LatencyMax = max(a.LatencyMax, b.LatencyMax)
-	mergeCounts(a.Details, b.Details)
-	if a.ByHandlingSite == nil {
-		a.ByHandlingSite = b.ByHandlingSite
-	} else if b.ByHandlingSite != nil {
-		mergeHttpRequestStats(a.ByHandlingSite, b.ByHandlingSite)
-	}
-}
-
-func mergeHttpRequestStats(a map[string]HttpRequestStats, b map[string]HttpRequestStats) {
-	for k, v := range b {
-		if s, ok := a[k]; ok {
-			s.merge(&v)
-			a[k] = s
-		} else {
-			a[k] = v
-		}
-	}
-}
-
-func getHttpRequestStats(in qdr.Record) map[string]HttpRequestStats {
-	out := map[string]HttpRequestStats{}
-	for k, v := range in {
-		m, ok := v.(map[string]interface{})
-		if ok {
-			r := qdr.Record(m)
-			hrs := HttpRequestStats{
-				Requests:   r.AsInt("requests"),
-				BytesIn:    r.AsInt("bytes_in"),
-				BytesOut:   r.AsInt("bytes_out"),
-				Details:    getHttpRequestDetails(r.AsRecord("details")),
-				LatencyMax: r.AsInt("latency_max"),
-			}
-			byHandlingSite := r.AsRecord("by_handling_site")
-			if byHandlingSite != nil {
-				hrs.ByHandlingSite = getHttpRequestStats(byHandlingSite)
-			}
-			out[k] = hrs
-		}
-	}
-	log.Printf("getHttpRequestsStats() => %#v\n", out)
-	return out
-}
-
-func getTargetName(connectorName string) string {
-	parts := strings.Split(connectorName, "@")
-	if len(parts) > 0 {
-		return parts[0]
-	} else {
-		return connectorName
-	}
-}
-
-func getHttpProtocol(protocolVersion string) string {
-	if protocolVersion == qdr.HttpVersion2 {
-		return "http2"
-	} else {
-		return "http"
-	}
-}
-
-func getTargetHost(iplookup *IpLookup, host string) string {
-	result := iplookup.getPodName(host)
-	if result == "" {
-		return host
-	} else {
-		return result
-	}
-}
-
-func getServiceStats(bridges []qdr.BridgeConfig, sites []Site, tcpconnections [][]qdr.TcpConnection, httpRequests [][]qdr.HttpRequestInfo, iplookup *IpLookup) []interface{} {
-	tcpServices := TcpServiceStatsMap{}
-	httpServices := HttpServiceStatsMap{}
-	for _, b := range bridges {
-		for _, c := range b.TcpConnectors {
-			target := []ServiceTarget{
-				ServiceTarget{
-					Name:   getTargetHost(iplookup, c.Host),
-					Target: getTargetName(c.Name),
-					SiteId: c.SiteId,
-				},
-			}
-			service, ok := tcpServices[c.Address]
-			if ok {
-				service.Targets = append(service.Targets, target...)
-				tcpServices[c.Address] = service
-			} else {
-				service = TcpServiceStats{
-					ServiceStats: ServiceStats{
-						Address:  c.Address,
-						Protocol: "tcp",
-						Targets:  target,
-					},
-				}
-				tcpServices[c.Address] = service
-			}
-		}
-		for _, l := range b.TcpListeners {
-			if _, ok := tcpServices[l.Address]; !ok {
-				tcpServices[l.Address] = TcpServiceStats{
-					ServiceStats: ServiceStats{
-						Address:  l.Address,
-						Protocol: "tcp",
-					},
-				}
-			}
-
-		}
-		for _, c := range b.HttpConnectors {
-			target := []ServiceTarget{
-				ServiceTarget{
-					Name:   getTargetHost(iplookup, c.Host),
-					Target: getTargetName(c.Name),
-					SiteId: c.SiteId,
-				},
-			}
-			service, ok := httpServices[c.Address]
-			if ok {
-				service.Targets = append(service.Targets, target...)
-				httpServices[c.Address] = service
-			} else {
-				service = HttpServiceStats{
-					ServiceStats: ServiceStats{
-						Address:  c.Address,
-						Protocol: getHttpProtocol(c.ProtocolVersion),
-						Targets:  target,
-					},
-					RequestsReceived: HttpRequestsReceivedList{},
-					RequestsHandled:  HttpRequestsHandledList{},
-				}
-				httpServices[c.Address] = service
-			}
-		}
-		for _, l := range b.HttpListeners {
-			if _, ok := httpServices[l.Address]; !ok {
-				httpServices[l.Address] = HttpServiceStats{
-					ServiceStats: ServiceStats{
-						Address:  l.Address,
-						Protocol: getHttpProtocol(l.ProtocolVersion),
-					},
-					RequestsReceived: HttpRequestsReceivedList{},
-					RequestsHandled:  HttpRequestsHandledList{},
-				}
-			}
-
-		}
-	}
-	for i, c := range tcpconnections {
-		tcpServices.updateTcpConnectionStats(sites[i].SiteId, c, iplookup)
-	}
-	for i, r := range httpRequests {
-		httpServices.updateHttpRequestStats(sites[i].SiteId, r, iplookup)
-	}
-
-	services := []interface{}{}
-	for _, s := range httpServices {
-		services = append(services, s)
-	}
-	for _, s := range tcpServices {
-		services = append(services, s)
-	}
-	return services
-}
-
-func getPeerIdentifier(addr string, iplookup *IpLookup) string {
-	parts := strings.Split(addr, ":")
-	peer := iplookup.getPodName(parts[0])
-	if peer == "" {
-		peer = parts[0]
-	}
-	return peer
-}
-
-type ConnectionStatsIndex map[string]map[string]ConnectionStats
-
-func asConnectionStats(connection *qdr.TcpConnection, iplookup *IpLookup) ConnectionStats {
-	stats := ConnectionStats{
-		Id:        connection.Name,
-		StartTime: connection.Uptime,
-		LastOut:   connection.LastOut,
-		LastIn:    connection.LastIn,
-		BytesIn:   connection.BytesIn,
-		BytesOut:  connection.BytesOut,
-	}
-	peer := getPeerIdentifier(connection.Host, iplookup)
-	if connection.Direction == "in" {
-		stats.Client = peer
-	} else {
-		stats.Server = peer
-	}
-	return stats
-}
-
-func (index ConnectionStatsIndex) updateTcpConnectionStats(c qdr.TcpConnection, iplookup *IpLookup) {
-	byId, ok := index[c.Address]
-	if ok {
-		byId[c.Name] = asConnectionStats(&c, iplookup)
-	} else {
-		index[c.Address] = map[string]ConnectionStats{
-			c.Name: asConnectionStats(&c, iplookup),
-		}
-	}
-}
-
-func (services TcpServiceStatsMap) updateTcpConnectionStats(siteId string, connections []qdr.TcpConnection, iplookup *IpLookup) {
-	log.Printf("Updating tcp connection stats for %s %d", siteId, len(connections))
-	ingress := ConnectionStatsIndex{}
-	egress := ConnectionStatsIndex{}
-	for _, c := range connections {
-		if c.Direction == "in" {
-			ingress.updateTcpConnectionStats(c, iplookup)
-		} else {
-			egress.updateTcpConnectionStats(c, iplookup)
-		}
-	}
-	for _, service := range services {
-		if ingress[service.Address] != nil {
-			service.ConnectionsIngress = append(service.ConnectionsIngress, SiteConnections{
-				SiteId:      siteId,
-				Connections: ingress[service.Address],
-			})
-		}
-		if egress[service.Address] != nil {
-			service.ConnectionsEgress = append(service.ConnectionsEgress, SiteConnections{
-				SiteId:      siteId,
-				Connections: egress[service.Address],
-			})
-		}
-		services[service.Address] = service
-		log.Printf("Adding site connection stats for %s to %s (%d %d)", siteId, service.Address, len(service.ConnectionsIngress), len(service.ConnectionsEgress))
-	}
-}
-
-type RequestStatsIndex map[string]map[string]HttpRequestStats
-
-func asHttpRequestStats(r *qdr.HttpRequestInfo) HttpRequestStats {
-	stats := HttpRequestStats{
-		Requests:   r.Requests,
-		LatencyMax: r.MaxLatency,
-		BytesIn:    r.BytesIn,
-		BytesOut:   r.BytesOut,
-		Details:    r.Details,
-	}
-	if r.Direction == "in" {
-		stats.ByHandlingSite = map[string]HttpRequestStats{
-			r.Site: stats,
-		}
-	}
-	return stats
-}
-
-func (index RequestStatsIndex) indexByHost(r *qdr.HttpRequestInfo, iplookup *IpLookup) {
-	host := iplookup.getPodName(r.Host)
-	if host == "" {
-		host = r.Host
-	}
-	_, ok := index[r.Address]
-	if ok {
-		stats, ok := index[r.Address][host]
-		if ok {
-			s := asHttpRequestStats(r)
-			stats.merge(&s)
-		} else {
-			stats = asHttpRequestStats(r)
-		}
-		index[r.Address][host] = stats
-	} else {
-		index[r.Address] = map[string]HttpRequestStats{
-			host: asHttpRequestStats(r),
-		}
-	}
-}
-
-func (index RequestStatsIndex) indexBySite(r *qdr.HttpRequestInfo) {
-	_, ok := index[r.Address]
-	if ok {
-		stats, ok := index[r.Address][r.Site]
-		if ok {
-			s := asHttpRequestStats(r)
-			stats.merge(&s)
-		} else {
-			stats = asHttpRequestStats(r)
-		}
-		index[r.Address][r.Site] = stats
-	} else {
-		index[r.Address] = map[string]HttpRequestStats{
-			r.Site: asHttpRequestStats(r),
-		}
-	}
-}
-
-func (services HttpServiceStatsMap) updateHttpRequestStats(siteId string, requests []qdr.HttpRequestInfo, iplookup *IpLookup) {
-	log.Printf("Updating http request stats for %s %d", siteId, len(requests))
-	byClient := RequestStatsIndex{}
-	byServer := RequestStatsIndex{}
-	byOriginatingSite := RequestStatsIndex{}
-	for _, r := range requests {
-		if r.Direction == "in" {
-			byClient.indexByHost(&r, iplookup)
-		} else {
-			byServer.indexByHost(&r, iplookup)
-			byOriginatingSite.indexBySite(&r)
-		}
-	}
-	log.Printf("Indexed http request stats for %s by client %#v by server %#v", siteId, byClient, byServer)
-	for _, service := range services {
-		if byClient[service.Address] != nil {
-			service.RequestsReceived = append(service.RequestsReceived, HttpRequestsReceived{
-				SiteId:   siteId,
-				ByClient: byClient[service.Address],
-			})
-		}
-		if byServer[service.Address] != nil || byOriginatingSite[service.Address] != nil {
-			service.RequestsHandled = append(service.RequestsHandled, HttpRequestsHandled{
-				SiteId:            siteId,
-				ByServer:          byServer[service.Address],
-				ByOriginatingSite: byOriginatingSite[service.Address],
-			})
-		}
-		services[service.Address] = service
-		log.Printf("Adding site request stats for %s to %s (%d %d)", siteId, service.Address, len(service.RequestsReceived), len(service.RequestsHandled))
-	}
-}
-
-type Site struct {
-	SiteName  string   `json:"site_name"`
-	SiteId    string   `json:"site_id"`
-	Version   string   `json:"version"`
-	Connected []string `json:"connected"`
-	Namespace string   `json:"namespace"`
-	Url       string   `json:"url"`
-	Edge      bool     `json:"edge"`
-}
-
-func replace(in []string, lookup map[string]string) []string {
-	out := make([]string, len(in))
-	for i, s := range in {
-		out[i] = lookup[s]
-	}
-	return out
-}
-
-func getSiteInfo(routers []qdr.Router) []Site {
-	sites := map[string]Site{}
-	lookup := map[string]string{}
+func getAllSites(routers []qdr.Router) []data.SiteQueryData {
+	sites := map[string]data.SiteQueryData{}
+	routerToSite := map[string]string{}
+	siteConnections := map[string]map[string]bool{}
 	for _, r := range routers {
-		if strings.Contains(r.Id, "skupper-router") {
-			lookup[r.Id] = r.Site.Id
-		}
-	}
-	for _, r := range routers {
-		if strings.Contains(r.Id, "skupper-router") {
-			if site, ok := sites[r.Site.Id]; ok {
-				site.Connected = append(site.Connected, replace(r.ConnectedTo, lookup)...)
-				sites[r.Site.Id] = site
-				log.Printf("Updating site %s based on router %s ", r.Site.Id, r.Id)
-			} else {
-				sites[r.Site.Id] = Site{
+		routerToSite[r.Id] = r.Site.Id
+		site, exists := sites[r.Site.Id]
+		if !exists {
+			sites[r.Site.Id] = data.SiteQueryData{
+				Site: data.Site{
 					SiteId:    r.Site.Id,
-					Connected: replace(r.ConnectedTo, lookup),
-					Edge:      r.Edge,
-				}
-				log.Printf("Adding site %s based on router %s ", r.Site.Id, r.Id)
+					Version:   r.Site.Version,
+					Edge:      r.Edge && strings.Contains(r.Id, "skupper-router"),
+					Connected: []string{},
+				},
 			}
-		} else {
-			log.Printf("Skipping router %s", r.Id)
+		} else if r.Site.Version != site.Version {
+			log.Printf("Conflicting site version for %s: %s != %s", site.SiteId, site.Version, r.Site.Version)
 		}
 	}
-	sitelist := []Site{}
-	for _, s := range sites {
-		sitelist = append(sitelist, s)
-	}
-	log.Printf("Sites: %v %v", sites, sitelist)
-	return sitelist
-}
-
-type ConsoleData struct {
-	Sites    []Site        `json:"sites"`
-	Services []interface{} `json:"services"`
-}
-
-func getSiteRouters(routers []qdr.Router) []qdr.Router {
-	sites := map[string]qdr.Router{}
 	for _, r := range routers {
-		if strings.Contains(r.Id, "skupper-router") {
-			sites[r.Site.Id] = r
+		for _, id := range r.ConnectedTo {
+			set(siteConnections, r.Site.Id, routerToSite[id])
 		}
 	}
-	list := []qdr.Router{}
-	for _, r := range sites {
-		list = append(list, r)
+	list := []data.SiteQueryData{}
+	for _, s := range sites {
+		m := siteConnections[s.SiteId]
+		for key, _ := range m {
+			s.Connected = append(s.Connected, key)
+		}
+		list = append(list, s)
 	}
 	return list
 }
 
-func getConsoleData(agent *qdr.Agent, iplookup *IpLookup) (*ConsoleData, error) {
+func getConsoleData(agent *qdr.Agent) (*data.ConsoleData, error) {
 	routers, err := agent.GetAllRouters()
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving routers: %s", err)
 	}
-	//TODO: handle multiple routers per site, for now ensure we only have one router per site
-	routers = getSiteRouters(routers)
-	bridges, err := agent.GetBridges(routers)
-	if err != nil {
-		return nil, fmt.Errorf("Error retrieving bridge configuration: %s", err)
+	sites := getAllSites(routers)
+	querySites(agent, sites)
+	for i, s := range sites {
+		if s.Version == "" {
+			// prior to 0.5 there was no version in router metadata
+			// and site query did not return services, so they are
+			// retrieved here separately
+			err = getServiceInfo(agent, routers, &sites[i], data.NewNullNameMapping())
+			if err != nil {
+				return nil, fmt.Errorf("Error retrieving service data from old site %s: %s", s.SiteId, err)
+			}
+		}
 	}
-	tcpConns, err := agent.GetTcpConnections(routers)
-	if err != nil {
-		return nil, fmt.Errorf("Error retrieving tcp connection stats: %s", err)
-	}
-	httpReqs, err := agent.GetHttpRequestInfo(routers)
-	if err != nil {
-		return nil, fmt.Errorf("Error retrieving http request stats: %s", err)
-	}
-	log.Printf("Bridge data: %#v", bridges)
-	data := ConsoleData{
-		Sites: getSiteInfo(routers),
-	}
-	data.Services = getServiceStats(bridges, data.Sites, tcpConns, httpReqs, iplookup)
-	//query each site for remaining information
-	err = getAllSiteInfo(agent, data.Sites)
-	if err != nil {
-		return nil, fmt.Errorf("Error with site queries: %s", err)
-	}
-	return &data, nil
+	consoleData := &data.ConsoleData{}
+	consoleData.Merge(sites)
+	return consoleData, nil
 }

--- a/cmd/service-controller/ip_lookup.go
+++ b/cmd/service-controller/ip_lookup.go
@@ -51,6 +51,17 @@ func (i *IpLookup) getPodName(ip string) string {
 	return i.lookup[ip]
 }
 
+//support data.NameMapping interface
+func (i *IpLookup) Lookup(ip string) string {
+	name := i.getPodName(ip)
+	log.Printf("LOOKUP: %s -> %s", ip, name)
+	if name == "" {
+		return ip
+	} else {
+		return name
+	}
+}
+
 func (i *IpLookup) translateKeys(ips map[string]interface{}) map[string]interface{} {
 	out := map[string]interface{}{}
 	i.lock.RLock()

--- a/pkg/data/http.go
+++ b/pkg/data/http.go
@@ -1,0 +1,260 @@
+package data
+
+import (
+	"github.com/skupperproject/skupper/pkg/qdr"
+)
+
+type HttpRequestsHandledList []HttpRequestsHandled
+type HttpRequestsReceivedList []HttpRequestsReceived
+
+type HttpService struct {
+	Service
+	RequestsReceived HttpRequestsReceivedList `json:"requests_received"`
+	RequestsHandled  HttpRequestsHandledList  `json:"requests_handled"`
+}
+
+type HttpServiceMap map[string]HttpService
+type HttpRequestStatsMap map[string]HttpRequestStats
+
+type HttpRequestsReceived struct {
+	SiteId   string              `json:"site_id"`
+	ByClient HttpRequestStatsMap `json:"by_client,omitempty"`
+}
+
+type HttpRequestsHandled struct {
+	SiteId            string              `json:"site_id"`
+	ByServer          HttpRequestStatsMap `json:"by_server,omitempty"`
+	ByOriginatingSite HttpRequestStatsMap `json:"by_originating_site,omitempty"`
+}
+
+type DetailsMap map[string]int
+
+type HttpRequestStats struct {
+	Requests       int                 `json:"requests"`
+	BytesIn        int                 `json:"bytes_in"`
+	BytesOut       int                 `json:"bytes_out"`
+	Details        DetailsMap          `json:"details"`
+	LatencyMax     int                 `json:"latency_max"`
+	ByHandlingSite HttpRequestStatsMap `json:"by_handling_site,omitempty"`
+}
+
+func max(a int, b int) int {
+	if b > a {
+		return b
+	} else {
+		return a
+	}
+}
+
+func (a DetailsMap) merge(b DetailsMap) DetailsMap {
+	c := DetailsMap{}
+	for k, v := range a {
+		c[k] = v
+	}
+	for k, v := range b {
+		if s, ok := c[k]; ok {
+			c[k] = s + v
+		} else {
+			c[k] = v
+		}
+	}
+	return c
+}
+
+func (a *HttpRequestStats) merge(b *HttpRequestStats) {
+	a.Requests += b.Requests
+	a.BytesIn += b.BytesIn
+	a.BytesOut += b.BytesOut
+	a.LatencyMax = max(a.LatencyMax, b.LatencyMax)
+	if a.Details == nil {
+		a.Details = b.Details
+	} else if b.Details != nil {
+		a.Details = a.Details.merge(b.Details)
+	}
+	if a.ByHandlingSite == nil {
+		a.ByHandlingSite = b.ByHandlingSite
+	} else if b.ByHandlingSite != nil {
+		a.ByHandlingSite.merge(b.ByHandlingSite)
+	}
+}
+
+func (a HttpRequestStatsMap) merge(b HttpRequestStatsMap) {
+	for k, v := range b {
+		if s, ok := a[k]; ok {
+			s.merge(&v)
+			a[k] = s
+		} else {
+			a[k] = v
+		}
+	}
+}
+
+func (a *HttpRequestsReceived) merge(b *HttpRequestsReceived) {
+	if a.ByClient == nil {
+		a.ByClient = b.ByClient
+	} else if b.ByClient != nil {
+		a.ByClient.merge(b.ByClient)
+	}
+}
+
+func (a *HttpRequestsHandled) merge(b *HttpRequestsHandled) {
+	if a.ByServer == nil {
+		a.ByServer = b.ByServer
+	} else if b.ByServer != nil {
+		a.ByServer.merge(b.ByServer)
+	}
+	if a.ByOriginatingSite == nil {
+		a.ByOriginatingSite = b.ByOriginatingSite
+	} else if b.ByOriginatingSite != nil {
+		a.ByOriginatingSite.merge(b.ByOriginatingSite)
+	}
+}
+
+func (service *HttpService) mergeReceived(r *HttpRequestsReceived) {
+	found := false
+	for _, entry := range service.RequestsReceived {
+		if entry.SiteId == r.SiteId {
+			entry.merge(r)
+			found = true
+		}
+	}
+	if !found {
+		service.RequestsReceived = append(service.RequestsReceived, *r)
+	}
+}
+
+func (service *HttpService) mergeHandled(r *HttpRequestsHandled) {
+	found := false
+	for _, entry := range service.RequestsHandled {
+		if entry.SiteId == r.SiteId {
+			entry.merge(r)
+			found = true
+		}
+	}
+	if !found {
+		service.RequestsHandled = append(service.RequestsHandled, *r)
+	}
+}
+
+func getHttpProtocol(protocolVersion string) string {
+	if protocolVersion == qdr.HttpVersion2 {
+		return "http2"
+	} else {
+		return "http"
+	}
+}
+
+func asHttpRequestStats(r *qdr.HttpRequestInfo) HttpRequestStats {
+	stats := HttpRequestStats{
+		Requests:   r.Requests,
+		LatencyMax: r.MaxLatency,
+		BytesIn:    r.BytesIn,
+		BytesOut:   r.BytesOut,
+		Details:    r.Details,
+	}
+	if r.Direction == qdr.DirectionIn {
+		stats.ByHandlingSite = HttpRequestStatsMap{
+			r.Site: stats,
+		}
+	}
+	return stats
+}
+
+func (index HttpServiceMap) merge(services []HttpService) {
+	for _, s := range services {
+		if service, ok := index[s.Address]; ok {
+			if s.Targets != nil {
+				service.Targets = append(service.Targets, s.Targets...)
+			}
+			for _, received := range s.RequestsReceived {
+				service.mergeReceived(&received)
+			}
+			for _, handled := range s.RequestsHandled {
+				service.mergeHandled(&handled)
+			}
+			index[s.Address] = service
+		} else {
+			index[s.Address] = s
+		}
+	}
+}
+
+func (index HttpServiceMap) Update(siteId string, requests []qdr.HttpRequestInfo, mapping NameMapping) {
+	for _, r := range requests {
+		host := mapping.Lookup(r.Host)
+		stats := asHttpRequestStats(&r)
+		if service, ok := index[r.Address]; ok {
+			if r.Direction == qdr.DirectionIn {
+				received := HttpRequestsReceived{
+					SiteId: siteId,
+					ByClient: HttpRequestStatsMap{
+						host: stats,
+					},
+				}
+				service.mergeReceived(&received)
+			} else {
+				handled := HttpRequestsHandled{
+					SiteId: siteId,
+					ByServer: HttpRequestStatsMap{
+						host: stats,
+					},
+					ByOriginatingSite: HttpRequestStatsMap{
+						r.Site: stats,
+					},
+				}
+				service.mergeHandled(&handled)
+			}
+			index[r.Address] = service
+		}
+	}
+}
+
+func (index HttpServiceMap) AddTargets(connectors []qdr.HttpEndpoint, mapping NameMapping) {
+	for _, c := range connectors {
+		service, ok := index[c.Address]
+		if !ok {
+			service = HttpService{
+				Service: Service{
+					Address:  c.Address,
+					Protocol: getHttpProtocol(c.ProtocolVersion),
+				},
+			}
+		}
+		service.AddTarget(c.Name, c.Host, c.SiteId, mapping)
+		index[c.Address] = service
+	}
+}
+
+func (index HttpServiceMap) AddServices(listeners []qdr.HttpEndpoint) {
+	for _, l := range listeners {
+		if _, ok := index[l.Address]; !ok {
+			service := HttpService{
+				Service: Service{
+					Address:  l.Address,
+					Protocol: getHttpProtocol(l.ProtocolVersion),
+				},
+			}
+			index[l.Address] = service
+		}
+	}
+}
+
+func (index HttpServiceMap) AsList() []HttpService {
+	list := []HttpService{}
+	for _, v := range index {
+		list = append(list, v)
+	}
+	return list
+}
+
+func GetHttpServices(siteId string, info [][]qdr.HttpRequestInfo, targets []qdr.HttpEndpoint, listeners []qdr.HttpEndpoint, lookup NameMapping) []HttpService {
+	flattened := []qdr.HttpRequestInfo{}
+	for _, l := range info {
+		flattened = append(flattened, l...)
+	}
+	services := HttpServiceMap{}
+	services.AddServices(listeners)
+	services.Update(siteId, flattened, lookup)
+	services.AddTargets(targets, lookup)
+	return services.AsList()
+}

--- a/pkg/data/http_test.go
+++ b/pkg/data/http_test.go
@@ -1,0 +1,351 @@
+package data
+
+import (
+	"github.com/skupperproject/skupper/pkg/qdr"
+	"reflect"
+	"testing"
+)
+
+type TestMapping struct {
+	mapping map[string]string
+}
+
+func (t *TestMapping) Lookup(name string) string {
+	if v, ok := t.mapping[name]; ok {
+		return v
+	} else {
+		return name
+	}
+}
+
+func GetTestMapping(mapping map[string]string) NameMapping {
+	return &TestMapping{
+		mapping: mapping,
+	}
+}
+
+func TestGetHttpServices(t *testing.T) {
+	siteId := "mysite"
+	router1Stats := []qdr.HttpRequestInfo{
+		qdr.HttpRequestInfo{
+			Name:       "ai",
+			Host:       "1.1.1.1",
+			Address:    "foo",
+			Site:       siteId,
+			Direction:  "in",
+			Requests:   5,
+			BytesIn:    100,
+			BytesOut:   2500,
+			MaxLatency: 10,
+			Details: map[string]int{
+				"GET:200":  3,
+				"POST:404": 2,
+			},
+		},
+		qdr.HttpRequestInfo{
+			Name:       "bi1",
+			Host:       "1.1.1.1",
+			Address:    "bar",
+			Site:       siteId,
+			Direction:  "in",
+			Requests:   3,
+			BytesIn:    300,
+			BytesOut:   300,
+			MaxLatency: 3,
+			Details: map[string]int{
+				"GET:200": 1,
+				"PUT:201": 2,
+			},
+		},
+		qdr.HttpRequestInfo{
+			Name:       "bi2",
+			Host:       "1.1.1.1",
+			Address:    "bar",
+			Site:       siteId,
+			Direction:  "in",
+			Requests:   1,
+			BytesIn:    100,
+			BytesOut:   100,
+			MaxLatency: 2,
+			Details: map[string]int{
+				"GET:200": 1,
+			},
+		},
+	}
+	router2Stats := []qdr.HttpRequestInfo{
+		qdr.HttpRequestInfo{
+			Name:       "ao1",
+			Host:       "2.2.2.2",
+			Address:    "foo",
+			Site:       siteId,
+			Direction:  "out",
+			Requests:   3,
+			BytesIn:    70,
+			BytesOut:   2300,
+			MaxLatency: 10,
+			Details: map[string]int{
+				"GET:200":  2,
+				"POST:404": 1,
+			},
+		},
+		qdr.HttpRequestInfo{
+			Name:       "ao2",
+			Host:       "3.3.3.3",
+			Address:    "foo",
+			Site:       siteId,
+			Direction:  "out",
+			Requests:   1,
+			BytesIn:    20,
+			BytesOut:   180,
+			MaxLatency: 15,
+			Details: map[string]int{
+				"GET:200": 1,
+			},
+		},
+		qdr.HttpRequestInfo{
+			Name:       "ao2",
+			Host:       "3.3.3.3",
+			Address:    "foo",
+			Site:       siteId,
+			Direction:  "out",
+			Requests:   1,
+			BytesIn:    10,
+			BytesOut:   20,
+			MaxLatency: 5,
+			Details: map[string]int{
+				"POST:404": 1,
+			},
+		},
+	}
+	routerStats := [][]qdr.HttpRequestInfo{
+		router1Stats,
+		router2Stats,
+	}
+	targets := []qdr.HttpEndpoint{
+		qdr.HttpEndpoint{
+			Name:    "c1",
+			Host:    "3.3.3.3",
+			Address: "foo",
+			SiteId:  siteId,
+		},
+		qdr.HttpEndpoint{
+			Name:    "c2",
+			Host:    "2.2.2.2",
+			Address: "foo",
+			SiteId:  siteId,
+		},
+		qdr.HttpEndpoint{
+			Name:    "c3",
+			Host:    "4.4.4.4",
+			Address: "bar",
+			SiteId:  siteId,
+		},
+	}
+	listeners := []qdr.HttpEndpoint{
+		qdr.HttpEndpoint{
+			Name:    "l1",
+			Address: "foo",
+			SiteId:  siteId,
+		},
+		qdr.HttpEndpoint{
+			Name:            "l2",
+			Address:         "bar",
+			ProtocolVersion: qdr.HttpVersion2,
+			SiteId:          siteId,
+		},
+	}
+	mapping := GetTestMapping(map[string]string{
+		"2.2.2.2": "myhost",
+		"4.4.4.4": "",
+	})
+
+	services := GetHttpServices(siteId, routerStats, targets, listeners, mapping)
+	if services == nil {
+		t.Errorf("Got nil services list")
+	}
+	expected := map[string]HttpService{
+		"foo": HttpService{
+			Service: Service{
+				Address:  "foo",
+				Protocol: "http",
+				Targets: []ServiceTarget{
+					ServiceTarget{
+						Target: "c1",
+						Name:   "3.3.3.3",
+						SiteId: siteId,
+					},
+					ServiceTarget{
+						Target: "c2",
+						Name:   "myhost",
+						SiteId: siteId,
+					},
+				},
+			},
+			RequestsReceived: []HttpRequestsReceived{
+				HttpRequestsReceived{
+					SiteId: siteId,
+					ByClient: map[string]HttpRequestStats{
+						"1.1.1.1": HttpRequestStats{
+							Requests: 5,
+							BytesIn:  100,
+							BytesOut: 2500,
+							Details: map[string]int{
+								"GET:200":  3,
+								"POST:404": 2,
+							},
+							LatencyMax: 10,
+							ByHandlingSite: map[string]HttpRequestStats{
+								siteId: HttpRequestStats{
+									Requests: 5,
+									BytesIn:  100,
+									BytesOut: 2500,
+									Details: map[string]int{
+										"GET:200":  3,
+										"POST:404": 2,
+									},
+									LatencyMax: 10,
+								},
+							},
+						},
+					},
+				},
+			},
+			RequestsHandled: []HttpRequestsHandled{
+				HttpRequestsHandled{
+					SiteId: siteId,
+					ByServer: map[string]HttpRequestStats{
+						"myhost": HttpRequestStats{
+							Requests: 3,
+							BytesIn:  70,
+							BytesOut: 2300,
+							Details: map[string]int{
+								"GET:200":  2,
+								"POST:404": 1,
+							},
+							LatencyMax: 10,
+						},
+						"3.3.3.3": HttpRequestStats{
+							Requests: 2,
+							BytesIn:  30,
+							BytesOut: 200,
+							Details: map[string]int{
+								"GET:200":  1,
+								"POST:404": 1,
+							},
+							LatencyMax: 15,
+						},
+					},
+					ByOriginatingSite: map[string]HttpRequestStats{
+						siteId: HttpRequestStats{
+							Requests: 5,
+							BytesIn:  100,
+							BytesOut: 2500,
+							Details: map[string]int{
+								"GET:200":  3,
+								"POST:404": 2,
+							},
+							LatencyMax: 15,
+						},
+					},
+				},
+			},
+		},
+		"bar": HttpService{
+			Service: Service{
+				Address:  "bar",
+				Protocol: "http2",
+				Targets: []ServiceTarget{
+					ServiceTarget{
+						Target: "c3",
+						Name:   "",
+						SiteId: siteId,
+					},
+				},
+			},
+			RequestsReceived: []HttpRequestsReceived{
+				HttpRequestsReceived{
+					SiteId: siteId,
+					ByClient: map[string]HttpRequestStats{
+						"1.1.1.1": HttpRequestStats{
+							Requests: 4,
+							BytesIn:  400,
+							BytesOut: 400,
+							Details: map[string]int{
+								"GET:200": 2,
+								"PUT:201": 2,
+							},
+							LatencyMax: 3,
+							ByHandlingSite: map[string]HttpRequestStats{
+								siteId: HttpRequestStats{
+									Requests: 4,
+									BytesIn:  400,
+									BytesOut: 400,
+									Details: map[string]int{
+										"GET:200": 2,
+										"PUT:201": 2,
+									},
+									LatencyMax: 3,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if len(services) != len(expected) {
+		t.Errorf("Expected %d services, got %d", len(expected), len(services))
+	}
+	for _, s := range services {
+		e := expected[s.Address]
+		if !reflect.DeepEqual(e.Service, s.Service) {
+			t.Errorf("Incorrect service definition for %s; expected %v, got %v", e.Service.Address, e.Service, s.Service)
+		}
+		if !reflect.DeepEqual(e.RequestsReceived, s.RequestsReceived) {
+			t.Errorf("Incorrect requests-received for %s; expected %v, got %v", e.Service.Address, e.RequestsReceived, s.RequestsReceived)
+		}
+		if !reflect.DeepEqual(e.RequestsHandled, s.RequestsHandled) {
+			t.Errorf("Incorrect requests-handled for %s; expected %v, got %v", e.Service.Address, e.RequestsHandled, s.RequestsHandled)
+		}
+	}
+}
+
+func TestTargetDefinesService(t *testing.T) {
+	siteId := "whatever"
+	routerStats := [][]qdr.HttpRequestInfo{}
+	targets := []qdr.HttpEndpoint{
+		qdr.HttpEndpoint{
+			Name:    "c1",
+			Host:    "3.3.3.3",
+			Address: "foo",
+			SiteId:  siteId,
+		},
+	}
+	listeners := []qdr.HttpEndpoint{}
+	mapping := NewNullNameMapping()
+	services := GetHttpServices(siteId, routerStats, targets, listeners, mapping)
+	if services == nil {
+		t.Errorf("Got nil services list")
+	}
+	expected := map[string]HttpService{
+		"foo": HttpService{
+			Service: Service{
+				Address:  "foo",
+				Protocol: "http",
+				Targets: []ServiceTarget{
+					ServiceTarget{
+						Target: "c1",
+						Name:   "3.3.3.3",
+						SiteId: siteId,
+					},
+				},
+			},
+		},
+	}
+	for _, s := range services {
+		e := expected[s.Address]
+		if !reflect.DeepEqual(e.Service, s.Service) {
+			t.Errorf("Incorrect service definition for %s; expected %v, got %v", e.Service.Address, e.Service, s.Service)
+		}
+	}
+}

--- a/pkg/data/query.go
+++ b/pkg/data/query.go
@@ -1,0 +1,63 @@
+package data
+
+type ConsoleData struct {
+	Sites    []Site        `json:"sites"`
+	Services []interface{} `json:"services"`
+}
+
+type SiteQueryData struct {
+	Site
+	TcpServices  []TcpService  `json:"tcp_services"`
+	HttpServices []HttpService `json:"http_services"`
+}
+
+//Used for interacting with 0.4.x sites
+type LegacySiteInfo struct {
+	SiteId    string
+	SiteName  string
+	Version   string
+	Namespace string
+	Url       string
+}
+
+func (s *Site) AsLegacySiteInfo() *LegacySiteInfo {
+	return &LegacySiteInfo{
+		SiteId:    s.SiteId,
+		SiteName:  s.SiteName,
+		Version:   s.Version,
+		Namespace: s.Namespace,
+		Url:       s.Url,
+	}
+}
+
+func (c *ConsoleData) Merge(data []SiteQueryData) {
+	http := HttpServiceMap{}
+	tcp := TcpServiceMap{}
+	for _, d := range data {
+		c.Sites = append(c.Sites, d.Site)
+		http.merge(d.HttpServices)
+		tcp.merge(d.TcpServices)
+	}
+	c.Services = []interface{}{}
+	for _, s := range http {
+		c.Services = append(c.Services, s)
+	}
+	for _, s := range tcp {
+		c.Services = append(c.Services, s)
+	}
+}
+
+type NameMapping interface {
+	Lookup(name string) string
+}
+
+type NullNameMapping struct {
+}
+
+func (n *NullNameMapping) Lookup(name string) string {
+	return name
+}
+
+func NewNullNameMapping() NameMapping {
+	return &NullNameMapping{}
+}

--- a/pkg/data/query_test.go
+++ b/pkg/data/query_test.go
@@ -1,0 +1,528 @@
+package data
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConsoleDataMerge(t *testing.T) {
+	data := ConsoleData{}
+	one := SiteQueryData{
+		Site: Site{
+			SiteName: "one",
+			SiteId:   "1",
+			Version:  "abc",
+			Connected: []string{
+				"two",
+			},
+			Namespace: "default",
+			Url:       "http:some.cluster.com",
+			Edge:      false,
+		},
+		TcpServices: []TcpService{
+			TcpService{
+				Service: Service{
+					Address:  "a",
+					Protocol: "tcp",
+					Targets: []ServiceTarget{
+						ServiceTarget{
+							Target: "c2",
+							Name:   "3.3.3.3",
+							SiteId: "one",
+						},
+						ServiceTarget{
+							Target: "c3",
+							Name:   "4.4.4.4",
+							SiteId: "one",
+						},
+					},
+				},
+				ConnectionsIngress: []TcpServiceEndpoints{
+					TcpServiceEndpoints{
+						SiteId: "one",
+						Connections: map[string]TcpConnectionStats{
+							"a1": TcpConnectionStats{
+								Id:        "a1",
+								StartTime: 60,
+								LastOut:   4,
+								LastIn:    5,
+								BytesIn:   10,
+								BytesOut:  20,
+								Client:    "1.1.1.1",
+							},
+							"a2": TcpConnectionStats{
+								Id:        "a2",
+								StartTime: 90,
+								LastOut:   9,
+								LastIn:    10,
+								BytesIn:   40,
+								BytesOut:  80,
+								Client:    "2.2.2.2",
+							},
+						},
+					},
+				},
+				ConnectionsEgress: []TcpServiceEndpoints{
+					TcpServiceEndpoints{
+						SiteId: "one",
+						Connections: map[string]TcpConnectionStats{
+							"a1": TcpConnectionStats{
+								Id:        "a1",
+								StartTime: 60,
+								LastOut:   4,
+								LastIn:    5,
+								BytesIn:   20,
+								BytesOut:  10,
+								Server:    "3.3.3.3",
+							},
+							"a2": TcpConnectionStats{
+								Id:        "a2",
+								StartTime: 90,
+								LastOut:   10,
+								LastIn:    9,
+								BytesIn:   80,
+								BytesOut:  40,
+								Server:    "4.4.4.4",
+							},
+						},
+					},
+				},
+			},
+			TcpService{
+				Service: Service{
+					Address:  "b",
+					Protocol: "tcp",
+					Targets: []ServiceTarget{
+						ServiceTarget{
+							Target: "c1",
+							Name:   "1.1.1.1",
+							SiteId: "one",
+						},
+					},
+				},
+				ConnectionsIngress: []TcpServiceEndpoints{
+					TcpServiceEndpoints{
+						SiteId: "one",
+						Connections: map[string]TcpConnectionStats{
+							"b1": TcpConnectionStats{
+								Id:        "b1",
+								StartTime: 120,
+								LastOut:   1,
+								LastIn:    1,
+								BytesIn:   15,
+								BytesOut:  15,
+								Client:    "5.5.5.5",
+							},
+						},
+					},
+				},
+				ConnectionsEgress: []TcpServiceEndpoints{
+					TcpServiceEndpoints{
+						SiteId: "one",
+						Connections: map[string]TcpConnectionStats{
+							"b1": TcpConnectionStats{
+								Id:        "b1",
+								StartTime: 120,
+								LastOut:   1,
+								LastIn:    1,
+								BytesIn:   15,
+								BytesOut:  15,
+								Server:    "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+			TcpService{
+				Service: Service{
+					Address:  "c",
+					Protocol: "tcp",
+					Targets: []ServiceTarget{
+						ServiceTarget{
+							Target: "c4",
+							Name:   "6.6.6.6",
+							SiteId: "one",
+						},
+					},
+				},
+			},
+		},
+		HttpServices: []HttpService{
+			HttpService{
+				Service: Service{
+					Address:  "foo",
+					Protocol: "http",
+					Targets: []ServiceTarget{
+						ServiceTarget{
+							Target: "c1",
+							Name:   "3.3.3.3",
+							SiteId: "one",
+						},
+						ServiceTarget{
+							Target: "c2",
+							Name:   "myhost",
+							SiteId: "one",
+						},
+					},
+				},
+				RequestsReceived: []HttpRequestsReceived{
+					HttpRequestsReceived{
+						SiteId: "one",
+						ByClient: map[string]HttpRequestStats{
+							"1.1.1.1": HttpRequestStats{
+								Requests: 5,
+								BytesIn:  100,
+								BytesOut: 2500,
+								Details: map[string]int{
+									"GET:200":  3,
+									"POST:404": 2,
+								},
+								LatencyMax: 10,
+								ByHandlingSite: map[string]HttpRequestStats{
+									"one": HttpRequestStats{
+										Requests: 5,
+										BytesIn:  100,
+										BytesOut: 2500,
+										Details: map[string]int{
+											"GET:200":  3,
+											"POST:404": 2,
+										},
+										LatencyMax: 10,
+									},
+								},
+							},
+						},
+					},
+				},
+				RequestsHandled: []HttpRequestsHandled{
+					HttpRequestsHandled{
+						SiteId: "one",
+						ByServer: map[string]HttpRequestStats{
+							"myhost": HttpRequestStats{
+								Requests: 3,
+								BytesIn:  70,
+								BytesOut: 2300,
+								Details: map[string]int{
+									"GET:200":  2,
+									"POST:404": 1,
+								},
+								LatencyMax: 10,
+							},
+							"3.3.3.3": HttpRequestStats{
+								Requests: 2,
+								BytesIn:  30,
+								BytesOut: 200,
+								Details: map[string]int{
+									"GET:200":  1,
+									"POST:404": 1,
+								},
+								LatencyMax: 15,
+							},
+						},
+						ByOriginatingSite: map[string]HttpRequestStats{
+							"one": HttpRequestStats{
+								Requests: 5,
+								BytesIn:  100,
+								BytesOut: 2500,
+								Details: map[string]int{
+									"GET:200":  3,
+									"POST:404": 2,
+								},
+								LatencyMax: 15,
+							},
+						},
+					},
+				},
+			},
+			HttpService{
+				Service: Service{
+					Address:  "bar",
+					Protocol: "http2",
+					Targets: []ServiceTarget{
+						ServiceTarget{
+							Target: "c3",
+							Name:   "",
+							SiteId: "one",
+						},
+					},
+				},
+				RequestsReceived: []HttpRequestsReceived{
+					HttpRequestsReceived{
+						SiteId: "one",
+						ByClient: map[string]HttpRequestStats{
+							"1.1.1.1": HttpRequestStats{
+								Requests: 4,
+								BytesIn:  400,
+								BytesOut: 400,
+								Details: map[string]int{
+									"GET:200": 2,
+									"PUT:201": 2,
+								},
+								LatencyMax: 3,
+								ByHandlingSite: map[string]HttpRequestStats{
+									"one": HttpRequestStats{
+										Requests: 4,
+										BytesIn:  400,
+										BytesOut: 400,
+										Details: map[string]int{
+											"GET:200": 2,
+											"PUT:201": 2,
+										},
+										LatencyMax: 3,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	two := SiteQueryData{
+		Site: Site{
+			SiteName:  "two",
+			SiteId:    "2",
+			Version:   "def",
+			Connected: []string{},
+			Namespace: "myspace",
+			Url:       "http:some.other.cluster.com",
+			Edge:      false,
+		},
+		TcpServices: []TcpService{
+			TcpService{
+				Service: Service{
+					Address:  "a",
+					Protocol: "tcp",
+					Targets: []ServiceTarget{
+						ServiceTarget{
+							Target: "c5",
+							Name:   "7.7.7.7",
+							SiteId: "two",
+						},
+					},
+				},
+				ConnectionsIngress: []TcpServiceEndpoints{
+					TcpServiceEndpoints{
+						SiteId: "two",
+						Connections: map[string]TcpConnectionStats{
+							"a3": TcpConnectionStats{
+								Id:        "a3",
+								StartTime: 60,
+								LastOut:   4,
+								LastIn:    5,
+								BytesIn:   10,
+								BytesOut:  20,
+								Client:    "1.1.1.1",
+							},
+						},
+					},
+				},
+				ConnectionsEgress: []TcpServiceEndpoints{
+					TcpServiceEndpoints{
+						SiteId: "two",
+						Connections: map[string]TcpConnectionStats{
+							"a3": TcpConnectionStats{
+								Id:        "a3",
+								StartTime: 60,
+								LastOut:   4,
+								LastIn:    5,
+								BytesIn:   20,
+								BytesOut:  10,
+								Server:    "3.3.3.3",
+							},
+						},
+					},
+				},
+			},
+			TcpService{
+				Service: Service{
+					Address:  "c",
+					Protocol: "tcp",
+					Targets: []ServiceTarget{
+						ServiceTarget{
+							Target: "c7",
+							Name:   "6.6.6.6",
+							SiteId: "two",
+						},
+					},
+				},
+				ConnectionsIngress: []TcpServiceEndpoints{
+					TcpServiceEndpoints{
+						SiteId: "two",
+						Connections: map[string]TcpConnectionStats{
+							"c2": TcpConnectionStats{
+								Id:        "c2",
+								StartTime: 60,
+								LastOut:   4,
+								LastIn:    5,
+								BytesIn:   10,
+								BytesOut:  20,
+								Client:    "1.1.1.1",
+							},
+						},
+					},
+				},
+				ConnectionsEgress: []TcpServiceEndpoints{
+					TcpServiceEndpoints{
+						SiteId: "two",
+						Connections: map[string]TcpConnectionStats{
+							"c2": TcpConnectionStats{
+								Id:        "c2",
+								StartTime: 60,
+								LastOut:   4,
+								LastIn:    5,
+								BytesIn:   20,
+								BytesOut:  10,
+								Server:    "3.3.3.3",
+							},
+						},
+					},
+				},
+			},
+		},
+		HttpServices: []HttpService{
+			HttpService{
+				Service: Service{
+					Address:  "foo",
+					Protocol: "http",
+					Targets: []ServiceTarget{
+						ServiceTarget{
+							Target: "c10",
+							Name:   "3.3.3.3",
+							SiteId: "two",
+						},
+					},
+				},
+			},
+			HttpService{
+				Service: Service{
+					Address:  "bar",
+					Protocol: "http2",
+					Targets: []ServiceTarget{
+						ServiceTarget{
+							Target: "c10",
+							Name:   "3.3.3.3",
+							SiteId: "two",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	sites := []SiteQueryData{
+		one,
+		two,
+	}
+	data.Merge(sites)
+	expectedSites := map[string]Site{
+		"one": Site{
+			SiteName: "one",
+			SiteId:   "1",
+			Version:  "abc",
+			Connected: []string{
+				"two",
+			},
+			Namespace: "default",
+			Url:       "http:some.cluster.com",
+			Edge:      false,
+		},
+		"two": Site{
+			SiteName:  "two",
+			SiteId:    "2",
+			Version:   "def",
+			Connected: []string{},
+			Namespace: "myspace",
+			Url:       "http:some.other.cluster.com",
+			Edge:      false,
+		},
+	}
+	if len(data.Sites) != len(expectedSites) {
+		t.Errorf("Expected %d sites, got %d", len(data.Sites), len(expectedSites))
+	}
+	for _, s := range data.Sites {
+		e := expectedSites[s.SiteName]
+		if !reflect.DeepEqual(e, s) {
+			t.Errorf("Incorrect site for %s; expected %v, got %v", s.SiteName, e, s)
+		}
+	}
+	expectedServices := map[string]Service{
+		"a": Service{
+			Address:  "a",
+			Protocol: "tcp",
+		},
+		"b": Service{
+			Address:  "b",
+			Protocol: "tcp",
+		},
+		"c": Service{
+			Address:  "c",
+			Protocol: "tcp",
+		},
+		"foo": Service{
+			Address:  "foo",
+			Protocol: "http",
+		},
+		"bar": Service{
+			Address:  "bar",
+			Protocol: "http2",
+		},
+	}
+	if len(data.Services) != len(expectedServices) {
+		t.Errorf("Expected %d services, got %d", len(data.Services), len(expectedServices))
+	}
+	for _, s := range data.Services {
+		var service Service
+		matched := false
+		if t, ok := s.(TcpService); ok {
+			service = t.Service
+			matched = true
+		} else if h, ok := s.(HttpService); ok {
+			service = h.Service
+			matched = true
+		}
+		if !matched {
+			t.Errorf("Unrecognised service item %v", s)
+		} else {
+			e := expectedServices[service.Address]
+			if e.Address != service.Address {
+				t.Errorf("Incorrect service address; expected %s, got %s", e.Address, service.Address)
+			}
+			if e.Protocol != service.Protocol {
+				t.Errorf("Incorrect service protocol; expected %s, got %s", e.Protocol, service.Protocol)
+			}
+		}
+	}
+}
+
+func TestAsLegacySiteInfo(t *testing.T) {
+	one := Site{
+		SiteName: "one",
+		SiteId:   "1",
+		Version:  "abc",
+		Connected: []string{
+			"two",
+		},
+		Namespace: "default",
+		Url:       "http:some.cluster.com",
+		Edge:      false,
+	}
+	legacy := one.AsLegacySiteInfo()
+	expected := LegacySiteInfo{
+		SiteId:    one.SiteId,
+		SiteName:  one.SiteName,
+		Version:   one.Version,
+		Namespace: one.Namespace,
+		Url:       one.Url,
+	}
+	if expected != *legacy {
+		t.Errorf("AsLegacySiteInfo returned invalid result; expected %v, got %v", expected, legacy)
+	}
+}
+
+func TestNullMapping(t *testing.T) {
+	m := NewNullNameMapping()
+	if "foo" != m.Lookup("foo") {
+		t.Errorf("Null mapping doesn't work!")
+	}
+}

--- a/pkg/data/service.go
+++ b/pkg/data/service.go
@@ -1,0 +1,26 @@
+package data
+
+import (
+	"strings"
+)
+
+type Service struct {
+	Address  string          `json:"address"`
+	Protocol string          `json:"protocol"`
+	Targets  []ServiceTarget `json:"targets"`
+}
+
+type ServiceTarget struct {
+	Name   string `json:"name"`
+	Target string `json:"target"`
+	SiteId string `json:"site_id"`
+}
+
+func (s *Service) AddTarget(name string, host string, siteId string, mapping NameMapping) {
+	target := ServiceTarget{
+		Name:   mapping.Lookup(host),
+		Target: strings.Split(name, "@")[0],
+		SiteId: siteId,
+	}
+	s.Targets = append(s.Targets, target)
+}

--- a/pkg/data/site.go
+++ b/pkg/data/site.go
@@ -1,0 +1,11 @@
+package data
+
+type Site struct {
+	SiteName  string   `json:"site_name"`
+	SiteId    string   `json:"site_id"`
+	Version   string   `json:"version"`
+	Connected []string `json:"connected"`
+	Namespace string   `json:"namespace"`
+	Url       string   `json:"url"`
+	Edge      bool     `json:"edge"`
+}

--- a/pkg/data/tcp.go
+++ b/pkg/data/tcp.go
@@ -1,0 +1,163 @@
+package data
+
+import (
+	"strings"
+
+	"github.com/skupperproject/skupper/pkg/qdr"
+)
+
+type TcpService struct {
+	Service
+	ConnectionsIngress TcpServiceEndpointsList `json:"connections_ingress,omitempty"`
+	ConnectionsEgress  TcpServiceEndpointsList `json:"connections_egress,omitempty"`
+}
+
+type TcpServiceMap map[string]TcpService
+
+type TcpServiceEndpointsList []TcpServiceEndpoints
+
+type TcpServiceEndpoints struct {
+	SiteId      string                        `json:"site_id"`
+	Connections map[string]TcpConnectionStats `json:"connections"`
+}
+
+type TcpConnectionStats struct {
+	Id        string `json:"id"`
+	StartTime uint64 `json:"start_time"`
+	LastOut   uint64 `json:"last_out"`
+	LastIn    uint64 `json:"last_in"`
+	BytesIn   int    `json:"bytes_in"`
+	BytesOut  int    `json:"bytes_out"`
+	Client    string `json:"client,omitempty"`
+	Server    string `json:"server,omitempty"`
+}
+
+func asTcpConnectionStats(connection *qdr.TcpConnection, mapping NameMapping) TcpConnectionStats {
+	stats := TcpConnectionStats{
+		Id:        connection.Name,
+		StartTime: connection.Uptime,
+		LastOut:   connection.LastOut,
+		LastIn:    connection.LastIn,
+		BytesIn:   connection.BytesIn,
+		BytesOut:  connection.BytesOut,
+	}
+	peer := mapping.Lookup(strings.Split(connection.Host, ":")[0])
+	if connection.Direction == qdr.DirectionIn {
+		stats.Client = peer
+	} else {
+		stats.Server = peer
+	}
+	return stats
+}
+
+func (a *TcpServiceEndpoints) merge(b *TcpServiceEndpoints) {
+	for k, v := range b.Connections {
+		a.Connections[k] = v
+	}
+}
+
+func (service *TcpService) mergeIngress(record *TcpServiceEndpoints) {
+	found := false
+	for _, entry := range service.ConnectionsIngress {
+		if entry.SiteId == record.SiteId {
+			entry.merge(record)
+			found = true
+		}
+	}
+	if !found {
+		service.ConnectionsIngress = append(service.ConnectionsIngress, *record)
+	}
+}
+
+func (service *TcpService) mergeEgress(record *TcpServiceEndpoints) {
+	found := false
+	for _, entry := range service.ConnectionsEgress {
+		if entry.SiteId == record.SiteId {
+			entry.merge(record)
+			found = true
+		}
+	}
+	if !found {
+		service.ConnectionsEgress = append(service.ConnectionsEgress, *record)
+	}
+}
+
+func (index TcpServiceMap) merge(services []TcpService) {
+	for _, s := range services {
+		if service, ok := index[s.Address]; ok {
+			if s.Targets != nil {
+				service.Targets = append(service.Targets, s.Targets...)
+			}
+			for _, ingress := range s.ConnectionsIngress {
+				service.mergeIngress(&ingress)
+			}
+			for _, egress := range s.ConnectionsEgress {
+				service.mergeEgress(&egress)
+			}
+			index[s.Address] = service
+		} else {
+			index[s.Address] = s
+		}
+	}
+}
+
+func (index TcpServiceMap) Update(siteId string, connections []qdr.TcpConnection, mapping NameMapping) {
+	for _, c := range connections {
+		record := TcpServiceEndpoints{
+			SiteId: siteId,
+			Connections: map[string]TcpConnectionStats{
+				c.Name: asTcpConnectionStats(&c, mapping),
+			},
+		}
+		service, ok := index[c.Address]
+		if !ok {
+			service = TcpService{
+				Service: Service{
+					Address:  c.Address,
+					Protocol: "tcp",
+				},
+			}
+		}
+		if c.Direction == qdr.DirectionIn {
+			service.mergeIngress(&record)
+		} else {
+			service.mergeEgress(&record)
+		}
+		index[c.Address] = service
+	}
+}
+
+func (s TcpServiceMap) AddTargets(connectors []qdr.TcpEndpoint, mapping NameMapping) {
+	for _, c := range connectors {
+		service, ok := s[c.Address]
+		if !ok {
+			service = TcpService{
+				Service: Service{
+					Address:  c.Address,
+					Protocol: "tcp",
+				},
+			}
+		}
+		service.AddTarget(c.Name, c.Host, c.SiteId, mapping)
+		s[c.Address] = service
+	}
+}
+
+func (s TcpServiceMap) AsList() []TcpService {
+	list := []TcpService{}
+	for _, v := range s {
+		list = append(list, v)
+	}
+	return list
+}
+
+func GetTcpServices(siteId string, info [][]qdr.TcpConnection, targets []qdr.TcpEndpoint, lookup NameMapping) []TcpService {
+	flattened := []qdr.TcpConnection{}
+	for _, l := range info {
+		flattened = append(flattened, l...)
+	}
+	services := TcpServiceMap{}
+	services.Update(siteId, flattened, lookup)
+	services.AddTargets(targets, lookup)
+	return services.AsList()
+}

--- a/pkg/data/tcp_test.go
+++ b/pkg/data/tcp_test.go
@@ -1,0 +1,261 @@
+package data
+
+import (
+	"github.com/skupperproject/skupper/pkg/qdr"
+	"reflect"
+	"testing"
+)
+
+func TestGetTcpServices(t *testing.T) {
+	siteId := "mysite"
+	connections := [][]qdr.TcpConnection{
+		[]qdr.TcpConnection{
+			qdr.TcpConnection{
+				Name:      "a1",
+				Host:      "1.1.1.1",
+				Address:   "a",
+				Direction: "in",
+				BytesIn:   10,
+				BytesOut:  20,
+				Uptime:    60,
+				LastIn:    5,
+				LastOut:   4,
+			},
+			qdr.TcpConnection{
+				Name:      "b1",
+				Host:      "1.1.1.1",
+				Address:   "b",
+				Direction: "out",
+				BytesIn:   15,
+				BytesOut:  15,
+				Uptime:    120,
+				LastIn:    1,
+				LastOut:   1,
+			},
+		},
+		[]qdr.TcpConnection{
+			qdr.TcpConnection{
+				Name:      "a2",
+				Host:      "2.2.2.2",
+				Address:   "a",
+				Direction: "in",
+				BytesIn:   40,
+				BytesOut:  80,
+				Uptime:    90,
+				LastIn:    10,
+				LastOut:   9,
+			},
+		},
+		[]qdr.TcpConnection{
+			qdr.TcpConnection{
+				Name:      "a1",
+				Host:      "3.3.3.3",
+				Address:   "a",
+				Direction: "out",
+				BytesIn:   20,
+				BytesOut:  10,
+				Uptime:    60,
+				LastIn:    5,
+				LastOut:   4,
+			},
+			qdr.TcpConnection{
+				Name:      "a2",
+				Host:      "4.4.4.4",
+				Address:   "a",
+				Direction: "out",
+				BytesIn:   80,
+				BytesOut:  40,
+				Uptime:    90,
+				LastIn:    9,
+				LastOut:   10,
+			},
+			qdr.TcpConnection{
+				Name:      "b1",
+				Host:      "5.5.5.5",
+				Address:   "b",
+				Direction: "in",
+				BytesIn:   15,
+				BytesOut:  15,
+				Uptime:    120,
+				LastIn:    1,
+				LastOut:   1,
+			},
+		},
+	}
+	targets := []qdr.TcpEndpoint{
+		qdr.TcpEndpoint{
+			Name:    "c1",
+			Host:    "1.1.1.1",
+			Address: "b",
+			SiteId:  siteId,
+		},
+		qdr.TcpEndpoint{
+			Name:    "c2",
+			Host:    "3.3.3.3",
+			Address: "a",
+			SiteId:  siteId,
+		},
+		qdr.TcpEndpoint{
+			Name:    "c3",
+			Host:    "4.4.4.4",
+			Address: "a",
+			SiteId:  siteId,
+		},
+		qdr.TcpEndpoint{
+			Name:    "c4",
+			Host:    "6.6.6.6",
+			Address: "c",
+			SiteId:  siteId,
+		},
+	}
+	mapping := GetTestMapping(map[string]string{})
+
+	services := GetTcpServices(siteId, connections, targets, mapping)
+	if services == nil {
+		t.Errorf("Got nil services list")
+	}
+	expected := map[string]TcpService{
+		"a": TcpService{
+			Service: Service{
+				Address:  "a",
+				Protocol: "tcp",
+				Targets: []ServiceTarget{
+					ServiceTarget{
+						Target: "c2",
+						Name:   "3.3.3.3",
+						SiteId: siteId,
+					},
+					ServiceTarget{
+						Target: "c3",
+						Name:   "4.4.4.4",
+						SiteId: siteId,
+					},
+				},
+			},
+			ConnectionsIngress: []TcpServiceEndpoints{
+				TcpServiceEndpoints{
+					SiteId: siteId,
+					Connections: map[string]TcpConnectionStats{
+						"a1": TcpConnectionStats{
+							Id:        "a1",
+							StartTime: 60,
+							LastOut:   4,
+							LastIn:    5,
+							BytesIn:   10,
+							BytesOut:  20,
+							Client:    "1.1.1.1",
+						},
+						"a2": TcpConnectionStats{
+							Id:        "a2",
+							StartTime: 90,
+							LastOut:   9,
+							LastIn:    10,
+							BytesIn:   40,
+							BytesOut:  80,
+							Client:    "2.2.2.2",
+						},
+					},
+				},
+			},
+			ConnectionsEgress: []TcpServiceEndpoints{
+				TcpServiceEndpoints{
+					SiteId: siteId,
+					Connections: map[string]TcpConnectionStats{
+						"a1": TcpConnectionStats{
+							Id:        "a1",
+							StartTime: 60,
+							LastOut:   4,
+							LastIn:    5,
+							BytesIn:   20,
+							BytesOut:  10,
+							Server:    "3.3.3.3",
+						},
+						"a2": TcpConnectionStats{
+							Id:        "a2",
+							StartTime: 90,
+							LastOut:   10,
+							LastIn:    9,
+							BytesIn:   80,
+							BytesOut:  40,
+							Server:    "4.4.4.4",
+						},
+					},
+				},
+			},
+		},
+		"b": TcpService{
+			Service: Service{
+				Address:  "b",
+				Protocol: "tcp",
+				Targets: []ServiceTarget{
+					ServiceTarget{
+						Target: "c1",
+						Name:   "1.1.1.1",
+						SiteId: siteId,
+					},
+				},
+			},
+			ConnectionsIngress: []TcpServiceEndpoints{
+				TcpServiceEndpoints{
+					SiteId: siteId,
+					Connections: map[string]TcpConnectionStats{
+						"b1": TcpConnectionStats{
+							Id:        "b1",
+							StartTime: 120,
+							LastOut:   1,
+							LastIn:    1,
+							BytesIn:   15,
+							BytesOut:  15,
+							Client:    "5.5.5.5",
+						},
+					},
+				},
+			},
+			ConnectionsEgress: []TcpServiceEndpoints{
+				TcpServiceEndpoints{
+					SiteId: siteId,
+					Connections: map[string]TcpConnectionStats{
+						"b1": TcpConnectionStats{
+							Id:        "b1",
+							StartTime: 120,
+							LastOut:   1,
+							LastIn:    1,
+							BytesIn:   15,
+							BytesOut:  15,
+							Server:    "1.1.1.1",
+						},
+					},
+				},
+			},
+		},
+		"c": TcpService{
+			Service: Service{
+				Address:  "c",
+				Protocol: "tcp",
+				Targets: []ServiceTarget{
+					ServiceTarget{
+						Target: "c4",
+						Name:   "6.6.6.6",
+						SiteId: siteId,
+					},
+				},
+			},
+		},
+	}
+	if len(services) != len(expected) {
+		t.Errorf("Expected %d services, got %d", len(expected), len(services))
+	}
+	for _, s := range services {
+		e := expected[s.Address]
+		if !reflect.DeepEqual(e.Service, s.Service) {
+			t.Errorf("Incorrect service definition for %s; expected %v, got %v", s.Service.Address, e.Service, s.Service)
+		}
+		if !reflect.DeepEqual(e.ConnectionsIngress, s.ConnectionsIngress) {
+			t.Errorf("Incorrect ingress connections for %s; expected %v, got %v", s.Service.Address, e.ConnectionsIngress, s.ConnectionsIngress)
+		}
+		if !reflect.DeepEqual(e.ConnectionsEgress, s.ConnectionsEgress) {
+			t.Errorf("Incorrect egress connections for %s; expected %v, got %v", s.Service.Address, e.ConnectionsEgress, s.ConnectionsEgress)
+		}
+	}
+
+}

--- a/pkg/qdr/qdr.go
+++ b/pkg/qdr/qdr.go
@@ -162,6 +162,36 @@ func (bc *BridgeConfig) AddHttpListener(e HttpEndpoint) {
 	bc.HttpListeners[e.Name] = e
 }
 
+func GetHttpConnectors(bridges []BridgeConfig) []HttpEndpoint {
+	connectors := []HttpEndpoint{}
+	for _, bridge := range bridges {
+		for _, connector := range bridge.HttpConnectors {
+			connectors = append(connectors, connector)
+		}
+	}
+	return connectors
+}
+
+func GetHttpListeners(bridges []BridgeConfig) []HttpEndpoint {
+	listeners := []HttpEndpoint{}
+	for _, bridge := range bridges {
+		for _, listener := range bridge.HttpListeners {
+			listeners = append(listeners, listener)
+		}
+	}
+	return listeners
+}
+
+func GetTcpConnectors(bridges []BridgeConfig) []TcpEndpoint {
+	connectors := []TcpEndpoint{}
+	for _, bridge := range bridges {
+		for _, connector := range bridge.TcpConnectors {
+			connectors = append(connectors, connector)
+		}
+	}
+	return connectors
+}
+
 type Role string
 
 const (

--- a/pkg/qdr/request.go
+++ b/pkg/qdr/request.go
@@ -1,0 +1,115 @@
+package qdr
+
+import (
+	"context"
+	"fmt"
+
+	amqp "github.com/interconnectedcloud/go-amqp"
+)
+
+const (
+	VersionProperty string = "version"
+)
+
+type Request struct {
+	Address    string
+	Type       string
+	Version    string
+	Properties map[string]interface{}
+}
+
+type Response struct {
+	Type       string
+	Version    string
+	Properties map[string]interface{}
+	Body       string
+}
+
+type RequestResponse interface {
+	Request(request *Request) (*Response, error)
+}
+
+type RequestServer struct {
+	pool    *AgentPool
+	address string
+	handler RequestResponse
+}
+
+func NewRequestServer(address string, handler RequestResponse, pool *AgentPool) *RequestServer {
+	return &RequestServer{
+		pool, address, handler,
+	}
+}
+
+func (s *RequestServer) Run(ctx context.Context) error {
+	agent, err := s.pool.Get()
+	if err != nil {
+		return fmt.Errorf("Could not get management agent: %s", err)
+	}
+	defer agent.Close()
+
+	receiver, err := agent.newReceiver(s.address)
+	if err != nil {
+		return fmt.Errorf("Could not open receiver for %s: %s", s.address, err)
+	}
+	for {
+		err = s.serve(ctx, receiver, agent.anonymous)
+		if err != nil {
+			return fmt.Errorf("Error handling request for %s: %s", s.address, err)
+		}
+	}
+}
+
+func (s *RequestServer) serve(ctx context.Context, receiver *amqp.Receiver, sender *amqp.Sender) error {
+	for {
+		requestMsg, err := receiver.Receive(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed reading request from %s: %s", s.address, err.Error())
+		}
+		requestMsg.Accept()
+
+		request := Request{
+			Address:    requestMsg.Properties.To,
+			Type:       requestMsg.Properties.Subject,
+			Properties: map[string]interface{}{},
+		}
+		for k, v := range requestMsg.ApplicationProperties {
+			if k == VersionProperty {
+				if version, ok := v.(string); ok {
+					request.Version = version
+				}
+			} else {
+				request.Properties[k] = v
+			}
+		}
+
+		response, err := s.handler.Request(&request)
+		if err != nil {
+			//TODO: send back error response to avoid
+			//requesting client having to time out
+			return err
+		}
+
+		responseMsg := amqp.Message{
+			Properties: &amqp.MessageProperties{
+				To:      requestMsg.Properties.ReplyTo,
+				Subject: response.Type,
+			},
+			ApplicationProperties: map[string]interface{}{},
+			Value:                 response.Body,
+		}
+		correlationId, ok := AsUint64(requestMsg.Properties.CorrelationID)
+		if !ok {
+			responseMsg.Properties.CorrelationID = correlationId
+		}
+		for k, v := range response.Properties {
+			responseMsg.ApplicationProperties[k] = v
+		}
+		responseMsg.ApplicationProperties[VersionProperty] = response.Version
+
+		err = sender.Send(ctx, &responseMsg)
+		if err != nil {
+			return fmt.Errorf("Could not send response: %s", err)
+		}
+	}
+}


### PR DESCRIPTION
* ip to name mapping now correctly applied in each site
* moved the types and much of the data aggregation/manipulation into
  distinct packge for clarity and reuse e.g. in tests
* pulled out generic request-response over amqp abstraction from
  site-query