### PR TITLE
Allow annotations for router and service-controller pods to be specified

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -50,6 +50,7 @@ type SiteConfigSpec struct {
 	SiteControlled      bool
 	RouterLogging       []RouterLogConfig
 	RouterDebugMode     string
+	Annotations         map[string]string
 }
 
 const (

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -137,6 +137,7 @@ const (
 	TokenGeneratedBy            string = BaseQualifier + "/generated-by"
 	TokenCost                   string = BaseQualifier + "/cost"
 	UpdatedAnnotation           string = InternalQualifier + "/updated"
+	AnnotationExcludes          string = BaseQualifier + "/exclude-annotations"
 )
 
 // Service Interface constants

--- a/client/router_create.go
+++ b/client/router_create.go
@@ -257,6 +257,10 @@ func (cli *VanClient) GetRouterSpecFromOpts(options types.SiteConfigSpec, siteId
 		"skupper.io/component": types.TransportComponentName,
 	}
 	van.Transport.Annotations = types.TransportPrometheusAnnotations
+	van.Controller.Annotations = options.Annotations
+	for key, value := range options.Annotations {
+		van.Transport.Annotations[key] = value
+	}
 
 	isEdge := options.RouterMode == string(types.TransportModeEdge)
 	routerConfig := qdr.InitialConfig(van.Name+"-${HOSTNAME}", siteId, Version, isEdge)

--- a/client/router_update.go
+++ b/client/router_update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 	"time"
 
@@ -560,6 +561,45 @@ func (cli *VanClient) RouterUpdateDebugMode(ctx context.Context, settings *corev
 	}
 	return true, nil
 
+}
+
+func (cli *VanClient) updateAnnotationsOnDeployment(ctx context.Context, namespace string, name string, annotations map[string]string) (bool, error) {
+	deployment, err := cli.KubeClient.AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	if !reflect.DeepEqual(annotations, deployment.Spec.Template.ObjectMeta.Annotations) {
+		deployment.Spec.Template.ObjectMeta.Annotations = annotations
+		_, err = cli.KubeClient.AppsV1().Deployments(namespace).Update(deployment)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func (cli *VanClient) RouterUpdateAnnotations(ctx context.Context, settings *corev1.ConfigMap) (bool, error) {
+	siteConfig, err := cli.SiteConfigInspect(ctx, settings)
+	if err != nil {
+		return false, err
+	}
+	updated, err := cli.updateAnnotationsOnDeployment(ctx, settings.ObjectMeta.Namespace, types.ControllerDeploymentName, siteConfig.Spec.Annotations)
+	if err != nil {
+		return updated, err
+	}
+	transportAnnotations := map[string]string{}
+	for key, value := range types.TransportPrometheusAnnotations {
+		transportAnnotations[key] = value
+	}
+	for key, value := range siteConfig.Spec.Annotations {
+		transportAnnotations[key] = value
+	}
+	updated, err = cli.updateAnnotationsOnDeployment(ctx, settings.ObjectMeta.Namespace, types.TransportDeploymentName, transportAnnotations)
+	if err != nil {
+		return updated, err
+	}
+	return updated, nil
 }
 
 func (cli *VanClient) RouterRestart(ctx context.Context, namespace string) error {

--- a/client/site_config_create.go
+++ b/client/site_config_create.go
@@ -17,7 +17,8 @@ func (cli *VanClient) SiteConfigCreate(ctx context.Context, spec types.SiteConfi
 			Kind:       "ConfigMap",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "skupper-site",
+			Name:        "skupper-site",
+			Annotations: spec.Annotations,
 		},
 		Data: map[string]string{
 			"name":                   cli.Namespace,

--- a/client/site_config_inspect.go
+++ b/client/site_config_inspect.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -119,5 +120,18 @@ func (cli *VanClient) SiteConfigInspect(ctx context.Context, input *corev1.Confi
 		}
 		result.Spec.RouterLogging = logConf
 	}
+	exclusions := []string{}
+	annotations := map[string]string{}
+	for key, value := range siteConfig.ObjectMeta.Annotations {
+		if key == types.AnnotationExcludes {
+			exclusions = strings.Split(value, ",")
+		} else {
+			annotations[key] = value
+		}
+	}
+	for _, key := range exclusions {
+		delete(annotations, key)
+	}
+	result.Spec.Annotations = annotations
 	return &result, nil
 }

--- a/cmd/site-controller/controller.go
+++ b/cmd/site-controller/controller.go
@@ -255,6 +255,13 @@ func (c *SiteController) checkSite(key string) error {
 			} else if updatedDebugMode {
 				log.Println("Updated debug mode for", key)
 			}
+			updatedAnnotations, err := c.vanClient.RouterUpdateAnnotations(context.Background(), configmap)
+			if err != nil {
+				log.Println("Error checking annotations:", err)
+			} else if updatedAnnotations {
+				log.Println("Updated annotations for", key)
+			}
+
 			c.checkAllForSite()
 		} else if errors.IsNotFound(err) {
 			log.Println("Initialising skupper site ...")

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -189,6 +189,7 @@ var ClusterLocal bool
 
 func NewCmdInit(newClient cobraFunc) *cobra.Command {
 	var routerMode string
+	annotations := []string{}
 	var isEdge bool
 	cmd := &cobra.Command{
 		Use:   "init",
@@ -233,6 +234,17 @@ installation that can then be connected to other skupper installations`,
 				}
 			} else if !routerIngressFlag.Changed {
 				routerCreateOpts.Ingress = cli.GetIngressDefault()
+			}
+			for _, a := range annotations {
+				parts := strings.Split(a, "=")
+				if routerCreateOpts.Annotations == nil {
+					routerCreateOpts.Annotations = map[string]string{}
+				}
+				if len(parts) > 1 {
+					routerCreateOpts.Annotations[parts[0]] = parts[1]
+				} else {
+					routerCreateOpts.Annotations[parts[0]] = ""
+				}
 			}
 
 			routerCreateOpts.SkupperNamespace = ns
@@ -288,6 +300,7 @@ installation that can then be connected to other skupper installations`,
 	cmd.Flags().StringVarP(&routerCreateOpts.AuthMode, "console-auth", "", "", "Authentication mode for console(s). One of: 'openshift', 'internal', 'unsecured'")
 	cmd.Flags().StringVarP(&routerCreateOpts.User, "console-user", "", "", "Skupper console user. Valid only when --console-auth=internal")
 	cmd.Flags().StringVarP(&routerCreateOpts.Password, "console-password", "", "", "Skupper console user. Valid only when --console-auth=internal")
+	cmd.Flags().StringSliceVar(&annotations, "annotations", []string{}, "Annotations to add to skupper deployments")
 
 	cmd.Flags().BoolVarP(&ClusterLocal, "cluster-local", "", false, "Set up Skupper to only accept connections from within the local cluster.")
 	f := cmd.Flag("cluster-local")

--- a/pkg/kube/deployments.go
+++ b/pkg/kube/deployments.go
@@ -222,7 +222,8 @@ func NewControllerDeployment(van *types.RouterSpec, ownerRef *metav1.OwnerRefere
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels: van.Controller.Labels,
+						Labels:      van.Controller.Labels,
+						Annotations: van.Controller.Annotations,
 					},
 					Spec: corev1.PodSpec{
 						ServiceAccountName: types.ControllerServiceAccountName,


### PR DESCRIPTION
This can be done either as annotations on the skupper-site configmap, for use
with site-controller, or via command line.