### PR TITLE
revise deletion of links

### DIFF
--- a/client/connector_remove.go
+++ b/client/connector_remove.go
@@ -4,64 +4,25 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/retry"
 
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/pkg/kube"
-	"github.com/skupperproject/skupper/pkg/qdr"
 )
+
+func isToken(secret *corev1.Secret) bool {
+	typename, ok := secret.ObjectMeta.Labels[types.SkupperTypeQualifier]
+	return ok && (typename == types.TypeClaimRequest || typename == types.TypeToken)
+}
 
 func (cli *VanClient) ConnectorRemove(ctx context.Context, options types.ConnectorRemoveOptions) error {
 	secret, err := cli.KubeClient.CoreV1().Secrets(options.SkupperNamespace).Get(options.Name, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
+	if errors.IsNotFound(err) || (err == nil && !isToken(secret)) {
 		return fmt.Errorf("No such link %q", options.Name)
 	} else if err != nil {
 		return err
 	}
-	if secret.ObjectMeta.Labels[types.SkupperTypeQualifier] == types.TypeClaimRequest {
-		kube.DeleteSecret(options.Name, options.SkupperNamespace, cli.KubeClient)
-		return nil
-	} else if secret.ObjectMeta.Labels[types.SkupperTypeQualifier] == types.TypeToken {
-		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			deployment, err := kube.GetDeployment(types.TransportDeploymentName, options.SkupperNamespace, cli.KubeClient)
-			if err != nil {
-				return err
-			}
-			configmap, err := kube.GetConfigMap(types.TransportConfigMapName, options.SkupperNamespace, cli.KubeClient)
-			if err != nil {
-				return err
-			}
-			current, err := qdr.GetRouterConfigFromConfigMap(configmap)
-			if err != nil {
-				return err
-			}
-			found, connector := current.RemoveConnector(options.Name)
-			if found || options.ForceCurrent {
-				if connector.SslProfile != "" {
-					current.RemoveSslProfile(connector.SslProfile)
-				}
-				_, err := current.UpdateConfigMap(configmap)
-				if err != nil {
-					return err
-				}
-				_, err = cli.KubeClient.CoreV1().ConfigMaps(options.SkupperNamespace).Update(configmap)
-				if err != nil {
-					return err
-				}
-				kube.RemoveSecretVolumeForDeployment(options.Name, deployment, 0)
-				_, err = cli.KubeClient.AppsV1().Deployments(options.SkupperNamespace).Update(deployment)
-				if err != nil {
-					return err
-				}
-				//delete secret last, so that if there is a conflict updating deployment, it
-				//will still exist and retry will work
-				return kube.DeleteSecret(options.Name, options.SkupperNamespace, cli.KubeClient)
-			}
-			return nil
-		})
-	} else {
-		return fmt.Errorf("No such link %q", options.Name)
-	}
+	return kube.DeleteSecret(options.Name, options.SkupperNamespace, cli.KubeClient)
 }


### PR DESCRIPTION
Separate the removal of the link from config, from the deletion of the secret. The
latter is the trigger for the former. The former is handled by the service-controller.

This avoids conflicts from both cli and service-controller executing the same code.