### PR TITLE
Improved how CLI tests wait for skupper pods to be running

### DIFF
--- a/pkg/kube/pods.go
+++ b/pkg/kube/pods.go
@@ -122,6 +122,30 @@ func WaitForPodStatus(namespace string, clientset kubernetes.Interface, podName 
 	return pod, err
 }
 
+func WaitForPodsStatus(namespace string, clientset kubernetes.Interface, selector string, status corev1.PodPhase, timeout time.Duration, interval time.Duration) error {
+	var err error
+
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+	defer cancel()
+	err = utils.RetryWithContext(ctx, interval, func() (bool, error) {
+		pods, err := GetPods(selector, namespace, clientset)
+		if err != nil {
+			return false, nil
+		}
+		if len(pods) == 0 {
+			return false, nil
+		}
+		for _, pod := range pods {
+			if pod.Status.Phase != status {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+
+	return err
+}
+
 func GetPodContainerLogs(podName string, containerName string, namespace string, clientset kubernetes.Interface) (string, error) {
 	podLogOpts := corev1.PodLogOptions{}
 	return GetPodContainerLogsWithOpts(podName, containerName, namespace, clientset, podLogOpts)

--- a/test/utils/base/skupper.go
+++ b/test/utils/base/skupper.go
@@ -51,21 +51,13 @@ func WaitSkupperRunning(c *ClusterContext) error {
 }
 
 func WaitSkupperComponentRunning(c *ClusterContext, component string) error {
-
 	tick := constants.DefaultTick
 	timeout := constants.ImagePullingAndResourceCreationTimeout
-
-	// wait for skupper router component to be running
-	pods, err := kube.GetPods("skupper.io/component="+component, c.Namespace, c.VanClient.KubeClient)
-	if err != nil {
+	// wait for skupper component to be running
+	selector := "skupper.io/component=" + component
+	if err := kube.WaitForPodsStatus(c.Namespace, c.VanClient.KubeClient, selector, corev1.PodRunning, timeout, tick); err != nil {
 		return err
 	}
-	for _, pod := range pods {
-		if _, err := kube.WaitForPodStatus(c.Namespace, c.VanClient.KubeClient, pod.Name, corev1.PodRunning, timeout, tick); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This fix refreshes the list of skupper pods in every iteration as router pod might restart after initialization.
Fixes issues observed in Services TLS PR with the CLI integration tests.