### PR TITLE
Nodeport CA subject fix

### DIFF
--- a/client/router_create.go
+++ b/client/router_create.go
@@ -653,10 +653,14 @@ func (cli *VanClient) GetRouterSpecFromOpts(options types.SiteConfigSpec, siteId
 				controllerHosts = append(controllerHosts, controllerIngressHost)
 			}
 		}
+		siteServerSubject := types.TransportServiceName
+		if options.IsIngressNodePort() {
+			siteServerSubject = options.GetRouterIngressHost()
+		}
 		credentials = append(credentials, types.Credential{
 			CA:          types.SiteCaSecret,
 			Name:        types.SiteServerSecret,
-			Subject:     types.TransportServiceName,
+			Subject:     siteServerSubject,
 			Hosts:       routerHosts,
 			ConnectJson: false,
 			Post:        post,


### PR DESCRIPTION
The `skupper-site-server` secret's subject was not set to the `router-ingress-host` when using
`nodeport` and it was causing a host verification problem at the client side (bypassed if forcibly
using verifyHostname as false).

Another fix included here is to avoid calling `AppendSecretVolume` when the secret is already
part of the volumes list. Without it, I was facing the following error:
```
error updating deployment: Deployment.apps "skupper-router" is invalid: [spec.template.spec.volumes[4].name: Duplicate value: "conn1", spec.template.spec.containers[0].volumeMounts[4].mountPath: Invalid value: "/etc/qpid-dispatch-certs/conn1-profile/": must be unique]
```

@grs please check this out and let me know if you think it makes sense to you.