### PR TITLE
service configuration checking

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -9,22 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func path(arg string) (string, error) {
-	if arg == "" {
-		return "version", nil
-	}
-	if arg == "events" || arg == "version" || arg == "sites" || arg == "services" {
-		return arg, nil
-	}
-	return "", fmt.Errorf("Invalid argument: %s", arg)
-}
-
-func get(arg string, output string) error {
-	path, err := path(arg)
-	if err != nil {
-		return err
-	}
-
+func get(path string, output string) error {
 	url := "http://localhost:8181/" + path
 	if output == "json" {
 		url += "?output=json"
@@ -48,24 +33,38 @@ func get(arg string, output string) error {
 }
 
 var output string
-var rootCmd = &cobra.Command{
-	Use:   "get [events|sites|services|version]",
-	Short: "A simple tool to retrieve information via a HTTP GET request",
-	Args:  cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		// Do Stuff Here
-		path := ""
-		if len(args) > 0 {
-			path = args[0]
-		}
-		if err := get(path, output); err != nil {
-			fmt.Println(err)
-		}
-	},
+
+func simplePathCommand(path string, description string) *cobra.Command {
+	return &cobra.Command{
+		Use:   path,
+		Short: description,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return get(path, output)
+		},
+	}
 }
 
 func main() {
-	rootCmd.Flags().StringVarP(&output, "output", "o", "", "The output format to use (one of json or text)")
+	var rootCmd = &cobra.Command{Use: "get"}
+
+	rootCmd.AddCommand(simplePathCommand("events", "Shows most recent events"))
+	rootCmd.AddCommand(simplePathCommand("version", "Shows version information"))
+	rootCmd.AddCommand(simplePathCommand("sites", "Shows connected sites"))
+	rootCmd.AddCommand(simplePathCommand("services", "Shows exposed services"))
+
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "servicecheck <address>",
+		Short: "Check configuration for an exposed service",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := "servicecheck/" + args[0]
+			return get(path, output)
+		},
+	})
+
+	rootCmd.PersistentFlags().StringVarP(&output, "output", "o", "", "The output format to use (one of json or text)")
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/service-controller/site_query.go
+++ b/cmd/service-controller/site_query.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,11 +19,14 @@ import (
 )
 
 const (
-	SiteQueryError   string = "SiteQueryError"
-	SiteQueryRequest string = "SiteQueryRequest"
+	SiteQueryError      string = "SiteQueryError"
+	SiteQueryRequest    string = "SiteQueryRequest"
+	ServiceCheckError   string = "ServiceCheckError"
+	ServiceCheckRequest string = "ServiceCheckRequest"
 )
 
 type SiteQueryServer struct {
+	client    *client.VanClient
 	tlsConfig *tls.Config
 	agentPool *qdr.AgentPool
 	server    *qdr.RequestServer
@@ -32,11 +36,12 @@ type SiteQueryServer struct {
 
 func newSiteQueryServer(cli *client.VanClient, config *tls.Config) *SiteQueryServer {
 	sqs := SiteQueryServer{
+		client:    cli,
 		tlsConfig: config,
 		agentPool: qdr.NewAgentPool("amqps://skupper-messaging:5671", config),
 		iplookup:  NewIpLookup(cli),
 	}
-	sqs.getLocalSiteInfo(cli)
+	sqs.getLocalSiteInfo()
 	sqs.server = qdr.NewRequestServer(getSiteQueryAddress(sqs.siteInfo.SiteId), &sqs, sqs.agentPool)
 	return &sqs
 }
@@ -44,12 +49,12 @@ func newSiteQueryServer(cli *client.VanClient, config *tls.Config) *SiteQuerySer
 func siteQueryError(err error) {
 }
 
-func (s *SiteQueryServer) getLocalSiteInfo(vanClient *client.VanClient) {
+func (s *SiteQueryServer) getLocalSiteInfo() {
 	s.siteInfo.SiteId = os.Getenv("SKUPPER_SITE_ID")
 	s.siteInfo.SiteName = os.Getenv("SKUPPER_SITE_NAME")
 	s.siteInfo.Namespace = os.Getenv("SKUPPER_NAMESPACE")
 	s.siteInfo.Version = client.Version
-	url, err := getSiteUrl(vanClient)
+	url, err := getSiteUrl(s.client)
 	if err != nil {
 		event.Recordf(SiteQueryError, "Failed to get site url: %s", err)
 	} else {
@@ -105,7 +110,19 @@ func getSiteQueryAddress(siteId string) string {
 	return siteId + "/skupper-site-query"
 }
 
+const (
+	ServiceCheck string = "service-check"
+)
+
 func (s *SiteQueryServer) Request(request *qdr.Request) (*qdr.Response, error) {
+	if request.Type == ServiceCheck {
+		return s.HandleServiceCheck(request)
+	} else {
+		return s.HandleSiteQuery(request)
+	}
+}
+
+func (s *SiteQueryServer) HandleSiteQuery(request *qdr.Request) (*qdr.Response, error) {
 	//if request has explicit version, send SiteQueryData, else send LegacySiteData
 	if request.Version == "" {
 		event.Record(SiteQueryRequest, "legacy site data request")
@@ -135,6 +152,27 @@ func (s *SiteQueryServer) Request(request *qdr.Request) (*qdr.Response, error) {
 	}
 }
 
+func (s *SiteQueryServer) HandleServiceCheck(request *qdr.Request) (*qdr.Response, error) {
+	event.Recordf(ServiceCheckRequest, "checking service %s", request.Body)
+	data, err := s.getServiceDetail(context.Background(), request.Body)
+	if err != nil {
+		return &qdr.Response{
+			Version: client.Version,
+			Type:    ServiceCheckError,
+			Body:    err.Error(),
+		}, nil
+	}
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("Could not encode service check response: %s", err)
+	}
+	return &qdr.Response{
+		Version: client.Version,
+		Type:    request.Type,
+		Body:    string(bytes),
+	}, nil
+}
+
 func (s *SiteQueryServer) run() {
 	for {
 		ctxt := context.Background()
@@ -149,6 +187,126 @@ func (s *SiteQueryServer) start(stopCh <-chan struct{}) error {
 	err := s.iplookup.start(stopCh)
 	go s.run()
 	return err
+}
+
+func (s *SiteQueryServer) getServiceDetail(context context.Context, address string) (data.ServiceDetail, error) {
+	detail := data.ServiceDetail{
+		SiteId: s.siteInfo.SiteId,
+	}
+	definition, err := s.client.ServiceInterfaceInspect(context, address)
+	if err != nil {
+		return detail, err
+	}
+	if definition == nil {
+		return detail, fmt.Errorf("No such service %q", address)
+	}
+	detail.Definition = *definition
+
+	service, err := kube.GetService(address, s.client.Namespace, s.client.KubeClient)
+	if err != nil {
+		return detail, err
+	}
+	if len(service.Spec.Ports) == 1 {
+		detail.IngressBinding.ServicePort = int(service.Spec.Ports[0].Port)
+		detail.IngressBinding.ServiceTargetPort = service.Spec.Ports[0].TargetPort.IntValue()
+	} else if len(service.Spec.Ports) > 1 {
+		var name string
+		for _, ports := range service.Spec.Ports {
+			if int(ports.Port) == detail.Definition.Port {
+				name = ports.Name
+				detail.IngressBinding.ServicePort = int(ports.Port)
+				detail.IngressBinding.ServiceTargetPort = ports.TargetPort.IntValue()
+				break
+			}
+		}
+		if name == "" {
+			detail.AddObservation("Service Spec has multiple ports defined, none of which match port in definition")
+		} else {
+			detail.AddObservation("Service Spec has multiple ports defined; using " + name)
+		}
+	} else {
+		detail.AddObservation("Service Spec has no ports defined")
+	}
+	detail.IngressBinding.ServiceSelector = service.Spec.Selector
+
+	agent, err := s.agentPool.Get()
+	if err != nil {
+		return detail, fmt.Errorf("Could not get management agent: %s", err)
+	}
+	defer s.agentPool.Put(agent)
+
+	if detail.Definition.Protocol == "tcp" {
+		listener, err := agent.GetLocalTcpListener(detail.Definition.Address, detail.IngressBinding.ServiceTargetPort)
+		if err != nil {
+			return detail, fmt.Errorf("Error retrieving tcp listener for %s: %s", detail.Definition.Address, err)
+		}
+		if listener == nil {
+			detail.AddObservation(fmt.Sprintf("No tcp listener defined for %s on %d", detail.Definition.Address, detail.IngressBinding.ServiceTargetPort))
+		} else {
+			if detail.Definition.Address != listener.Address {
+				detail.AddObservation(fmt.Sprintf("Wrong address for tcp listener on %d", detail.IngressBinding.ServiceTargetPort))
+			} else {
+				port, err := strconv.Atoi(listener.Port)
+				if err != nil {
+					detail.AddObservation(fmt.Sprintf("Bad port for listener %s: %s %s", listener.Name, listener.Port, err))
+				}
+				detail.IngressBinding.ListenerPort = port
+				if detail.IngressBinding.ListenerPort != detail.IngressBinding.ServiceTargetPort {
+					detail.AddObservation(fmt.Sprintf("listener port does not match service target port (%d != %d)",
+						detail.IngressBinding.ListenerPort, detail.IngressBinding.ServiceTargetPort))
+				}
+			}
+		}
+
+		connectors, err := agent.GetLocalTcpConnectors(detail.Definition.Address)
+		if err != nil {
+			return detail, fmt.Errorf("Error retrieving tcp connectors for %s: %s", detail.Definition.Address, err)
+		}
+		for _, connector := range connectors {
+			port, err := strconv.Atoi(connector.Port)
+			if err != nil {
+				detail.AddObservation(fmt.Sprintf("Bad port for connector %s: %s %s", connector.Name, connector.Port, err))
+			}
+			detail.EgressBindings = append(detail.EgressBindings, data.EgressBinding{
+				Port: port,
+				Host: connector.Host,
+			})
+		}
+	} else if detail.Definition.Protocol == "http" || detail.Definition.Protocol == "http2" {
+		listener, err := agent.GetLocalHttpListener(detail.Definition.Address, detail.IngressBinding.ServiceTargetPort)
+		if err != nil {
+			return detail, fmt.Errorf("Error retrieving http listener for %s: %s", detail.Definition.Address, err)
+		}
+		if listener == nil {
+			detail.AddObservation(fmt.Sprintf("No http listener defined for %s on %d", detail.Definition.Address, detail.IngressBinding.ServiceTargetPort))
+		} else {
+			if detail.Definition.Address != listener.Address {
+				detail.AddObservation(fmt.Sprintf("Wrong address for http listener on %d", detail.IngressBinding.ServiceTargetPort))
+			}
+		}
+
+		connectors, err := agent.GetLocalHttpConnectors(detail.Definition.Address)
+		if err != nil {
+			return detail, fmt.Errorf("Error retrieving http connectors for %s: %s", detail.Definition.Address, err)
+		}
+		for _, connector := range connectors {
+			port, err := strconv.Atoi(connector.Port)
+			if err != nil {
+				detail.AddObservation(fmt.Sprintf("Bad port for connector %s: %s %s", connector.Name, connector.Port, err))
+			}
+			detail.EgressBindings = append(detail.EgressBindings, data.EgressBinding{
+				Port: port,
+				Host: connector.Host,
+			})
+		}
+	} else {
+		return detail, fmt.Errorf("Unrecognised protocol: %s", detail.Definition.Protocol)
+	}
+
+	if len(detail.Definition.Targets) > 0 && len(detail.EgressBindings) == 0 {
+		detail.AddObservation(fmt.Sprintf("No connectors on %s for %s ", detail.SiteId, detail.Definition.Address))
+	}
+	return detail, nil
 }
 
 func querySites(agent qdr.RequestResponse, sites []data.SiteQueryData) {
@@ -206,5 +364,36 @@ func getServiceInfo(agent *qdr.Agent, network []qdr.Router, site *data.SiteQuery
 
 	site.HttpServices = data.GetHttpServices(site.SiteId, httpRequestInfo, qdr.GetHttpConnectors(bridges), qdr.GetHttpListeners(bridges), lookup)
 	site.TcpServices = data.GetTcpServices(site.SiteId, tcpConnections, qdr.GetTcpConnectors(bridges), lookup)
+	return nil
+}
+
+func checkServiceForSites(agent qdr.RequestResponse, address string, sites *data.ServiceCheck) error {
+	details := []data.ServiceDetail{}
+	for _, s := range sites.Details {
+		request := qdr.Request{
+			Address: getSiteQueryAddress(s.SiteId),
+			Version: client.Version,
+			Type:    ServiceCheck,
+			Body:    address,
+		}
+		response, err := agent.Request(&request)
+		if err != nil {
+			event.Recordf(ServiceCheckError, "Request to %s failed: %s", s.SiteId, err)
+			return err
+		}
+		if response.Type == ServiceCheckError {
+			sites.AddObservation(fmt.Sprintf("%s on %s", response.Body, s.SiteId))
+		} else {
+			detail := data.ServiceDetail{}
+			err = json.Unmarshal([]byte(response.Body), &detail)
+			if err != nil {
+				event.Recordf(ServiceCheckError, "Error parsing json for service check %q from %s: %s", response.Body, s.SiteId, err)
+				return err
+			}
+			details = append(details, detail)
+		}
+	}
+	sites.Details = details
+	data.CheckService(sites)
 	return nil
 }

--- a/pkg/data/service.go
+++ b/pkg/data/service.go
@@ -1,7 +1,10 @@
 package data
 
 import (
+	"fmt"
 	"strings"
+
+	"github.com/skupperproject/skupper/api/types"
 )
 
 type Service struct {
@@ -23,4 +26,91 @@ func (s *Service) AddTarget(name string, host string, siteId string, mapping Nam
 		SiteId: siteId,
 	}
 	s.Targets = append(s.Targets, target)
+}
+
+type IngressBinding struct {
+	ListenerPort      int               `json:"listener_port"`
+	ServicePort       int               `json:"service_port"`
+	ServiceTargetPort int               `json:"service_target_port"`
+	ServiceSelector   map[string]string `json:"service_selector"`
+}
+
+type EgressBinding struct {
+	Port int    `json:"port"`
+	Host string `json:"host"`
+}
+
+type ServiceDetail struct {
+	SiteId         string                 `json:"site_id"`
+	Definition     types.ServiceInterface `json:"definition"`
+	IngressBinding IngressBinding         `json:"ingress_binding"`
+	EgressBindings []EgressBinding        `json:"egress_bindings"`
+	Observations   []string               `json:"observations,omitempty"`
+}
+
+type ServiceCheck struct {
+	Details      []ServiceDetail `json:"site_details"`
+	Observations []string        `json:"observations,omitempty"`
+}
+
+func (sd *ServiceDetail) AddObservation(message string) {
+	sd.Observations = append(sd.Observations, message)
+}
+
+func (sc *ServiceCheck) AddObservation(message string) {
+	sc.Observations = append(sc.Observations, message)
+}
+
+func (sc *ServiceCheck) HasDetailObservations() bool {
+	for _, d := range sc.Details {
+		if len(d.Observations) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func CheckService(details *ServiceCheck) {
+	//consistency checking
+	//- do definitions from different sites match?
+	for i := 0; i+1 < len(details.Details); i++ {
+		aSiteId := details.Details[i].SiteId
+		bSiteId := details.Details[i+1].SiteId
+		a := &details.Details[i].Definition
+		b := &details.Details[i+1].Definition
+		if a.Address != "" && b.Address != "" {
+			if a.Address != b.Address {
+				details.AddObservation(fmt.Sprintf("Mismatched address between sites %s and %s (%s != %s)", aSiteId, bSiteId, a.Address, b.Address))
+			}
+			if a.Protocol != b.Protocol {
+				details.AddObservation(fmt.Sprintf("Mismatched protocol between sites %s and %s (%s != %s)", aSiteId, bSiteId, a.Protocol, b.Protocol))
+			}
+			if a.Port != b.Port {
+				details.AddObservation(fmt.Sprintf("Different port used in sites %s (%d) and %s (%d)", aSiteId, a.Port, bSiteId, b.Port))
+			}
+		}
+	}
+	//- do all sites have a correctly defined ingress binding?
+	//- do all sites with a target defined have at least one egress binding?
+	egressCount := 0
+	for _, site := range details.Details {
+		if site.IngressBinding.ListenerPort == 0 {
+			details.AddObservation(fmt.Sprintf("No valid ingress binding for site %s, listener port not set", site.SiteId))
+		}
+		if site.IngressBinding.ServicePort == 0 {
+			details.AddObservation(fmt.Sprintf("No valid ingress binding for site %s, service port not set", site.SiteId))
+		}
+		if site.IngressBinding.ServiceTargetPort != site.IngressBinding.ListenerPort {
+			details.AddObservation(fmt.Sprintf("Invalid ingress binding for site %s, target port on service does not match listener port", site.SiteId))
+		}
+		for _, egress := range site.EgressBindings {
+			if egress.Host != "" && egress.Port != 0 {
+				egressCount++
+			}
+		}
+	}
+	//- is there at least one egress binding?
+	if egressCount == 0 {
+		details.AddObservation("There are no egress bindings")
+	}
 }


### PR DESCRIPTION
Adds a service configuration checking mechanism intended to automate intial part of troubleshooting.

See /servicecheck/<address> on controller 8080 port, or use kubectl exec -it <service-controller-pod> -- get servicecheck <address>