### PR TITLE
Support for nginx ingress

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -74,6 +74,7 @@ type SiteConfigSpec struct {
 	Password            string
 	Ingress             string
 	ConsoleIngress      string
+	IngressHost         string
 	Replicas            int32
 	SiteControlled      bool
 	Annotations         map[string]string
@@ -86,6 +87,7 @@ const (
 	IngressRouteString        string = "route"
 	IngressLoadBalancerString string = "loadbalancer"
 	IngressNodePortString     string = "nodeport"
+	IngressNginxIngressString string = "nginx-ingress-v1"
 	IngressNoneString         string = "none"
 )
 
@@ -97,6 +99,9 @@ func (s *SiteConfigSpec) IsIngressLoadBalancer() bool {
 }
 func (s *SiteConfigSpec) IsIngressNodePort() bool {
 	return s.Ingress == IngressNodePortString
+}
+func (s *SiteConfigSpec) IsIngressNginxIngress() bool {
+	return s.Ingress == IngressNginxIngressString
 }
 func (s *SiteConfigSpec) IsIngressNone() bool {
 	return s.Ingress == IngressNoneString
@@ -111,6 +116,9 @@ func (s *SiteConfigSpec) IsConsoleIngressLoadBalancer() bool {
 func (s *SiteConfigSpec) IsConsoleIngressNodePort() bool {
 	return s.getConsoleIngress() == IngressNodePortString
 }
+func (s *SiteConfigSpec) IsConsoleIngressNginxIngress() bool {
+	return s.getConsoleIngress() == IngressNginxIngressString
+}
 func (s *SiteConfigSpec) IsConsoleIngressNone() bool {
 	return s.getConsoleIngress() == IngressNoneString
 }
@@ -122,7 +130,7 @@ func (s *SiteConfigSpec) getConsoleIngress() string {
 }
 
 func isValidIngress(ingress string) bool {
-	return ingress == "" || ingress == IngressRouteString || ingress == IngressLoadBalancerString || ingress == IngressNodePortString || ingress == IngressNoneString
+	return ingress == "" || ingress == IngressRouteString || ingress == IngressLoadBalancerString || ingress == IngressNodePortString || ingress == IngressNginxIngressString || ingress == IngressNoneString
 }
 
 func (s *SiteConfigSpec) CheckIngress() error {
@@ -137,6 +145,20 @@ func (s *SiteConfigSpec) CheckConsoleIngress() error {
 		return fmt.Errorf("Invalid value for console-ingress: %s", s.ConsoleIngress)
 	}
 	return nil
+}
+
+func (s *SiteConfigSpec) GetRouterIngressHost() string {
+	if s.Router.IngressHost != "" {
+		return s.Router.IngressHost
+	}
+	return s.IngressHost
+}
+
+func (s *SiteConfigSpec) GetControllerIngressHost() string {
+	if s.Controller.IngressHost != "" {
+		return s.Controller.IngressHost
+	}
+	return s.IngressHost
 }
 
 type SiteConfigReference struct {

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -53,10 +53,12 @@ type RouterOptions struct {
 	DebugMode        string
 	MaxFrameSize     int
 	MaxSessionFrames int
+	IngressHost      string
 }
 
 type ControllerOptions struct {
 	Tuning
+	IngressHost string
 }
 
 type SiteConfigSpec struct {
@@ -83,6 +85,7 @@ type SiteConfigSpec struct {
 const (
 	IngressRouteString        string = "route"
 	IngressLoadBalancerString string = "loadbalancer"
+	IngressNodePortString     string = "nodeport"
 	IngressNoneString         string = "none"
 )
 
@@ -91,6 +94,9 @@ func (s *SiteConfigSpec) IsIngressRoute() bool {
 }
 func (s *SiteConfigSpec) IsIngressLoadBalancer() bool {
 	return s.Ingress == IngressLoadBalancerString
+}
+func (s *SiteConfigSpec) IsIngressNodePort() bool {
+	return s.Ingress == IngressNodePortString
 }
 func (s *SiteConfigSpec) IsIngressNone() bool {
 	return s.Ingress == IngressNoneString
@@ -101,6 +107,9 @@ func (s *SiteConfigSpec) IsConsoleIngressRoute() bool {
 }
 func (s *SiteConfigSpec) IsConsoleIngressLoadBalancer() bool {
 	return s.getConsoleIngress() == IngressLoadBalancerString
+}
+func (s *SiteConfigSpec) IsConsoleIngressNodePort() bool {
+	return s.getConsoleIngress() == IngressNodePortString
 }
 func (s *SiteConfigSpec) IsConsoleIngressNone() bool {
 	return s.getConsoleIngress() == IngressNoneString
@@ -113,7 +122,7 @@ func (s *SiteConfigSpec) getConsoleIngress() string {
 }
 
 func isValidIngress(ingress string) bool {
-	return ingress == "" || ingress == IngressRouteString || ingress == IngressLoadBalancerString || ingress == IngressNoneString
+	return ingress == "" || ingress == IngressRouteString || ingress == IngressLoadBalancerString || ingress == IngressNodePortString || ingress == IngressNoneString
 }
 
 func (s *SiteConfigSpec) CheckIngress() error {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -190,6 +190,7 @@ const (
 	ConsoleOpenShiftOauthServicePort       int32  = 443
 	ConsoleOpenShiftOauthServiceTargetPort int32  = 8443
 	ConsoleRouteName                       string = "skupper"
+	ConsoleIngressName                     string = "skupper-console"
 	RouterConsoleRouteName                 string = "skupper-router-console"
 	RouterConsoleServiceName               string = "skupper-router-console"
 )
@@ -219,6 +220,7 @@ const (
 	InterRouterListenerPort int32  = 55671
 	InterRouterRouteName    string = "skupper-inter-router"
 	InterRouterProfile      string = "skupper-internal"
+	IngressName             string = "skupper"
 )
 
 // Service Sync constants

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -105,6 +105,11 @@ var ControllerPolicyRule = []rbacv1.PolicyRule{
 		APIGroups: []string{"route.openshift.io"},
 		Resources: []string{"routes"},
 	},
+	{
+		Verbs:     []string{"get", "list", "watch"},
+		APIGroups: []string{"networking.k8s.io"},
+		Resources: []string{"ingresses"},
+	},
 }
 
 // Certifcates/Secrets constants

--- a/client/connector_token_create.go
+++ b/client/connector_token_create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -64,6 +65,35 @@ func configureHostPortsFromRoutes(result *RouterHostPorts, cli *VanClient, names
 	}
 }
 
+func getNodePorts(result *RouterHostPorts, service *corev1.Service) bool {
+	foundEdge, foundInterRouter := false, false
+	for _, p := range service.Spec.Ports {
+		if p.Name == "inter-router" {
+			result.InterRouter.Port = strconv.Itoa(int(p.NodePort))
+			foundInterRouter = true
+		} else if p.Name == "edge" {
+			result.Edge.Port = strconv.Itoa(int(p.NodePort))
+			foundEdge = true
+		}
+	}
+	return foundEdge && foundInterRouter
+}
+
+func getIngressHost(result *RouterHostPorts, cli *VanClient, namespace string) bool {
+	configmap, err := kube.GetConfigMap(types.SiteConfigMapName, cli.Namespace, cli.KubeClient)
+	if err != nil {
+		fmt.Printf("Failed to look up ingress host for nodeport: %s, ", err)
+		fmt.Println()
+		return false
+	} else if len(configmap.Data) > 0 && configmap.Data[SiteConfigRouterIngressHostKey] != "" {
+		result.Hosts = configmap.Data[SiteConfigRouterIngressHostKey]
+		result.InterRouter.Host = result.Hosts
+		result.Edge.Host = result.Hosts
+		return true
+	}
+	return false
+}
+
 func configureHostPorts(result *RouterHostPorts, cli *VanClient, namespace string) bool {
 	if namespace == "" {
 		namespace = cli.Namespace
@@ -89,7 +119,11 @@ func configureHostPorts(result *RouterHostPorts, cli *VanClient, namespace strin
 					return true
 				} else {
 					fmt.Printf("LoadBalancer Host/IP not yet allocated for service %s, ", service.ObjectMeta.Name)
+					fmt.Println()
 				}
+			} else if service.Spec.Type == corev1.ServiceTypeNodePort && getNodePorts(result, service) {
+				getIngressHost(result, cli, namespace)
+				return true
 			}
 			result.LocalOnly = true
 			host := fmt.Sprintf("%s.%s", types.TransportServiceName, namespace)

--- a/client/connector_token_create.go
+++ b/client/connector_token_create.go
@@ -125,7 +125,7 @@ func configureHostPorts(result *RouterHostPorts, cli *VanClient, namespace strin
 				getIngressHost(result, cli, namespace)
 				return true
 			} else {
-				ingressRoutes, err := kube.GetIngressRoutes("skupper-ingress", cli.Namespace, cli.KubeClient)
+				ingressRoutes, err := kube.GetIngressRoutes(types.IngressName, cli.Namespace, cli.KubeClient)
 				if err != nil {
 					fmt.Printf("Could not check for ingress: %s", err)
 					fmt.Println()

--- a/client/revoke_all.go
+++ b/client/revoke_all.go
@@ -37,6 +37,10 @@ func (cli *VanClient) regenerateSiteSecret(ca *corev1.Secret) error {
 		if err != nil {
 			return err
 		}
+		err = cli.appendIngressHost([]string{"inter-router", "edge"}, cli.Namespace, &siteServerSecret)
+		if err != nil {
+			return err
+		}
 	}
 	_, err := kube.RegenerateCredentials(siteServerSecret, cli.Namespace, ca, cli.KubeClient)
 	if err != nil {
@@ -63,6 +67,10 @@ func (cli *VanClient) regenerateClaimsSecret(ca *corev1.Secret) error {
 	}
 	if !usingRoutes {
 		err := cli.appendLoadBalancerHostOrIp(types.ControllerServiceName, cli.Namespace, &claimsServerSecret)
+		if err != nil {
+			return err
+		}
+		err = cli.appendIngressHost([]string{"claims"}, cli.Namespace, &claimsServerSecret)
 		if err != nil {
 			return err
 		}

--- a/client/router_inspect.go
+++ b/client/router_inspect.go
@@ -38,7 +38,11 @@ func (cli *VanClient) getConsoleUrl() (string, error) {
 				}
 				return "http://" + config.Spec.Controller.IngressHost + ":" + port, nil
 			} else {
-				return "", nil
+				routes, err := kube.GetIngressRoutes(types.ConsoleIngressName, cli.Namespace, cli.KubeClient)
+				if err != nil || len(routes) == 0 {
+					return "", err
+				}
+				return "http://" + routes[0].Host, nil
 			}
 		}
 	} else {

--- a/client/router_inspect.go
+++ b/client/router_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -21,6 +22,21 @@ func (cli *VanClient) getConsoleUrl() (string, error) {
 			if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
 				host := kube.GetLoadBalancerHostOrIp(service)
 				return "http://" + host + ":8080", nil
+			} else if service.Spec.Type == corev1.ServiceTypeNodePort {
+				port := ""
+				for _, p := range service.Spec.Ports {
+					if p.Name == "metrics" {
+						port = strconv.Itoa(int(p.NodePort))
+					}
+				}
+				config, err := cli.SiteConfigInspect(context.Background(), nil)
+				if err != nil {
+					return "", err
+				}
+				if config.Spec.Controller.IngressHost == "" || port == "" {
+					return "", nil
+				}
+				return "http://" + config.Spec.Controller.IngressHost + ":" + port, nil
 			} else {
 				return "", nil
 			}

--- a/client/site_config_create.go
+++ b/client/site_config_create.go
@@ -36,6 +36,7 @@ const (
 	SiteConfigRouterNodeSelectorKey     string = "router-node-selector"
 	SiteConfigRouterMaxFrameSizeKey     string = "xp-router-max-frame-size"
 	SiteConfigRouterMaxSessionFramesKey string = "xp-router-max-session-frames"
+	SiteConfigRouterIngressHostKey      string = "router-ingress-host"
 
 	//controller options
 	SiteConfigServiceControllerKey      string = "service-controller"
@@ -45,6 +46,7 @@ const (
 	SiteConfigControllerAffinityKey     string = "controller-pod-affinity"
 	SiteConfigControllerAntiAffinityKey string = "controller-pod-antiaffinity"
 	SiteConfigControllerNodeSelectorKey string = "controller-node-selector"
+	SiteConfigControllerIngressHostKey  string = "controller-ingress-host"
 )
 
 func (cli *VanClient) SiteConfigCreate(ctx context.Context, spec types.SiteConfigSpec) (*types.SiteConfig, error) {
@@ -132,6 +134,9 @@ func (cli *VanClient) SiteConfigCreate(ctx context.Context, spec types.SiteConfi
 	if spec.Router.NodeSelector != "" {
 		siteConfig.Data[SiteConfigRouterNodeSelectorKey] = spec.Router.NodeSelector
 	}
+	if spec.Router.IngressHost != "" {
+		siteConfig.Data[SiteConfigRouterIngressHostKey] = spec.Router.IngressHost
+	}
 	if spec.Router.MaxFrameSize != types.RouterMaxFrameSizeDefault {
 		siteConfig.Data[SiteConfigRouterMaxFrameSizeKey] = strconv.Itoa(spec.Router.MaxFrameSize)
 	}
@@ -158,6 +163,9 @@ func (cli *VanClient) SiteConfigCreate(ctx context.Context, spec types.SiteConfi
 	}
 	if spec.Controller.NodeSelector != "" {
 		siteConfig.Data[SiteConfigControllerNodeSelectorKey] = spec.Controller.NodeSelector
+	}
+	if spec.Controller.IngressHost != "" {
+		siteConfig.Data[SiteConfigControllerIngressHostKey] = spec.Controller.IngressHost
 	}
 	// TODO: allow Replicas to be set through skupper-site configmap?
 	if !spec.SiteControlled {

--- a/client/site_config_create.go
+++ b/client/site_config_create.go
@@ -14,9 +14,10 @@ import (
 
 const (
 	//core options
-	SiteConfigNameKey       string = "name"
-	SiteConfigRouterModeKey string = "router-mode"
-	SiteConfigIngressKey    string = "ingress"
+	SiteConfigNameKey        string = "name"
+	SiteConfigRouterModeKey  string = "router-mode"
+	SiteConfigIngressKey     string = "ingress"
+	SiteConfigIngressHostKey string = "ingress-host"
 
 	//console options
 	SiteConfigConsoleKey               string = "console"
@@ -106,6 +107,9 @@ func (cli *VanClient) SiteConfigCreate(ctx context.Context, spec types.SiteConfi
 	}
 	if spec.ConsoleIngress != "" {
 		siteConfig.Data[SiteConfigConsoleIngressKey] = spec.ConsoleIngress
+	}
+	if spec.IngressHost != "" {
+		siteConfig.Data[SiteConfigIngressHostKey] = spec.IngressHost
 	}
 	if spec.Router.Logging != nil {
 		siteConfig.Data[SiteConfigRouterLoggingKey] = RouterLogConfigToString(spec.Router.Logging)

--- a/client/site_config_inspect.go
+++ b/client/site_config_inspect.go
@@ -104,6 +104,9 @@ func (cli *VanClient) SiteConfigInspectInNamespace(ctx context.Context, input *c
 	if consoleIngress, ok := siteConfig.Data[SiteConfigConsoleIngressKey]; ok {
 		result.Spec.ConsoleIngress = consoleIngress
 	}
+	if ingressHost, ok := siteConfig.Data[SiteConfigIngressHostKey]; ok {
+		result.Spec.IngressHost = ingressHost
+	}
 	// TODO: allow Replicas to be set through skupper-site configmap?
 	if siteConfig.ObjectMeta.Labels == nil {
 		result.Spec.SiteControlled = true

--- a/client/site_config_inspect.go
+++ b/client/site_config_inspect.go
@@ -142,6 +142,9 @@ func (cli *VanClient) SiteConfigInspectInNamespace(ctx context.Context, input *c
 	if routerAntiAffinity, ok := siteConfig.Data[SiteConfigRouterAntiAffinityKey]; ok && routerAntiAffinity != "" {
 		result.Spec.Router.AntiAffinity = routerAntiAffinity
 	}
+	if routerIngressHost, ok := siteConfig.Data[SiteConfigRouterIngressHostKey]; ok && routerIngressHost != "" {
+		result.Spec.Router.IngressHost = routerIngressHost
+	}
 
 	if routerMaxFrameSize, ok := siteConfig.Data[SiteConfigRouterMaxFrameSizeKey]; ok && routerMaxFrameSize != "" {
 		val, err := strconv.Atoi(routerMaxFrameSize)
@@ -176,6 +179,9 @@ func (cli *VanClient) SiteConfigInspectInNamespace(ctx context.Context, input *c
 	}
 	if controllerAntiAffinity, ok := siteConfig.Data[SiteConfigControllerAntiAffinityKey]; ok && controllerAntiAffinity != "" {
 		result.Spec.Controller.AntiAffinity = controllerAntiAffinity
+	}
+	if controllerIngressHost, ok := siteConfig.Data[SiteConfigControllerIngressHostKey]; ok && controllerIngressHost != "" {
+		result.Spec.Controller.IngressHost = controllerIngressHost
 	}
 
 	annotationExclusions := []string{}

--- a/client/site_config_test.go
+++ b/client/site_config_test.go
@@ -145,6 +145,26 @@ func TestSiteConfigRoundtrip(t *testing.T) {
 				},
 			},
 		},
+		{
+			input: types.SiteConfigSpec{
+				Ingress: "nodeport",
+				Router: types.RouterOptions{
+					IngressHost: "foo.com",
+				},
+			},
+			expected: types.SiteConfigSpec{
+				SkupperName:      "site-config-roundtrip-6",
+				SkupperNamespace: "site-config-roundtrip-6",
+				Ingress:          "nodeport",
+				RouterMode:       "interior",
+				AuthMode:         "internal",
+				Annotations:      map[string]string{},
+				Labels:           map[string]string{},
+				Router: types.RouterOptions{
+					IngressHost: "foo.com",
+				},
+			},
+		},
 	}
 
 	isCluster := *clusterRun

--- a/client/token_claim_create.go
+++ b/client/token_claim_create.go
@@ -93,6 +93,21 @@ func (cli *VanClient) TokenClaimCreate(ctx context.Context, name string, passwor
 			return err
 		}
 		localOnly = false
+	} else {
+		ingressRoutes, err := kube.GetIngressRoutes("skupper-ingress", cli.Namespace, cli.KubeClient)
+		if err != nil {
+			return err
+		}
+		if len(ingressRoutes) > 0 {
+			for _, route := range ingressRoutes {
+				if route.ServicePort == int(types.ClaimRedemptionPort) {
+					host = route.Host
+					port = 443
+					localOnly = false
+					break
+				}
+			}
+		}
 	}
 	recordName, err := uuid.NewUUID()
 	if err != nil {

--- a/client/token_claim_create.go
+++ b/client/token_claim_create.go
@@ -94,7 +94,7 @@ func (cli *VanClient) TokenClaimCreate(ctx context.Context, name string, passwor
 		}
 		localOnly = false
 	} else {
-		ingressRoutes, err := kube.GetIngressRoutes("skupper-ingress", cli.Namespace, cli.KubeClient)
+		ingressRoutes, err := kube.GetIngressRoutes(types.IngressName, cli.Namespace, cli.KubeClient)
 		if err != nil {
 			return err
 		}

--- a/cmd/site-controller/deploy-watch-all-ns.yaml
+++ b/cmd/site-controller/deploy-watch-all-ns.yaml
@@ -54,6 +54,16 @@ rules:
   - create
   - delete
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/cmd/site-controller/deploy-watch-current-ns.yaml
+++ b/cmd/site-controller/deploy-watch-current-ns.yaml
@@ -53,6 +53,16 @@ rules:
   - create
   - delete
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -338,8 +338,9 @@ installation that can then be connected to other skupper installations`,
 	cmd.Flags().StringVarP(&routerCreateOpts.AuthMode, "console-auth", "", "", "Authentication mode for console(s). One of: 'openshift', 'internal', 'unsecured'")
 	cmd.Flags().StringVarP(&routerCreateOpts.User, "console-user", "", "", "Skupper console user. Valid only when --console-auth=internal")
 	cmd.Flags().StringVarP(&routerCreateOpts.Password, "console-password", "", "", "Skupper console user. Valid only when --console-auth=internal")
-	cmd.Flags().StringVarP(&routerCreateOpts.Ingress, "ingress", "", "", "Setup Skupper ingress to one of: [loadbalancer|route|nodeport|none]. If not specified route is used when available, otherwise loadbalancer is used.")
-	cmd.Flags().StringVarP(&routerCreateOpts.ConsoleIngress, "console-ingress", "", "", "Determines if/how console is exposed outside cluster. If not specified uses value of --ingress. One of: [loadbalancer|route|nodeport|none].")
+	cmd.Flags().StringVarP(&routerCreateOpts.Ingress, "ingress", "", "", "Setup Skupper ingress to one of: [loadbalancer|route|nodeport|nginx-ingress-v1|none]. If not specified route is used when available, otherwise loadbalancer is used.")
+	cmd.Flags().StringVarP(&routerCreateOpts.ConsoleIngress, "console-ingress", "", "", "Determines if/how console is exposed outside cluster. If not specified uses value of --ingress. One of: [loadbalancer|route|nodeport|nginx-ingress-v1|none].")
+	cmd.Flags().StringVarP(&routerCreateOpts.IngressHost, "ingress-host", "", "", "Hostname by which the ingress proxy can be reached")
 	cmd.Flags().StringVarP(&routerMode, "router-mode", "", string(types.TransportModeInterior), "Skupper router-mode")
 
 	cmd.Flags().StringSliceVar(&annotations, "annotations", []string{}, "Annotations to add to skupper pods")

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -277,6 +277,9 @@ installation that can then be connected to other skupper installations`,
 			} else if !routerIngressFlag.Changed {
 				routerCreateOpts.Ingress = cli.GetIngressDefault()
 			}
+			if routerCreateOpts.Ingress == types.IngressNodePortString && routerCreateOpts.Router.IngressHost == "" {
+				return fmt.Errorf(`--router-ingress-host option is required when using "--ingress nodeport"`)
+			}
 			routerCreateOpts.Annotations = asMap(annotations)
 			routerCreateOpts.Labels = asMap(labels)
 			if err := routerCreateOpts.CheckIngress(); err != nil {
@@ -335,8 +338,8 @@ installation that can then be connected to other skupper installations`,
 	cmd.Flags().StringVarP(&routerCreateOpts.AuthMode, "console-auth", "", "", "Authentication mode for console(s). One of: 'openshift', 'internal', 'unsecured'")
 	cmd.Flags().StringVarP(&routerCreateOpts.User, "console-user", "", "", "Skupper console user. Valid only when --console-auth=internal")
 	cmd.Flags().StringVarP(&routerCreateOpts.Password, "console-password", "", "", "Skupper console user. Valid only when --console-auth=internal")
-	cmd.Flags().StringVarP(&routerCreateOpts.Ingress, "ingress", "", "", "Setup Skupper ingress to one of: [loadbalancer|route|none]. If not specified route is used when available, otherwise loadbalancer is used.")
-	cmd.Flags().StringVarP(&routerCreateOpts.ConsoleIngress, "console-ingress", "", "", "Determines if/how console is exposed outside cluster. If not specified uses value of --ingress. One of: [loadbalancer|route|none].")
+	cmd.Flags().StringVarP(&routerCreateOpts.Ingress, "ingress", "", "", "Setup Skupper ingress to one of: [loadbalancer|route|nodeport|none]. If not specified route is used when available, otherwise loadbalancer is used.")
+	cmd.Flags().StringVarP(&routerCreateOpts.ConsoleIngress, "console-ingress", "", "", "Determines if/how console is exposed outside cluster. If not specified uses value of --ingress. One of: [loadbalancer|route|nodeport|none].")
 	cmd.Flags().StringVarP(&routerMode, "router-mode", "", string(types.TransportModeInterior), "Skupper router-mode")
 
 	cmd.Flags().StringSliceVar(&annotations, "annotations", []string{}, "Annotations to add to skupper pods")
@@ -351,12 +354,14 @@ installation that can then be connected to other skupper installations`,
 	cmd.Flags().StringVar(&routerCreateOpts.Router.NodeSelector, "router-node-selector", "", "Node selector to control placement of router pods")
 	cmd.Flags().StringVar(&routerCreateOpts.Router.Affinity, "router-pod-affinity", "", "Pod affinity label matches to control placement of router pods")
 	cmd.Flags().StringVar(&routerCreateOpts.Router.AntiAffinity, "router-pod-antiaffinity", "", "Pod antiaffinity label matches to control placement of router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.IngressHost, "router-ingress-host", "", "Host through which node is accessible when using nodeport as ingress.")
 
 	cmd.Flags().StringVar(&routerCreateOpts.Controller.Cpu, "controller-cpu", "", "CPU request for controller pods")
 	cmd.Flags().StringVar(&routerCreateOpts.Controller.Memory, "controller-memory", "", "Memory request for controller pods")
 	cmd.Flags().StringVar(&routerCreateOpts.Controller.NodeSelector, "controller-node-selector", "", "Node selector to control placement of controller pods")
 	cmd.Flags().StringVar(&routerCreateOpts.Controller.Affinity, "controller-pod-affinity", "", "Pod affinity label matches to control placement of controller pods")
 	cmd.Flags().StringVar(&routerCreateOpts.Controller.AntiAffinity, "controller-pod-antiaffinity", "", "Pod antiaffinity label matches to control placement of controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.IngressHost, "controller-ingress-host", "", "Host through which node is accessible when using nodeport as ingress.")
 
 	cmd.Flags().BoolVarP(&ClusterLocal, "cluster-local", "", false, "Set up Skupper to only accept connections from within the local cluster.")
 	f := cmd.Flag("cluster-local")

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.1.2
 	github.com/gophercloud/gophercloud v0.8.0 // indirect
+	github.com/gorilla/mux v1.8.0
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/interconnectedcloud/go-amqp v0.12.6-0.20200506124159-f51e540008b5
 	github.com/openshift/api v0.0.0-20200109182645-c3cf38ec5571

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsC
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.8.0 h1:1ylFFLRx7otpfRPSuOm77q8HLSlSOwYCGDeXmXJhX7A=
 github.com/gophercloud/gophercloud v0.8.0/go.mod h1:Kc/QKr9thLKruO/dG0szY8kRIYS+iENz0ziI0hJf76A=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/pkg/kube/ingress.go
+++ b/pkg/kube/ingress.go
@@ -1,0 +1,150 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+)
+
+type IngressRoute struct {
+	Host        string
+	ServiceName string
+	ServicePort int
+	Resolve     bool
+}
+
+func (r *IngressRoute) toRule() networkingv1.IngressRule {
+	return networkingv1.IngressRule{
+		Host: r.Host,
+		IngressRuleValue: networkingv1.IngressRuleValue{
+			HTTP: &networkingv1.HTTPIngressRuleValue{
+				Paths: []networkingv1.HTTPIngressPath{
+					{
+						Path: "/",
+						Backend: networkingv1.IngressBackend{
+							ServiceName: r.ServiceName,
+							ServicePort: intstr.FromInt(r.ServicePort),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func fromRule(rule *networkingv1.IngressRule) IngressRoute {
+	return IngressRoute{
+		Host:        rule.Host,
+		ServiceName: rule.IngressRuleValue.HTTP.Paths[0].Backend.ServiceName,
+		ServicePort: rule.IngressRuleValue.HTTP.Paths[0].Backend.ServicePort.IntValue(),
+	}
+}
+
+func getStatus(ingress *networkingv1.Ingress) *corev1.LoadBalancerIngress {
+	if len(ingress.Status.LoadBalancer.Ingress) > 0 {
+		status := ingress.Status.LoadBalancer.Ingress[0]
+		if status.IP != "" || status.Hostname != "" {
+			return &status
+		}
+	}
+	return nil
+}
+
+func CreatePassthroughIngress(name string, routes []IngressRoute, owner *metav1.OwnerReference, namespace string, cli kubernetes.Interface) error {
+	ingress := networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class":                 "nginx",
+				"nginx.ingress.kubernetes.io/ssl-passthrough": "true",
+				"nginx.ingress.kubernetes.io/ssl-redirect":    "true",
+			},
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{},
+		},
+	}
+	if owner != nil {
+		ingress.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*owner}
+
+	}
+	resolve := false
+	for _, route := range routes {
+		ingress.Spec.Rules = append(ingress.Spec.Rules, route.toRule())
+		if route.Resolve {
+			resolve = true
+		}
+	}
+	updated, err := cli.NetworkingV1beta1().Ingresses(namespace).Create(&ingress)
+	if err != nil {
+		return err
+	}
+	if resolve {
+		hostOrIp := getStatus(updated)
+		for i := 0; i < 60 && hostOrIp == nil; i++ {
+			if i%10 == 0 {
+				fmt.Printf("Waiting for ingress host/ip...")
+				fmt.Println()
+			}
+			time.Sleep(time.Second)
+			updated, err = cli.NetworkingV1beta1().Ingresses(namespace).Get(name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			hostOrIp = getStatus(updated)
+		}
+		if hostOrIp == nil {
+			return fmt.Errorf("Could not resolve host or ip of ingress")
+		}
+		updated.Spec.Rules = nil
+		for _, route := range routes {
+			if route.Resolve {
+				if hostOrIp.IP != "" {
+					route.Host = route.Host + "." + hostOrIp.IP + ".nip.io"
+				} else {
+					route.Host = route.Host + "." + hostOrIp.Hostname
+				}
+			}
+			updated.Spec.Rules = append(updated.Spec.Rules, route.toRule())
+		}
+		_, err = cli.NetworkingV1beta1().Ingresses(namespace).Update(updated)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func GetIngressRoutes(name string, namespace string, cli kubernetes.Interface) ([]IngressRoute, error) {
+	var routes []IngressRoute
+	ingress, err := cli.NetworkingV1beta1().Ingresses(namespace).Get(name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return routes, nil
+	} else if err != nil {
+		return routes, err
+	}
+	for _, rule := range ingress.Spec.Rules {
+		routes = append(routes, fromRule(&rule))
+	}
+	return routes, nil
+}


### PR DESCRIPTION
(Uses v1beta1 as that is the latest available using the kube client version skupper is currently using. That can be updated though if we want to support v1).

Requires `--enable-ssl-passthrough` to be enabled. On minikube: ```minikube addons enable ingress``` then ```kubectl edit deployment -n kube-system ingress-nginx-controller``` to add `--enable-ssl-passthrough` to command line args for container.

To select, specify `--ingress nginx-ingress-v1` to `skupper init`. Can also specify `--ingress-host` if there is a hostname mapped in dns. If that is not specified skupper will try to deduce it from ingress status (if its an ip then it will use a nip.io hostname for it).