### PR TITLE
Allow gettings pods logs using custom options

### DIFF
--- a/pkg/kube/pods.go
+++ b/pkg/kube/pods.go
@@ -124,6 +124,10 @@ func WaitForPodStatus(namespace string, clientset kubernetes.Interface, podName 
 
 func GetPodContainerLogs(podName string, containerName string, namespace string, clientset kubernetes.Interface) (string, error) {
 	podLogOpts := corev1.PodLogOptions{}
+	return GetPodContainerLogsWithOpts(podName, containerName, namespace, clientset, podLogOpts)
+}
+
+func GetPodContainerLogsWithOpts(podName string, containerName string, namespace string, clientset kubernetes.Interface, podLogOpts corev1.PodLogOptions) (string, error) {
 	if containerName != "" {
 		podLogOpts.Container = containerName
 	}


### PR DESCRIPTION
This is helpful, especially on integration tests when we need to retrieve
previous pods logs, to determine root cause of errors.