### PR TITLE
Improved gateway cli tests to run in containers

### DIFF
--- a/test/integration/acceptance/gateway/common.go
+++ b/test/integration/acceptance/gateway/common.go
@@ -12,6 +12,7 @@ import (
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/client"
 	"github.com/skupperproject/skupper/pkg/kube"
+	"github.com/skupperproject/skupper/pkg/utils"
 	"github.com/skupperproject/skupper/test/integration/examples/tcp_echo"
 	"github.com/skupperproject/skupper/test/utils/base"
 	"github.com/skupperproject/skupper/test/utils/constants"
@@ -30,17 +31,29 @@ var (
 )
 
 // ValidateSkip validates whether gateway tests should be skipped
-func ValidateSkip(t *testing.T) {
-	// If skupper, systemctl or qdrouterd binaries are not available, skip
-	binaries := []string{"skupper", "systemctl", "qdrouterd"}
-	missingBinaries := []string{}
-	for _, binary := range binaries {
-		if err := exec.Command(binary, "--help").Run(); err != nil {
-			missingBinaries = append(missingBinaries, binary)
+func ValidateSkip(t *testing.T, gatewayType string) {
+	if utils.StringSliceContains([]string{"", "service"}, gatewayType) {
+		// If skupper, systemctl or qdrouterd binaries are not available, skip
+		binaries := []string{"skupper", "systemctl", "qdrouterd"}
+		missingBinaries := []string{}
+		for _, binary := range binaries {
+			if err := exec.Command(binary, "--help").Run(); err != nil {
+				missingBinaries = append(missingBinaries, binary)
+			}
 		}
-	}
-	if len(missingBinaries) > 0 {
-		t.Skipf("skipping - required binaries not available: %s", missingBinaries)
+		if len(missingBinaries) > 0 {
+			t.Skipf("skipping - required binaries not available: %s", missingBinaries)
+		}
+	} else if gatewayType == "docker" {
+		// If docker binary is not available, skip
+		if err := exec.Command("docker", "--help").Run(); err != nil {
+			t.Skipf("skipping - required binary not available: docker")
+		}
+	} else if gatewayType == "podman" {
+		// If podman binary is not available, skip
+		if err := exec.Command("podman", "--help").Run(); err != nil {
+			t.Skipf("skipping - required binary not available: podman")
+		}
 	}
 }
 

--- a/test/utils/skupper/cli/gateway/init.go
+++ b/test/utils/skupper/cli/gateway/init.go
@@ -18,6 +18,11 @@ type InitTester struct {
 	Name          string
 	ExportOnly    bool
 	GeneratedName *string
+	Type          string
+}
+
+func (i *InitTester) isService() bool {
+	return i.Type == "" || i.Type == "service"
 }
 
 func (i *InitTester) Command(cluster *base.ClusterContext) []string {
@@ -29,6 +34,9 @@ func (i *InitTester) Command(cluster *base.ClusterContext) []string {
 	}
 	if i.ExportOnly {
 		args = append(args, "--exportonly")
+	}
+	if i.Type != "" {
+		args = append(args, "--type", i.Type)
 	}
 
 	return args
@@ -128,19 +136,31 @@ func (i *InitTester) Run(cluster *base.ClusterContext) (stdout string, stderr st
 		return
 	}
 
-	// Validating systemd user service created
 	expectAvailable := !i.ExportOnly
-	available := SystemdUnitAvailable(gatewayName)
-	if available != expectAvailable {
-		err = fmt.Errorf("systemd unit %s.service availability issue - available: %v - expected: %v", gatewayName, available, expectAvailable)
-		return
-	}
+	if i.isService() {
+		// Validating systemd user service created
+		available := SystemdUnitAvailable(gatewayName)
+		if available != expectAvailable {
+			err = fmt.Errorf("systemd unit %s.service availability issue - available: %v - expected: %v", gatewayName, available, expectAvailable)
+			return
+		}
 
-	// Validating systemd user service enabled
-	enabled := SystemdUnitEnabled(gatewayName)
-	if enabled != expectAvailable {
-		err = fmt.Errorf("systemd unit %s.service availability issue - enabled: %v - expected: %v", gatewayName, enabled, expectAvailable)
-		return
+		// Validating systemd user service enabled
+		enabled := SystemdUnitEnabled(gatewayName)
+		if enabled != expectAvailable {
+			err = fmt.Errorf("systemd unit %s.service availability issue - enabled: %v - expected: %v", gatewayName, enabled, expectAvailable)
+			return
+		}
+	} else if i.Type == "docker" {
+		available, _ := IsDockerContainerRunning(gatewayName)
+		if available != expectAvailable {
+			err = fmt.Errorf("docker container %s availability issue - enabled: %v - expected: %v", gatewayName, available, expectAvailable)
+		}
+	} else if i.Type == "podman" {
+		available, _ := IsPodmanContainerRunning(gatewayName)
+		if available != expectAvailable {
+			err = fmt.Errorf("podman container %s availability issue - enabled: %v - expected: %v", gatewayName, available, expectAvailable)
+		}
 	}
 
 	// Setting Generated Name


### PR DESCRIPTION
Integration tests are now running with both podman or docker,
depending on their availability.
The --exportonly tests have been disabled.