### PR TITLE
Initial support for nodeport as ingress

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -53,10 +53,12 @@ type RouterOptions struct {
 	DebugMode        string
 	MaxFrameSize     int
 	MaxSessionFrames int
+	IngressHost      string
 }
 
 type ControllerOptions struct {
 	Tuning
+	IngressHost string
 }
 
 type SiteConfigSpec struct {
@@ -83,6 +85,7 @@ type SiteConfigSpec struct {
 const (
 	IngressRouteString        string = "route"
 	IngressLoadBalancerString string = "loadbalancer"
+	IngressNodePortString     string = "nodeport"
 	IngressNoneString         string = "none"
 )
 
@@ -91,6 +94,9 @@ func (s *SiteConfigSpec) IsIngressRoute() bool {
 }
 func (s *SiteConfigSpec) IsIngressLoadBalancer() bool {
 	return s.Ingress == IngressLoadBalancerString
+}
+func (s *SiteConfigSpec) IsIngressNodePort() bool {
+	return s.Ingress == IngressNodePortString
 }
 func (s *SiteConfigSpec) IsIngressNone() bool {
 	return s.Ingress == IngressNoneString
@@ -101,6 +107,9 @@ func (s *SiteConfigSpec) IsConsoleIngressRoute() bool {
 }
 func (s *SiteConfigSpec) IsConsoleIngressLoadBalancer() bool {
 	return s.getConsoleIngress() == IngressLoadBalancerString
+}
+func (s *SiteConfigSpec) IsConsoleIngressNodePort() bool {
+	return s.getConsoleIngress() == IngressNodePortString
 }
 func (s *SiteConfigSpec) IsConsoleIngressNone() bool {
 	return s.getConsoleIngress() == IngressNoneString
@@ -113,7 +122,7 @@ func (s *SiteConfigSpec) getConsoleIngress() string {
 }
 
 func isValidIngress(ingress string) bool {
-	return ingress == "" || ingress == IngressRouteString || ingress == IngressLoadBalancerString || ingress == IngressNoneString
+	return ingress == "" || ingress == IngressRouteString || ingress == IngressLoadBalancerString || ingress == IngressNodePortString || ingress == IngressNoneString
 }
 
 func (s *SiteConfigSpec) CheckIngress() error {

--- a/client/connector_token_create.go
+++ b/client/connector_token_create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -64,6 +65,35 @@ func configureHostPortsFromRoutes(result *RouterHostPorts, cli *VanClient, names
 	}
 }
 
+func getNodePorts(result *RouterHostPorts, service *corev1.Service) bool {
+	foundEdge, foundInterRouter := false, false
+	for _, p := range service.Spec.Ports {
+		if p.Name == "inter-router" {
+			result.InterRouter.Port = strconv.Itoa(int(p.NodePort))
+			foundInterRouter = true
+		} else if p.Name == "edge" {
+			result.Edge.Port = strconv.Itoa(int(p.NodePort))
+			foundEdge = true
+		}
+	}
+	return foundEdge && foundInterRouter
+}
+
+func getIngressHost(result *RouterHostPorts, cli *VanClient, namespace string) bool {
+	configmap, err := kube.GetConfigMap(types.SiteConfigMapName, cli.Namespace, cli.KubeClient)
+	if err != nil {
+		fmt.Printf("Failed to look up ingress host for nodeport: %s, ", err)
+		fmt.Println()
+		return false
+	} else if len(configmap.Data) > 0 && configmap.Data[SiteConfigRouterIngressHostKey] != "" {
+		result.Hosts = configmap.Data[SiteConfigRouterIngressHostKey]
+		result.InterRouter.Host = result.Hosts
+		result.Edge.Host = result.Hosts
+		return true
+	}
+	return false
+}
+
 func configureHostPorts(result *RouterHostPorts, cli *VanClient, namespace string) bool {
 	if namespace == "" {
 		namespace = cli.Namespace
@@ -89,7 +119,11 @@ func configureHostPorts(result *RouterHostPorts, cli *VanClient, namespace strin
 					return true
 				} else {
 					fmt.Printf("LoadBalancer Host/IP not yet allocated for service %s, ", service.ObjectMeta.Name)
+					fmt.Println()
 				}
+			} else if service.Spec.Type == corev1.ServiceTypeNodePort && getNodePorts(result, service) {
+				getIngressHost(result, cli, namespace)
+				return true
 			}
 			result.LocalOnly = true
 			host := fmt.Sprintf("%s.%s", types.TransportServiceName, namespace)

--- a/client/router_inspect.go
+++ b/client/router_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -21,6 +22,21 @@ func (cli *VanClient) getConsoleUrl() (string, error) {
 			if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
 				host := kube.GetLoadBalancerHostOrIp(service)
 				return "http://" + host + ":8080", nil
+			} else if service.Spec.Type == corev1.ServiceTypeNodePort {
+				port := ""
+				for _, p := range service.Spec.Ports {
+					if p.Name == "metrics" {
+						port = strconv.Itoa(int(p.NodePort))
+					}
+				}
+				config, err := cli.SiteConfigInspect(context.Background(), nil)
+				if err != nil {
+					return "", err
+				}
+				if config.Spec.Controller.IngressHost == "" || port == "" {
+					return "", nil
+				}
+				return "http://" + config.Spec.Controller.IngressHost + ":" + port, nil
 			} else {
 				return "", nil
 			}

--- a/client/site_config_create.go
+++ b/client/site_config_create.go
@@ -36,6 +36,7 @@ const (
 	SiteConfigRouterNodeSelectorKey     string = "router-node-selector"
 	SiteConfigRouterMaxFrameSizeKey     string = "xp-router-max-frame-size"
 	SiteConfigRouterMaxSessionFramesKey string = "xp-router-max-session-frames"
+	SiteConfigRouterIngressHostKey      string = "router-ingress-host"
 
 	//controller options
 	SiteConfigServiceControllerKey      string = "service-controller"
@@ -45,6 +46,7 @@ const (
 	SiteConfigControllerAffinityKey     string = "controller-pod-affinity"
 	SiteConfigControllerAntiAffinityKey string = "controller-pod-antiaffinity"
 	SiteConfigControllerNodeSelectorKey string = "controller-node-selector"
+	SiteConfigControllerIngressHostKey  string = "controller-ingress-host"
 )
 
 func (cli *VanClient) SiteConfigCreate(ctx context.Context, spec types.SiteConfigSpec) (*types.SiteConfig, error) {
@@ -132,6 +134,9 @@ func (cli *VanClient) SiteConfigCreate(ctx context.Context, spec types.SiteConfi
 	if spec.Router.NodeSelector != "" {
 		siteConfig.Data[SiteConfigRouterNodeSelectorKey] = spec.Router.NodeSelector
 	}
+	if spec.Router.IngressHost != "" {
+		siteConfig.Data[SiteConfigRouterIngressHostKey] = spec.Router.IngressHost
+	}
 	if spec.Router.MaxFrameSize != types.RouterMaxFrameSizeDefault {
 		siteConfig.Data[SiteConfigRouterMaxFrameSizeKey] = strconv.Itoa(spec.Router.MaxFrameSize)
 	}
@@ -158,6 +163,9 @@ func (cli *VanClient) SiteConfigCreate(ctx context.Context, spec types.SiteConfi
 	}
 	if spec.Controller.NodeSelector != "" {
 		siteConfig.Data[SiteConfigControllerNodeSelectorKey] = spec.Controller.NodeSelector
+	}
+	if spec.Controller.IngressHost != "" {
+		siteConfig.Data[SiteConfigControllerIngressHostKey] = spec.Controller.IngressHost
 	}
 	// TODO: allow Replicas to be set through skupper-site configmap?
 	if !spec.SiteControlled {

--- a/client/site_config_inspect.go
+++ b/client/site_config_inspect.go
@@ -142,6 +142,9 @@ func (cli *VanClient) SiteConfigInspectInNamespace(ctx context.Context, input *c
 	if routerAntiAffinity, ok := siteConfig.Data[SiteConfigRouterAntiAffinityKey]; ok && routerAntiAffinity != "" {
 		result.Spec.Router.AntiAffinity = routerAntiAffinity
 	}
+	if routerIngressHost, ok := siteConfig.Data[SiteConfigRouterIngressHostKey]; ok && routerIngressHost != "" {
+		result.Spec.Router.IngressHost = routerIngressHost
+	}
 
 	if routerMaxFrameSize, ok := siteConfig.Data[SiteConfigRouterMaxFrameSizeKey]; ok && routerMaxFrameSize != "" {
 		val, err := strconv.Atoi(routerMaxFrameSize)
@@ -176,6 +179,9 @@ func (cli *VanClient) SiteConfigInspectInNamespace(ctx context.Context, input *c
 	}
 	if controllerAntiAffinity, ok := siteConfig.Data[SiteConfigControllerAntiAffinityKey]; ok && controllerAntiAffinity != "" {
 		result.Spec.Controller.AntiAffinity = controllerAntiAffinity
+	}
+	if controllerIngressHost, ok := siteConfig.Data[SiteConfigControllerIngressHostKey]; ok && controllerIngressHost != "" {
+		result.Spec.Controller.IngressHost = controllerIngressHost
 	}
 
 	annotationExclusions := []string{}

--- a/client/site_config_test.go
+++ b/client/site_config_test.go
@@ -145,6 +145,26 @@ func TestSiteConfigRoundtrip(t *testing.T) {
 				},
 			},
 		},
+		{
+			input: types.SiteConfigSpec{
+				Ingress: "nodeport",
+				Router: types.RouterOptions{
+					IngressHost: "foo.com",
+				},
+			},
+			expected: types.SiteConfigSpec{
+				SkupperName:      "site-config-roundtrip-6",
+				SkupperNamespace: "site-config-roundtrip-6",
+				Ingress:          "nodeport",
+				RouterMode:       "interior",
+				AuthMode:         "internal",
+				Annotations:      map[string]string{},
+				Labels:           map[string]string{},
+				Router: types.RouterOptions{
+					IngressHost: "foo.com",
+				},
+			},
+		},
 	}
 
 	isCluster := *clusterRun

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -277,6 +277,9 @@ installation that can then be connected to other skupper installations`,
 			} else if !routerIngressFlag.Changed {
 				routerCreateOpts.Ingress = cli.GetIngressDefault()
 			}
+			if routerCreateOpts.Ingress == types.IngressNodePortString && routerCreateOpts.Router.IngressHost == "" {
+				return fmt.Errorf(`--router-ingress-host option is required when using "--ingress nodeport"`)
+			}
 			routerCreateOpts.Annotations = asMap(annotations)
 			routerCreateOpts.Labels = asMap(labels)
 			if err := routerCreateOpts.CheckIngress(); err != nil {
@@ -335,8 +338,8 @@ installation that can then be connected to other skupper installations`,
 	cmd.Flags().StringVarP(&routerCreateOpts.AuthMode, "console-auth", "", "", "Authentication mode for console(s). One of: 'openshift', 'internal', 'unsecured'")
 	cmd.Flags().StringVarP(&routerCreateOpts.User, "console-user", "", "", "Skupper console user. Valid only when --console-auth=internal")
 	cmd.Flags().StringVarP(&routerCreateOpts.Password, "console-password", "", "", "Skupper console user. Valid only when --console-auth=internal")
-	cmd.Flags().StringVarP(&routerCreateOpts.Ingress, "ingress", "", "", "Setup Skupper ingress to one of: [loadbalancer|route|none]. If not specified route is used when available, otherwise loadbalancer is used.")
-	cmd.Flags().StringVarP(&routerCreateOpts.ConsoleIngress, "console-ingress", "", "", "Determines if/how console is exposed outside cluster. If not specified uses value of --ingress. One of: [loadbalancer|route|none].")
+	cmd.Flags().StringVarP(&routerCreateOpts.Ingress, "ingress", "", "", "Setup Skupper ingress to one of: [loadbalancer|route|nodeport|none]. If not specified route is used when available, otherwise loadbalancer is used.")
+	cmd.Flags().StringVarP(&routerCreateOpts.ConsoleIngress, "console-ingress", "", "", "Determines if/how console is exposed outside cluster. If not specified uses value of --ingress. One of: [loadbalancer|route|nodeport|none].")
 	cmd.Flags().StringVarP(&routerMode, "router-mode", "", string(types.TransportModeInterior), "Skupper router-mode")
 
 	cmd.Flags().StringSliceVar(&annotations, "annotations", []string{}, "Annotations to add to skupper pods")
@@ -351,12 +354,14 @@ installation that can then be connected to other skupper installations`,
 	cmd.Flags().StringVar(&routerCreateOpts.Router.NodeSelector, "router-node-selector", "", "Node selector to control placement of router pods")
 	cmd.Flags().StringVar(&routerCreateOpts.Router.Affinity, "router-pod-affinity", "", "Pod affinity label matches to control placement of router pods")
 	cmd.Flags().StringVar(&routerCreateOpts.Router.AntiAffinity, "router-pod-antiaffinity", "", "Pod antiaffinity label matches to control placement of router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.IngressHost, "router-ingress-host", "", "Host through which node is accessible when using nodeport as ingress.")
 
 	cmd.Flags().StringVar(&routerCreateOpts.Controller.Cpu, "controller-cpu", "", "CPU request for controller pods")
 	cmd.Flags().StringVar(&routerCreateOpts.Controller.Memory, "controller-memory", "", "Memory request for controller pods")
 	cmd.Flags().StringVar(&routerCreateOpts.Controller.NodeSelector, "controller-node-selector", "", "Node selector to control placement of controller pods")
 	cmd.Flags().StringVar(&routerCreateOpts.Controller.Affinity, "controller-pod-affinity", "", "Pod affinity label matches to control placement of controller pods")
 	cmd.Flags().StringVar(&routerCreateOpts.Controller.AntiAffinity, "controller-pod-antiaffinity", "", "Pod antiaffinity label matches to control placement of controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.IngressHost, "controller-ingress-host", "", "Host through which node is accessible when using nodeport as ingress.")
 
 	cmd.Flags().BoolVarP(&ClusterLocal, "cluster-local", "", false, "Set up Skupper to only accept connections from within the local cluster.")
 	f := cmd.Flag("cluster-local")

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.1.2
 	github.com/gophercloud/gophercloud v0.8.0 // indirect
+	github.com/gorilla/mux v1.8.0
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/interconnectedcloud/go-amqp v0.12.6-0.20200506124159-f51e540008b5
 	github.com/openshift/api v0.0.0-20200109182645-c3cf38ec5571

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsC
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.8.0 h1:1ylFFLRx7otpfRPSuOm77q8HLSlSOwYCGDeXmXJhX7A=
 github.com/gophercloud/gophercloud v0.8.0/go.mod h1:Kc/QKr9thLKruO/dG0szY8kRIYS+iENz0ziI0hJf76A=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=


### PR DESCRIPTION
Also adds a --router-ingress-host by which the user can supply the appropriate name through which the node would be accessed.