### PR TITLE
Allow access to a site to be revoked

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -180,4 +180,5 @@ type VanClientInterface interface {
 	GetNamespace() string
 	GetVersion(component string, name string) string
 	GetIngressDefault() string
+	RevokeAccess(ctx context.Context) error
 }

--- a/client/revoke_all.go
+++ b/client/revoke_all.go
@@ -1,0 +1,59 @@
+package client
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/pkg/kube"
+)
+
+func (cli *VanClient) RevokeAccess(ctx context.Context) error {
+	records, err := cli.KubeClient.CoreV1().Secrets(cli.Namespace).List(metav1.ListOptions{LabelSelector: "skupper.io/type=token-claim-record"})
+	if err != nil {
+		return err
+	}
+	for _, record := range records.Items {
+		err = cli.KubeClient.CoreV1().Secrets(cli.Namespace).Delete(record.Name, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	ca, err := kube.RegenerateCertAuthority(types.SiteCaSecret, cli.Namespace, cli.KubeClient)
+	if err != nil {
+		return err
+	}
+	siteServerSecret := types.Credential{
+		Name:    types.SiteServerSecret,
+		Subject: types.TransportServiceName,
+	}
+	usingRoutes := false
+	if cli.RouteClient != nil {
+		route, err := kube.GetRoute(types.InterRouterRouteName, cli.Namespace, cli.RouteClient)
+		if err == nil {
+			usingRoutes = true
+			siteServerSecret.Hosts = append(siteServerSecret.Hosts, route.Spec.Host)
+			route, err = kube.GetRoute(types.EdgeRouteName, cli.Namespace, cli.RouteClient)
+			if err != nil {
+				return err
+			}
+			siteServerSecret.Hosts = append(siteServerSecret.Hosts, route.Spec.Host)
+		} else if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	if !usingRoutes {
+		err = cli.appendLoadBalancerHostOrIp(types.TransportServiceName, cli.Namespace, &siteServerSecret)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = kube.RegenerateCredentials(siteServerSecret, cli.Namespace, ca, cli.KubeClient)
+	if err != nil {
+		return err
+	}
+	return cli.restartRouter(cli.Namespace)
+}

--- a/client/revoke_all_test.go
+++ b/client/revoke_all_test.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/skupperproject/skupper/api/types"
+	"gotest.tools/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRevokeAccess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cli, err := newMockClient("skupper", "", "")
+
+	err = cli.RouterCreate(ctx, types.SiteConfig{
+		Spec: types.SiteConfigSpec{
+			SkupperName:       "skupper",
+			RouterMode:        string(types.TransportModeInterior),
+			EnableController:  true,
+			EnableServiceSync: true,
+			EnableConsole:     false,
+			AuthMode:          "",
+			User:              "",
+			Password:          "",
+			Ingress:           types.IngressNoneString,
+		},
+	})
+	assert.Check(t, err, "Unable to create router")
+
+	ca1, err := cli.KubeClient.CoreV1().Secrets(cli.Namespace).Get(types.SiteCaSecret, metav1.GetOptions{})
+	assert.Check(t, err, "Unable to get CA before revocation")
+
+	cert1, err := cli.KubeClient.CoreV1().Secrets(cli.Namespace).Get(types.SiteServerSecret, metav1.GetOptions{})
+	assert.Check(t, err, "Unable to get cert before revocation")
+
+	cli.RevokeAccess(ctx)
+
+	ca2, err := cli.KubeClient.CoreV1().Secrets(cli.Namespace).Get(types.SiteCaSecret, metav1.GetOptions{})
+	assert.Check(t, err, "Unable to get CA before revocation")
+
+	cert2, err := cli.KubeClient.CoreV1().Secrets(cli.Namespace).Get(types.SiteServerSecret, metav1.GetOptions{})
+	assert.Check(t, err, "Unable to get cert before revocation")
+
+	for key, value := range ca1.Data {
+		assert.Assert(t, !bytes.Equal(ca2.Data[key], value), "Same value for "+key)
+	}
+	for key, value := range cert1.Data {
+		assert.Assert(t, !bytes.Equal(cert2.Data[key], value), "Same value for "+key)
+	}
+}

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -882,6 +882,26 @@ func NewCmdDebugDump(newClient cobraFunc) *cobra.Command {
 	return cmd
 }
 
+func NewCmdRevokeaccess(newClient cobraFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "revoke-access",
+		Short: "Revoke all previously granted access to the site.",
+		Long: `This will invalidate all previously issued tokens and require that all
+links to this site be re-established with new tokens.`,
+		Args:   cobra.ExactArgs(0),
+		PreRun: newClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+			err := cli.RevokeAccess(context.Background())
+			if err != nil {
+				return fmt.Errorf("Unable to revoke access: %w", err)
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
 func NewCmdCompletion() *cobra.Command {
 	completionLong := `
 Output shell completion code for bash.
@@ -990,6 +1010,8 @@ func init() {
 
 	cmdCompletion := NewCmdCompletion()
 
+	cmdRevokeAll := NewCmdRevokeaccess(newClient)
+
 	rootCmd = &cobra.Command{Use: "skupper"}
 	rootCmd.AddCommand(cmdInit,
 		cmdDelete,
@@ -1010,7 +1032,8 @@ func init() {
 		cmdUnbind,
 		cmdVersion,
 		cmdDebug,
-		cmdCompletion)
+		cmdCompletion,
+		cmdRevokeAll)
 
 	rootCmd.PersistentFlags().StringVarP(&kubeConfigPath, "kubeconfig", "", "", "Path to the kubeconfig file to use")
 	rootCmd.PersistentFlags().StringVarP(&kubeContext, "context", "c", "", "The kubeconfig context to use")

--- a/cmd/skupper/skupper_mock_test.go
+++ b/cmd/skupper/skupper_mock_test.go
@@ -222,6 +222,10 @@ func (cli *vanClientMock) GetVersion(component string, name string) string {
 	return "not-found"
 }
 
+func (v *vanClientMock) RevokeAccess(ctx context.Context) error {
+	return nil
+}
+
 func TestCmdUnexposeRun(t *testing.T) {
 	cmd := NewCmdUnexpose(nil)
 	test := func(targetType, targetName, address string) {


### PR DESCRIPTION
Provides a CLI command with which to revoke access for any inbound links to a site, by regenerating the CA used to issue certificates for TLS connections.