### PR TITLE
avoid using null err variable

### DIFF
--- a/cmd/service-controller/controller.go
+++ b/cmd/service-controller/controller.go
@@ -575,7 +575,7 @@ func (c *Controller) updateBridgeConfig(name string) error {
 	if err != nil {
 		return fmt.Errorf("Error reading skupper-internal from cache: %s", err)
 	} else if !exists {
-		return fmt.Errorf("skupper-internal does not exist: %v", err.Error())
+		return fmt.Errorf("skupper-internal does not exist")
 	} else {
 		cm, ok := obj.(*corev1.ConfigMap)
 		if !ok {


### PR DESCRIPTION
Fixes part of #685, specifically the panic in the service controller when there is no skupper-internal configmap.