### PR TITLE
Add a breakdown list for incoming and outgoing connections when checking the link status

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -281,4 +281,5 @@ type VanClientInterface interface {
 	GetVersion(component string, name string) string
 	GetIngressDefault() string
 	RevokeAccess(ctx context.Context) error
+	BreakDownConnectionsList() (map[string]int, error)
 }

--- a/client/connector_list_test.go
+++ b/client/connector_list_test.go
@@ -121,4 +121,3 @@ func waitUntilConnectionsAreUpdated(cli *VanClient, createdConn bool) error {
 
 	return err
 }
-

--- a/client/connector_list_test.go
+++ b/client/connector_list_test.go
@@ -34,7 +34,7 @@ func TestBreakDownConnectionsList(t *testing.T) {
 	}{
 		{
 			namespace:     "van-link-status-1",
-			doc:           "Should return the incoming and outgoing connections.",
+			doc:           "Should return the incoming and outgoing links.",
 			createConn:    true,
 			connName:      "link1",
 			incomingSite1: 1,
@@ -44,7 +44,7 @@ func TestBreakDownConnectionsList(t *testing.T) {
 		},
 		{
 			namespace:     "van-link-status-2",
-			doc:           "Should not return the incoming nor outgoing connections because there is no link between them.",
+			doc:           "Should not return the incoming nor outgoing links if they don't exist.",
 			createConn:    false,
 			connName:      "",
 			incomingSite1: 0,

--- a/client/connector_list_test.go
+++ b/client/connector_list_test.go
@@ -1,0 +1,124 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/pkg/kube"
+	"github.com/skupperproject/skupper/pkg/qdr"
+	"github.com/skupperproject/skupper/pkg/utils"
+	"os"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+)
+
+func TestBreakDownConnectionsList(t *testing.T) {
+	if !*clusterRun {
+		lightRed := "\033[1;31m"
+		resetColor := "\033[0m"
+		t.Skip(fmt.Sprintf("%sSkipping: This test only works in real clusters.%s", string(lightRed), string(resetColor)))
+		return
+	}
+
+	testcases := []struct {
+		namespace     string
+		doc           string
+		createConn    bool
+		connName      string
+		incomingSite1 int
+		outgoingSite1 int
+		incomingSite2 int
+		outgoingSite2 int
+	}{
+		{
+			namespace:     "van-link-status-1",
+			doc:           "Should return the incoming and outgoing connections.",
+			createConn:    true,
+			connName:      "link1",
+			incomingSite1: 1,
+			outgoingSite1: 0,
+			incomingSite2: 0,
+			outgoingSite2: 1,
+		},
+		{
+			namespace:     "van-link-status-2",
+			doc:           "Should not return the incoming nor outgoing connections because there is no link between them.",
+			createConn:    false,
+			connName:      "",
+			incomingSite1: 0,
+			outgoingSite1: 0,
+			incomingSite2: 0,
+			outgoingSite2: 0,
+		},
+	}
+
+	testPath := "./tmp/"
+	os.Mkdir(testPath, 0755)
+	defer os.RemoveAll(testPath)
+
+	for _, c := range testcases {
+		fmt.Println("Test case: " + c.doc)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Create and set up the two namespaces that we will be using.
+		tokenCreatorNamespace := c.namespace + "-token-creator"
+		tokenUserNamespace := c.namespace + "-token-user"
+		tokenCreatorClient, tokenUserClient, err := setupTwoNamespaces(t, ctx, tokenCreatorNamespace, tokenUserNamespace)
+		assert.Assert(t, err, "Can't set up namespaces")
+		defer kube.DeleteNamespace(tokenCreatorNamespace, tokenCreatorClient.KubeClient)
+		defer kube.DeleteNamespace(tokenUserNamespace, tokenUserClient.KubeClient)
+
+		if c.createConn {
+			err = tokenCreatorClient.ConnectorTokenCreateFile(ctx, c.connName, testPath+c.connName+".yaml")
+			assert.Check(t, err, "Unable to create connector token "+c.connName)
+
+			_, err = tokenUserClient.ConnectorCreateFromFile(ctx, testPath+c.connName+".yaml", types.ConnectorCreateOptions{
+				Name:             c.connName,
+				SkupperNamespace: tokenUserNamespace,
+				Cost:             1,
+			})
+			assert.Check(t, err, "Unable to create connector for "+c.connName)
+
+		}
+
+		// wait for connection
+		err = waitUntilConnectionsAreUpdated(tokenUserClient, c.createConn)
+		assert.Assert(t, err)
+
+		resultsSite1, _ := tokenCreatorClient.BreakDownConnectionsList()
+
+		assert.DeepEqual(t, resultsSite1, map[string]int{"in": c.incomingSite1, "out": c.outgoingSite1})
+
+		resultsSite2, _ := tokenUserClient.BreakDownConnectionsList()
+
+		assert.DeepEqual(t, resultsSite2, map[string]int{"in": c.incomingSite2, "out": c.outgoingSite2})
+
+	}
+
+}
+
+func waitUntilConnectionsAreUpdated(cli *VanClient, createdConn bool) error {
+	var err error
+
+	err = utils.Retry(time.Second*5, 8, func() (bool, error) {
+		connections, err := qdr.GetConnections(cli.Namespace, cli.KubeClient, cli.RestConfig)
+		if err != nil {
+			return false, nil
+		}
+		for _, c := range connections {
+			if createdConn && (c.Role == "inter-router" || c.Role == "edge") {
+				return true, nil
+			}
+			if !createdConn && c.Role == "normal" {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+
+	return err
+}
+

--- a/cmd/skupper/README.md
+++ b/cmd/skupper/README.md
@@ -34,13 +34,13 @@ skupper expose
 To connect to this site from another site, you need to create an exchange tokens, for example:
 
 ```
-skupper connection-token /path/to/mysecret.yaml
+skupper token create /path/to/mysecret.yaml
 ```
 
 This command writes a token in the specified path, you can use that token from a second site by entering:
 
 ```
-skupper connect --secret /path/to/mysecret.yaml
+skupper link create /path/to/mysecret.yaml
 ```
 
 After waiting some time, check that the connection is working:

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -1391,6 +1391,9 @@ func init() {
 
 	cmdRevokeAll := NewCmdRevokeaccess(newClient)
 
+	cmdNetwork := NewCmdNetwork()
+	cmdNetwork.AddCommand(NewCmdNetworkStatus(newClient))
+
 	rootCmd = &cobra.Command{Use: "skupper"}
 	rootCmd.AddCommand(cmdInit,
 		cmdDelete,
@@ -1413,7 +1416,8 @@ func init() {
 		cmdDebug,
 		cmdCompletion,
 		cmdGateway,
-		cmdRevokeAll)
+		cmdRevokeAll,
+		cmdNetwork)
 
 	rootCmd.PersistentFlags().StringVarP(&kubeConfigPath, "kubeconfig", "", "", "Path to the kubeconfig file to use")
 	rootCmd.PersistentFlags().StringVarP(&kubeContext, "context", "c", "", "The kubeconfig context to use")

--- a/cmd/skupper/skupper_link.go
+++ b/cmd/skupper/skupper_link.go
@@ -120,6 +120,14 @@ func NewCmdLinkStatus(newClient cobraFunc) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			silenceCobra(cmd)
 
+			connectionMap, err := cli.BreakDownConnectionsList()
+			if err != nil {
+				fmt.Println(err)
+			}
+
+			printConnections(connectionMap["in"], "incoming")
+			printConnections(connectionMap["out"], "outgoing")
+
 			if len(args) == 1 && args[0] != "all" {
 				for i := 0; ; i++ {
 					if i > 0 {
@@ -184,4 +192,14 @@ func NewCmdLinkStatus(newClient cobraFunc) *cobra.Command {
 
 	return cmd
 
+}
+
+func printConnections(number int, direction string) {
+	if number == 0 {
+		fmt.Printf("There are no %v connections.\n", direction)
+	} else if number == 1 {
+		fmt.Printf("There is %v %v connection.\n", number, direction)
+	} else {
+		fmt.Printf("There are %v %v connections.\n", number, direction)
+	}
 }

--- a/cmd/skupper/skupper_link.go
+++ b/cmd/skupper/skupper_link.go
@@ -120,14 +120,6 @@ func NewCmdLinkStatus(newClient cobraFunc) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			silenceCobra(cmd)
 
-			connectionMap, err := cli.BreakDownConnectionsList()
-			if err != nil {
-				fmt.Println(err)
-			}
-
-			printConnections(connectionMap["in"], "incoming")
-			printConnections(connectionMap["out"], "outgoing")
-
 			if len(args) == 1 && args[0] != "all" {
 				for i := 0; ; i++ {
 					if i > 0 {
@@ -192,14 +184,4 @@ func NewCmdLinkStatus(newClient cobraFunc) *cobra.Command {
 
 	return cmd
 
-}
-
-func printConnections(number int, direction string) {
-	if number == 0 {
-		fmt.Printf("There are no %v connections.\n", direction)
-	} else if number == 1 {
-		fmt.Printf("There is %v %v connection.\n", number, direction)
-	} else {
-		fmt.Printf("There are %v %v connections.\n", number, direction)
-	}
 }

--- a/cmd/skupper/skupper_mock_test.go
+++ b/cmd/skupper/skupper_mock_test.go
@@ -274,6 +274,10 @@ func (v *vanClientMock) RevokeAccess(ctx context.Context) error {
 	return nil
 }
 
+func (v *vanClientMock) BreakDownConnectionsList() (map[string]int, error) {
+	return nil, nil
+}
+
 func TestCmdUnexposeRun(t *testing.T) {
 	cmd := NewCmdUnexpose(nil)
 	test := func(targetType, targetName, address string) {

--- a/cmd/skupper/skupper_network.go
+++ b/cmd/skupper/skupper_network.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdNetwork() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "network status",
+		Short: "Check incoming and outgoing links.",
+	}
+	return cmd
+}
+
+func NewCmdNetworkStatus(newClient cobraFunc) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "status",
+		Short:  "Check incoming and outgoing links.",
+		Args:   cobra.MaximumNArgs(0),
+		PreRun: newClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+
+			connectionMap, err := cli.BreakDownConnectionsList()
+			if err != nil {
+				fmt.Println(err)
+			}
+
+			printExistentLinks(connectionMap["in"], "incoming")
+			printExistentLinks(connectionMap["out"], "outgoing")
+
+			return nil
+		},
+	}
+
+	return cmd
+
+}
+
+func printExistentLinks(number int, direction string) {
+	if number == 0 {
+		fmt.Printf("There are no %v links.\n", direction)
+	} else if number == 1 {
+		fmt.Printf("There is %v %v link.\n", number, direction)
+	} else {
+		fmt.Printf("There are %v %v links.\n", number, direction)
+	}
+}


### PR DESCRIPTION
This PR aims to solve #437 issue by providing a breakdown list of incoming/outgoing connections on each skupper installation.

Using the [Getting Started](https://skupper.io/start/index.html) example, the output of `skupper network status` command will be like:
`west`
```
$ skupper network status
There is 1 incoming link.
There are no outgoing links.
```

`east`
```
$ skupper network status
There are no incoming links.
There is 1 outgoing link.
```
Using the example of [Online Boutique](https://github.com/skupperproject/skupper-example-grpc), the results would be like the following:
`private1`
```
$ skupper network status
There is 1 incoming link.
There are 2 outgoing links.
```
`public1`
```
$ skupper network status
There are 2 incoming links.
There are no outgoing links.
```

 `public2`
```
$ skupper network status
There is 1 incoming link.
There is 1 outgoing link.
```
