### PR TITLE
Refactored test jobs that run inside the cluster to use a different build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ all: build-cmd build-get build-controllers build-tests
 
 build-tests:
 	mkdir -p ${TEST_BINARIES_FOLDER}
-	go test -c -tags=integration -v ./test/integration/tcp_echo -o ${TEST_BINARIES_FOLDER}/tcp_echo_test
-	go test -c -tags=integration -v ./test/integration/http -o ${TEST_BINARIES_FOLDER}/http_test
-	go test -c -tags=integration -v ./test/integration/bookinfo -o ${TEST_BINARIES_FOLDER}/bookinfo_test
-	go test -c -tags=integration -v ./test/integration/mongodb -o ${TEST_BINARIES_FOLDER}/mongo_test
+	go test -c -tags=job -v ./test/integration/tcp_echo/job -o ${TEST_BINARIES_FOLDER}/tcp_echo_test
+	go test -c -tags=job -v ./test/integration/http/job -o ${TEST_BINARIES_FOLDER}/http_test
+	go test -c -tags=job -v ./test/integration/bookinfo/job -o ${TEST_BINARIES_FOLDER}/bookinfo_test
+	go test -c -tags=job -v ./test/integration/mongodb/job -o ${TEST_BINARIES_FOLDER}/mongo_test
 
 build-cmd:
 	go build -ldflags="${LDFLAGS}"  -o skupper ./cmd/skupper

--- a/test/integration/bookinfo/bookinfo_test.go
+++ b/test/integration/bookinfo/bookinfo_test.go
@@ -4,18 +4,10 @@ package bookinfo
 
 import (
 	"context"
-	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/skupperproject/skupper/test/utils/base"
-	"github.com/skupperproject/skupper/test/utils/k8s"
-	"gotest.tools/assert"
-
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
@@ -38,37 +30,4 @@ func TestBookinfo(t *testing.T) {
 		cancel()
 	})
 	Run(ctx, t, testRunner)
-}
-
-func tryProductPage() ([]byte, error) {
-	client := http.Client{
-		Timeout: 30 * time.Second,
-	}
-
-	resp, err := client.Get("http://productpage:9080/productpage?u=test")
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.Status != "200 OK" {
-		return nil, fmt.Errorf("unexpedted http response status: %v", resp.Status)
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	return body, nil
-}
-
-func TestBookinfoJob(t *testing.T) {
-	k8s.SkipTestJobIfMustBeSkipped(t)
-	_body, err := tryProductPage()
-	assert.Assert(t, err)
-
-	body := string(_body)
-	fmt.Printf("body:\n%s\n", body)
-	assert.Assert(t, strings.Contains(body, "Book Details"))
-	assert.Assert(t, strings.Contains(body, "An extremely entertaining play by Shakespeare. The slapstick humour is refreshing!"))
-	assert.Assert(t, !strings.Contains(body, "Ratings service is currently unavailable"))
 }

--- a/test/integration/bookinfo/job/bookinfojob_test.go
+++ b/test/integration/bookinfo/job/bookinfojob_test.go
@@ -1,0 +1,47 @@
+// +build job
+
+package job
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+)
+
+func TestBookinfoJob(t *testing.T) {
+	_body, err := tryProductPage()
+	assert.Assert(t, err)
+
+	body := string(_body)
+	fmt.Printf("body:\n%s\n", body)
+	assert.Assert(t, strings.Contains(body, "Book Details"))
+	assert.Assert(t, strings.Contains(body, "An extremely entertaining play by Shakespeare. The slapstick humour is refreshing!"))
+	assert.Assert(t, !strings.Contains(body, "Ratings service is currently unavailable"))
+}
+
+func tryProductPage() ([]byte, error) {
+	client := http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	resp, err := client.Get("http://productpage:9080/productpage?u=test")
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Status != "200 OK" {
+		return nil, fmt.Errorf("unexpedted http response status: %v", resp.Status)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+

--- a/test/integration/http/http_test.go
+++ b/test/integration/http/http_test.go
@@ -4,23 +4,10 @@ package http
 
 import (
 	"context"
-	"crypto/tls"
-	"fmt"
-	"io/ioutil"
-	"net"
-	"net/http"
 	"os"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/skupperproject/skupper/test/utils/base"
-	"github.com/skupperproject/skupper/test/utils/k8s"
-	"golang.org/x/net/http2"
-	"gotest.tools/assert"
-
-	"github.com/davecgh/go-spew/spew"
-	vegeta "github.com/tsenart/vegeta/v12/lib"
 )
 
 func TestMain(m *testing.M) {
@@ -42,70 +29,4 @@ func TestHttp(t *testing.T) {
 		cancel()
 	})
 	testRunner.Run(ctx, t)
-}
-
-func TestHttpJob(t *testing.T) {
-	testHttpJob(t, "http://httpbin:8080/")
-}
-
-func TestHttp2Job(t *testing.T) {
-	//TODO: enable this if we add suport for "Upgrade" in skupper http2
-	//testHttpJob(t, "http://nghttp2:8443/")
-
-	k8s.SkipTestJobIfMustBeSkipped(t)
-
-	//https://www.mailgun.com/blog/http-2-cleartext-h2c-client-example-go/
-	//hack to support h2c
-	client := http.Client{
-		Transport: &http2.Transport{
-			// So http2.Transport doesn't complain the URL scheme isn't 'https'
-			AllowHTTP: true,
-			// Pretend we are dialing a TLS endpoint.
-			// Note, we ignore the passed tls.Config
-			DialTLS: func(network, addr string, cfg *tls.Config) (net.Conn, error) {
-				return net.Dial(network, addr)
-			},
-		},
-	}
-
-	resp, err := client.Get("http://nghttp2:8443/")
-	assert.Assert(t, err)
-	fmt.Printf("Client Proto: %d\n", resp.ProtoMajor)
-	fmt.Println("Client Header:", resp.Header)
-
-	defer resp.Body.Close()
-	_body, err := ioutil.ReadAll(resp.Body)
-	assert.Assert(t, err)
-
-	body := string(_body)
-	assert.Assert(t, strings.Contains(body, "A simple HTTP Request &amp; Response Service."), body)
-	assert.Assert(t, resp.Status == "200 OK", resp.Status)
-}
-
-func testHttpJob(t *testing.T, url string) {
-	k8s.SkipTestJobIfMustBeSkipped(t)
-	fmt.Printf("Running job for url: %s\n", url)
-
-	rate := vegeta.Rate{Freq: 100, Per: time.Second}
-	duration := 4 * time.Second
-	targeter := vegeta.NewStaticTargeter(vegeta.Target{
-		Method: "GET",
-		URL:    url,
-	})
-	attacker := vegeta.NewAttacker()
-
-	var metrics vegeta.Metrics
-	for res := range attacker.Attack(targeter, rate, duration, "Big Bang!") {
-		metrics.Add(res)
-	}
-	metrics.Close()
-
-	//this is too verbose, anyway mantaining for now until we add more
-	//assertions
-	spew.Dump(metrics)
-
-	// Success is the percentage of non-error responses.
-	assert.Assert(t, metrics.Success > 0.95, "too many errors! see the log for details.")
-
-	fmt.Printf("Success!!\n")
 }

--- a/test/integration/http/job/httpjob_test.go
+++ b/test/integration/http/job/httpjob_test.go
@@ -1,0 +1,82 @@
+//+build job
+
+package job
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/tsenart/vegeta/v12/lib"
+	"golang.org/x/net/http2"
+	"gotest.tools/assert"
+)
+
+func TestHttpJob(t *testing.T) {
+	testHttpJob(t, "http://httpbin:8080/")
+}
+
+func TestHttp2Job(t *testing.T) {
+	//TODO: enable this if we add suport for "Upgrade" in skupper http2
+	//testHttpJob(t, "http://nghttp2:8443/")
+
+	//https://www.mailgun.com/blog/http-2-cleartext-h2c-client-example-go/
+	//hack to support h2c
+	client := http.Client{
+		Transport: &http2.Transport{
+			// So http2.Transport doesn't complain the URL scheme isn't 'https'
+			AllowHTTP: true,
+			// Pretend we are dialing a TLS endpoint.
+			// Note, we ignore the passed tls.Config
+			DialTLS: func(network, addr string, cfg *tls.Config) (net.Conn, error) {
+				return net.Dial(network, addr)
+			},
+		},
+	}
+
+	resp, err := client.Get("http://nghttp2:8443/")
+	assert.Assert(t, err)
+	fmt.Printf("Client Proto: %d\n", resp.ProtoMajor)
+	fmt.Println("Client Header:", resp.Header)
+
+	defer resp.Body.Close()
+	_body, err := ioutil.ReadAll(resp.Body)
+	assert.Assert(t, err)
+
+	body := string(_body)
+	assert.Assert(t, strings.Contains(body, "A simple HTTP Request &amp; Response Service."), body)
+	assert.Assert(t, resp.Status == "200 OK", resp.Status)
+}
+
+func testHttpJob(t *testing.T, url string) {
+	fmt.Printf("Running job for url: %s\n", url)
+
+	rate := vegeta.Rate{Freq: 100, Per: time.Second}
+	duration := 4 * time.Second
+	targeter := vegeta.NewStaticTargeter(vegeta.Target{
+		Method: "GET",
+		URL:    url,
+	})
+	attacker := vegeta.NewAttacker()
+
+	var metrics vegeta.Metrics
+	for res := range attacker.Attack(targeter, rate, duration, "Big Bang!") {
+		metrics.Add(res)
+	}
+	metrics.Close()
+
+	//this is too verbose, anyway mantaining for now until we add more
+	//assertions
+	spew.Dump(metrics)
+
+	// Success is the percentage of non-error responses.
+	assert.Assert(t, metrics.Success > 0.95, "too many errors! see the log for details.")
+
+	fmt.Printf("Success!!\n")
+}

--- a/test/integration/mongodb/job/mongojob_test.go
+++ b/test/integration/mongodb/job/mongojob_test.go
@@ -1,0 +1,109 @@
+//+build job
+
+package job
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"gotest.tools/assert"
+)
+
+type Post struct {
+	Title string `json:"title,omitempty"`
+	Body  string `json:"body,omitempty"`
+}
+
+var expected = Post{Title: "TheName", Body: "TheBody"}
+var TOTAL_DB_DOCUMENTS = 1000
+var DB_NAME = "my_database"
+var COLLECTION_NAME = "posts"
+
+func TestMongoJob(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	getClient := func(uri string) *mongo.Client {
+		client, err := mongo.NewClient(options.Client().ApplyURI(uri))
+		assert.Assert(t, err)
+		err = client.Connect(ctx)
+		assert.Assert(t, err)
+		return client
+	}
+	client_a := getClient("mongodb://mongo-a:27017")
+	client_b := getClient("mongodb://mongo-b:27017")
+	defer client_a.Disconnect(ctx)
+	defer client_b.Disconnect(ctx)
+
+	err := InsertAllPosts(client_a, ctx)
+	assert.Assert(t, err)
+
+	err = CountDocuments(client_b, TOTAL_DB_DOCUMENTS, ctx)
+	assert.Assert(t, err)
+
+	err = PopAllExpectedPosts(client_a, ctx)
+	assert.Assert(t, err)
+
+	err = CountDocuments(client_b, 0, ctx)
+	assert.Assert(t, err)
+}
+
+func InsertAllPosts(client *mongo.Client, ctx context.Context) error {
+	post := Post{expected.Title, expected.Body}
+	collection := client.Database(DB_NAME).Collection(COLLECTION_NAME)
+
+	for i := 0; i < TOTAL_DB_DOCUMENTS; i++ {
+		_, err := collection.InsertOne(ctx, post)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func CountDocuments(client *mongo.Client, expected_count int, ctx context.Context) error {
+	collection := client.Database(DB_NAME).Collection(COLLECTION_NAME)
+	count, err := collection.CountDocuments(ctx, bson.D{})
+	if err != nil {
+		return err
+	}
+	if int(count) != expected_count {
+		return fmt.Errorf("expected: %d, got %d", expected_count, count)
+	}
+	return nil
+}
+
+func PopAllExpectedPosts(client *mongo.Client, ctx context.Context) error {
+
+	collection := client.Database(DB_NAME).Collection(COLLECTION_NAME)
+	filter := bson.D{}
+	var post Post
+
+	count, err := collection.CountDocuments(ctx, filter)
+	if err != nil {
+		return err
+	}
+
+	if int(count) != TOTAL_DB_DOCUMENTS {
+		return fmt.Errorf("wrong number of documents in secondary DB, expected: %d, got: %d", TOTAL_DB_DOCUMENTS, count)
+
+	}
+
+	for i := 0; i < int(count); i++ {
+		post = Post{}
+		err = collection.FindOneAndDelete(ctx, filter).Decode(&post)
+		if err != nil {
+			return err
+		}
+		if post != expected {
+			return fmt.Errorf("extracted document different than expected. got: %v, expected: %v", post, expected)
+		}
+
+	}
+	return nil
+}

--- a/test/integration/mongodb/mongo_test.go
+++ b/test/integration/mongodb/mongo_test.go
@@ -4,17 +4,10 @@ package mongodb
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/skupperproject/skupper/test/utils/base"
-	"github.com/skupperproject/skupper/test/utils/k8s"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
-	"gotest.tools/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -36,99 +29,4 @@ func TestMongo(t *testing.T) {
 	//cancel()
 	//})
 	Run(context.Background(), t, testRunner)
-}
-
-type Post struct {
-	Title string `json:"title,omitempty"`
-	Body  string `json:"body,omitempty"`
-}
-
-var expected = Post{Title: "TheName", Body: "TheBody"}
-var TOTAL_DB_DOCUMENTS = 1000
-var DB_NAME = "my_database"
-var COLLECTION_NAME = "posts"
-
-func InsertAllPosts(client *mongo.Client, ctx context.Context) error {
-	post := Post{expected.Title, expected.Body}
-	collection := client.Database(DB_NAME).Collection(COLLECTION_NAME)
-
-	for i := 0; i < TOTAL_DB_DOCUMENTS; i++ {
-		_, err := collection.InsertOne(ctx, post)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func CountDocuments(client *mongo.Client, expected_count int, ctx context.Context) error {
-	collection := client.Database(DB_NAME).Collection(COLLECTION_NAME)
-	count, err := collection.CountDocuments(ctx, bson.D{})
-	if err != nil {
-		return err
-	}
-	if int(count) != expected_count {
-		return fmt.Errorf("expected: %d, got %d", expected_count, count)
-	}
-	return nil
-}
-
-func PopAllExpectedPosts(client *mongo.Client, ctx context.Context) error {
-
-	collection := client.Database(DB_NAME).Collection(COLLECTION_NAME)
-	filter := bson.D{}
-	var post Post
-
-	count, err := collection.CountDocuments(ctx, filter)
-	if err != nil {
-		return err
-	}
-
-	if int(count) != TOTAL_DB_DOCUMENTS {
-		return fmt.Errorf("wrong number of documents in secondary DB, expected: %d, got: %d", TOTAL_DB_DOCUMENTS, count)
-
-	}
-
-	for i := 0; i < int(count); i++ {
-		post = Post{}
-		err = collection.FindOneAndDelete(ctx, filter).Decode(&post)
-		if err != nil {
-			return err
-		}
-		if post != expected {
-			return fmt.Errorf("extracted document different than expected. got: %v, expected: %v", post, expected)
-		}
-
-	}
-	return nil
-}
-
-func TestMongoJob(t *testing.T) {
-	k8s.SkipTestJobIfMustBeSkipped(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	getClient := func(uri string) *mongo.Client {
-		client, err := mongo.NewClient(options.Client().ApplyURI(uri))
-		assert.Assert(t, err)
-		err = client.Connect(ctx)
-		assert.Assert(t, err)
-		return client
-	}
-	client_a := getClient("mongodb://mongo-a:27017")
-	client_b := getClient("mongodb://mongo-b:27017")
-	defer client_a.Disconnect(ctx)
-	defer client_b.Disconnect(ctx)
-
-	err := InsertAllPosts(client_a, ctx)
-	assert.Assert(t, err)
-
-	err = CountDocuments(client_b, TOTAL_DB_DOCUMENTS, ctx)
-	assert.Assert(t, err)
-
-	err = PopAllExpectedPosts(client_a, ctx)
-	assert.Assert(t, err)
-
-	err = CountDocuments(client_b, 0, ctx)
-	assert.Assert(t, err)
 }

--- a/test/integration/tcp_echo/job/tcp_echo_job_test.go
+++ b/test/integration/tcp_echo/job/tcp_echo_job_test.go
@@ -1,0 +1,78 @@
+//+build job
+
+package job
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+)
+
+func TestTcpEchoJob(t *testing.T) {
+	assert.Assert(t, SendReceive("tcp-go-echo:9090"))
+}
+
+func SendReceive(addr string) error {
+	doneCh := make(chan error)
+	go func(doneCh chan error) {
+
+		strEcho := "Halo"
+		log.Println("Resolving TCP Address")
+		tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
+		if err != nil {
+			doneCh <- fmt.Errorf("ResolveTCPAddr failed: %s\n", err.Error())
+			return
+		}
+
+		log.Println("Opening TCP connection")
+		conn, err := net.DialTCP("tcp", nil, tcpAddr)
+		if err != nil {
+			doneCh <- fmt.Errorf("Dial failed: %s\n", err.Error())
+			return
+		}
+		defer conn.Close()
+
+		log.Println("Sending data")
+		_, err = conn.Write([]byte(strEcho))
+		if err != nil {
+			doneCh <- fmt.Errorf("Write to server failed: %s\n", err.Error())
+			return
+		}
+
+		log.Println("Receiving reply")
+		reply := make([]byte, 1024)
+
+		_, err = conn.Read(reply)
+		if err != nil {
+			doneCh <- fmt.Errorf("Read from server failed: %s\n", err.Error())
+			return
+		}
+
+		log.Println("Sent to server = ", strEcho)
+		log.Println("Reply from server = ", string(reply))
+
+		if !strings.Contains(string(reply), strings.ToUpper(strEcho)) {
+			doneCh <- fmt.Errorf("Response from server different that expected: %s\n", string(reply))
+			return
+		}
+
+		doneCh <- nil
+	}(doneCh)
+	timeoutCh := time.After(time.Minute)
+
+	// TCP Echo Client job sometimes hangs waiting for response
+	// This will cause job to fail and a retry to occur
+	var err error
+	select {
+	case err = <-doneCh:
+	case <-timeoutCh:
+		err = fmt.Errorf("timed out waiting for tcp-echo job to finish")
+	}
+
+	return err
+}

--- a/test/integration/tcp_echo/tcp_echo.go
+++ b/test/integration/tcp_echo/tcp_echo.go
@@ -3,9 +3,6 @@ package tcp_echo
 import (
 	"context"
 	"fmt"
-	"log"
-	"net"
-	"strings"
 	"testing"
 	"time"
 
@@ -143,66 +140,6 @@ func (r *TcpEchoClusterTestRunner) Setup(ctx context.Context, t *testing.T) {
 
 	err = pub1Cluster.VanClient.ServiceInterfaceBind(ctx, &service, "deployment", "tcp-go-echo", "tcp", 0)
 	assert.Assert(t, err)
-}
-
-func SendReceive(addr string) error {
-	doneCh := make(chan error)
-	go func(doneCh chan error) {
-
-		strEcho := "Halo"
-		log.Println("Resolving TCP Address")
-		tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
-		if err != nil {
-			doneCh <- fmt.Errorf("ResolveTCPAddr failed: %s\n", err.Error())
-			return
-		}
-
-		log.Println("Opening TCP connection")
-		conn, err := net.DialTCP("tcp", nil, tcpAddr)
-		if err != nil {
-			doneCh <- fmt.Errorf("Dial failed: %s\n", err.Error())
-			return
-		}
-		defer conn.Close()
-
-		log.Println("Sending data")
-		_, err = conn.Write([]byte(strEcho))
-		if err != nil {
-			doneCh <- fmt.Errorf("Write to server failed: %s\n", err.Error())
-			return
-		}
-
-		log.Println("Receiving reply")
-		reply := make([]byte, 1024)
-
-		_, err = conn.Read(reply)
-		if err != nil {
-			doneCh <- fmt.Errorf("Read from server failed: %s\n", err.Error())
-			return
-		}
-
-		log.Println("Sent to server = ", strEcho)
-		log.Println("Reply from server = ", string(reply))
-
-		if !strings.Contains(string(reply), strings.ToUpper(strEcho)) {
-			doneCh <- fmt.Errorf("Response from server different that expected: %s\n", string(reply))
-			return
-		}
-
-		doneCh <- nil
-	}(doneCh)
-	timeoutCh := time.After(time.Minute)
-
-	// TCP Echo Client job sometimes hangs waiting for response
-	// This will cause job to fail and a retry to occur
-	var err error
-	select {
-	case err = <-doneCh:
-	case <-timeoutCh:
-		err = fmt.Errorf("timed out waiting for tcp-echo job to finish")
-	}
-
-	return err
 }
 
 func (r *TcpEchoClusterTestRunner) Run(ctx context.Context, t *testing.T) {

--- a/test/integration/tcp_echo/tcp_echo_test.go
+++ b/test/integration/tcp_echo/tcp_echo_test.go
@@ -8,9 +8,6 @@ import (
 	"testing"
 
 	"github.com/skupperproject/skupper/test/utils/base"
-	"github.com/skupperproject/skupper/test/utils/k8s"
-
-	"gotest.tools/assert"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
@@ -34,9 +31,4 @@ func TestTcpEcho(t *testing.T) {
 		cancel()
 	})
 	testRunner.Run(ctx, t)
-}
-
-func TestTcpEchoJob(t *testing.T) {
-	k8s.SkipTestJobIfMustBeSkipped(t)
-	assert.Assert(t, SendReceive("tcp-go-echo:9090"))
 }

--- a/test/utils/k8s/job.go
+++ b/test/utils/k8s/job.go
@@ -109,9 +109,3 @@ func AssertJob(t *testing.T, job *batchv1.Job) {
 		t.Logf("WARNING! THIS JOB NEEDED RETRIES TO SUCCEED! Job.Status.Failed = %d\n", job.Status.Failed)
 	}
 }
-
-func SkipTestJobIfMustBeSkipped(t *testing.T) {
-	if os.Getenv("JOB") == "" {
-		t.Skip("JOB environment variable not defined")
-	}
-}


### PR DESCRIPTION
The test jobs have been placed into another package and they now use a
`job` tag. This way there is no longer a need to call `SkipTestJobIfMustBeSkipped`
as those tests won't be executed as an integration test.

Resolves #424