### PR TITLE
Use correct namespace for default site name

### DIFF
--- a/client/router_create.go
+++ b/client/router_create.go
@@ -321,15 +321,15 @@ func (cli *VanClient) GetRouterSpecFromOpts(options types.SiteConfigSpec, siteId
 
 	van := &types.RouterSpec{}
 	//todo: think through van name, router name, secret names, etc.
-	if options.SkupperName == "" {
-		van.Name = cli.Namespace
-	} else {
-		van.Name = options.SkupperName
-	}
 	if options.SkupperNamespace == "" {
 		van.Namespace = cli.Namespace
 	} else {
 		van.Namespace = options.SkupperNamespace
+	}
+	if options.SkupperName == "" {
+		van.Name = van.Namespace
+	} else {
+		van.Name = options.SkupperName
 	}
 
 	van.AuthMode = types.ConsoleAuthMode(options.AuthMode)

--- a/client/site_config_inspect.go
+++ b/client/site_config_inspect.go
@@ -13,7 +13,13 @@ import (
 )
 
 func (cli *VanClient) SiteConfigInspect(ctx context.Context, input *corev1.ConfigMap) (*types.SiteConfig, error) {
-	return cli.SiteConfigInspectInNamespace(ctx, input, cli.Namespace)
+	var namespace string
+	if input == nil {
+		namespace = cli.Namespace
+	} else {
+		namespace = input.ObjectMeta.Namespace
+	}
+	return cli.SiteConfigInspectInNamespace(ctx, input, namespace)
 }
 
 func (cli *VanClient) SiteConfigInspectInNamespace(ctx context.Context, input *corev1.ConfigMap, namespace string) (*types.SiteConfig, error) {


### PR DESCRIPTION
This fixes an issue using site-controller, where the name defaults to the namespace under which the site controller is running.