### PR TITLE
Allow a period in gateway names

### DIFF
--- a/client/gateway.go
+++ b/client/gateway.go
@@ -1049,7 +1049,7 @@ func (cli *VanClient) GatewayInit(ctx context.Context, gatewayName string, gatew
 	}
 
 	if gatewayName != "" {
-		nameRegex := regexp.MustCompile(`^[a-z]([a-z0-9-]*[a-z0-9])*$`)
+		nameRegex := regexp.MustCompile(`^[a-z]([a-z0-9\.-]*[a-z0-9])*$`)
 		if !nameRegex.MatchString(gatewayName) {
 			return "", fmt.Errorf("Gateway name must consist of lower case letters, numerals and '-'. Must start with a letter.")
 		}

--- a/client/gateway_test.go
+++ b/client/gateway_test.go
@@ -541,6 +541,13 @@ func TestGatewayInit(t *testing.T) {
 		},
 		{
 			gwType:        GatewayMockType,
+			initName:      "test-gateway1.fqdn",
+			actualName:    "test-gateway1.fqdn",
+			expectedError: "",
+			initTwice:     false,
+		},
+		{
+			gwType:        GatewayMockType,
 			initName:      "",
 			actualName:    "",
 			expectedError: "",

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -1100,7 +1100,7 @@ func NewCmdInitGateway(newClient cobraFunc) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}
-			fmt.Println("Skupper gateway: '" + actual + "'. Use 'skupper gateway status' to get more informaiton.")
+			fmt.Println("Skupper gateway: '" + actual + "'. Use 'skupper gateway status' to get more information.")
 
 			return nil
 		},


### PR DESCRIPTION
The gateway name is derived from a hostname, so periods should be allowed.
    
Fixes:

```    
$> skupper gateway init
Skupper gateway: 'markmc-machine.lab.redhat.com-markmc'. Use 'skupper gateway status' to get more informaiton.
```