### PR TITLE
cli: remove repeated function

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -180,24 +179,6 @@ func NewClientHandleError(namespace string, context string, kubeConfigPath strin
 var routerCreateOpts types.SiteConfigSpec
 var routerLogging string
 
-// TODO unit-test me
-func inStringSlice(options []string, value string) bool {
-	l := options[:] //do a copy to avoid modifying the original list
-	sort.Sort(sort.StringSlice(l))
-
-	// from library doc:
-	// SearchStrings searches for x in a sorted slice of strings and returns the index
-	// as specified by Search. The return value is the index to insert x if x is not
-	// present (it could be len(a)).
-	// The slice must be sorted in ascending order.
-	//
-	position := sort.SearchStrings(l, value)
-	if position == len(l) || (l[position] != value) {
-		return false
-	}
-	return true
-}
-
 var ClusterLocal bool
 
 func NewCmdInit(newClient cobraFunc) *cobra.Command {
@@ -224,7 +205,7 @@ installation that can then be connected to other skupper installations`,
 
 			if routerModeFlag.Changed {
 				options := []string{string(types.TransportModeInterior), string(types.TransportModeEdge)}
-				if !inStringSlice(options, routerMode) {
+				if !stringSliceContains(options, routerMode) {
 					return fmt.Errorf(`invalid "--router-mode=%v", it must be one of "%v"`, routerMode, strings.Join(options, ", "))
 				}
 				routerCreateOpts.RouterMode = routerMode


### PR DESCRIPTION
Removing a function that checks for a string in a slice
in favor of using an existing function that is faster
with less allocations.

```go
func Benchmark_stringSliceContains(b *testing.B) {
	sli := []string{"some", "thing", "passed", "to", "a", "cli", "command"}
	str := "to"
	for n := 0; n < b.N; n++ {
		if contains := stringSliceContains(sli, str); !contains {
			b.Fatal("slice does contains str")
		}
	}
}

func Benchmark_inStringSlice(b *testing.B) {
	sli := []string{"some", "thing", "passed", "to", "a", "cli", "command"}
	str := "to"
	for n := 0; n < b.N; n++ {
		if contains := inStringSlice(sli, str); !contains {
			b.Fatal("slice does contains str")
		}
	}
}
```

Results:

```
 ► go test -benchmem -run=^$ -bench ^Benchmark_stringSliceContains$ github.com/skupperproject/skupper/cmd/skupper
goos: linux
goarch: amd64
pkg: github.com/skupperproject/skupper/cmd/skupper
cpu: Intel(R) Core(TM) i7-7600U CPU @ 2.80GHz
Benchmark_stringSliceContains-4   	146819398	         8.318 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/skupperproject/skupper/cmd/skupper	2.060s

 ► go test -benchmem -run=^$ -bench ^Benchmark_inStringSlice$ github.com/skupperproject/skupper/cmd/skupper
goos: linux
goarch: amd64
pkg: github.com/skupperproject/skupper/cmd/skupper
cpu: Intel(R) Core(TM) i7-7600U CPU @ 2.80GHz
Benchmark_inStringSlice-4   	 6577165	       166.9 ns/op	      24 B/op	       1 allocs/op
PASS
ok  	github.com/skupperproject/skupper/cmd/skupper	1.294s

```
