### PR TITLE
Added retries in the Connector Remove test 

### DIFF
--- a/client/connector_remove_test.go
+++ b/client/connector_remove_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/skupperproject/skupper/pkg/utils"
 	"os"
 	"strings"
 	"testing"
@@ -115,7 +116,11 @@ func TestConnectorRemove(t *testing.T) {
 			assert.Assert(t, k8serrors.IsNotFound(err), c.namespace)
 		}
 
-		_, err = tokenUserClient.ConnectorInspect(ctx, c.connName)
+		err = utils.Retry(10, 5, func() (bool, error) {
+			_, err = tokenUserClient.ConnectorInspect(ctx, c.connName)
+			return err!=nil && err.Error() == `secrets "`+c.connName+`" not found`, err
+		})
+
 		assert.Error(t, err, `secrets "`+c.connName+`" not found`, "Expect error when connector is removed")
 	}
 }

--- a/client/connector_remove_test.go
+++ b/client/connector_remove_test.go
@@ -118,7 +118,7 @@ func TestConnectorRemove(t *testing.T) {
 
 		err = utils.Retry(10, 5, func() (bool, error) {
 			_, err = tokenUserClient.ConnectorInspect(ctx, c.connName)
-			return err!=nil && err.Error() == `secrets "`+c.connName+`" not found`, err
+			return err != nil && err.Error() == `secrets "`+c.connName+`" not found`, err
 		})
 
 		assert.Error(t, err, `secrets "`+c.connName+`" not found`, "Expect error when connector is removed")

--- a/client/connector_remove_test.go
+++ b/client/connector_remove_test.go
@@ -116,7 +116,7 @@ func TestConnectorRemove(t *testing.T) {
 			assert.Assert(t, k8serrors.IsNotFound(err), c.namespace)
 		}
 
-		err = utils.Retry(10, 5, func() (bool, error) {
+		err = utils.Retry(20*time.Second, 5, func() (bool, error) {
 			_, err = tokenUserClient.ConnectorInspect(ctx, c.connName)
 			return err != nil && err.Error() == `secrets "`+c.connName+`" not found`, err
 		})


### PR DESCRIPTION
In the Connector Remove test, when the connector has been removed,  ConnectorInspect is executed to check that there is no connector and secrets;  but this assertion fails in the master build. 

I could reproduce it only a few times, when the test was executed faster than usual.

For that reason, in this PR the test includes a retry function to call ConnectorInspect (for a specific duration of times and number of attempts) until it returns an error related with a non-existent connector, making pass the test.