### PR TITLE
enable route host name

### DIFF
--- a/client/router_create.go
+++ b/client/router_create.go
@@ -218,7 +218,7 @@ func (cli *VanClient) GetVanControllerSpec(options types.SiteConfigSpec, van *ty
 					TargetPort: intstr.FromInt(int(types.ConsoleOpenShiftOauthServiceTargetPort)),
 				}
 			}
-			host := options.GetRouterIngressHost()
+			host := options.GetControllerIngressHost()
 			if host != "" {
 				host = types.ConsoleRouteName + "-" + van.Namespace + "." + host
 			}
@@ -290,7 +290,7 @@ func (cli *VanClient) GetVanControllerSpec(options types.SiteConfigSpec, van *ty
 			Port:     types.ClaimRedemptionPort,
 		})
 		if options.IsIngressRoute() {
-			host := options.GetRouterIngressHost()
+			host := options.GetControllerIngressHost()
 			if host != "" {
 				host = types.ClaimRedemptionRouteName + "-" + van.Namespace + "." + host
 			}

--- a/client/router_create.go
+++ b/client/router_create.go
@@ -218,6 +218,10 @@ func (cli *VanClient) GetVanControllerSpec(options types.SiteConfigSpec, van *ty
 					TargetPort: intstr.FromInt(int(types.ConsoleOpenShiftOauthServiceTargetPort)),
 				}
 			}
+			host := options.GetRouterIngressHost()
+			if host != "" {
+				host = types.ConsoleRouteName + "-" + van.Namespace + "." + host
+			}
 			routes = append(routes, &routev1.Route{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",
@@ -228,6 +232,7 @@ func (cli *VanClient) GetVanControllerSpec(options types.SiteConfigSpec, van *ty
 				},
 				Spec: routev1.RouteSpec{
 					Path: "",
+					Host: host,
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString("metrics"),
 					},
@@ -285,6 +290,10 @@ func (cli *VanClient) GetVanControllerSpec(options types.SiteConfigSpec, van *ty
 			Port:     types.ClaimRedemptionPort,
 		})
 		if options.IsIngressRoute() {
+			host := options.GetRouterIngressHost()
+			if host != "" {
+				host = types.ClaimRedemptionRouteName + "-" + van.Namespace + "." + host
+			}
 			routes = append(routes, &routev1.Route{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",
@@ -295,6 +304,7 @@ func (cli *VanClient) GetVanControllerSpec(options types.SiteConfigSpec, van *ty
 				},
 				Spec: routev1.RouteSpec{
 					Path: "",
+					Host: host,
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString(types.ClaimRedemptionPortName),
 					},
@@ -923,6 +933,13 @@ func (cli *VanClient) GetRouterSpecFromOpts(options types.SiteConfigSpec, siteId
 
 	routes := []*routev1.Route{}
 	if !isEdge && options.IsIngressRoute() {
+		hostInterRouter := ""
+		hostEdge := ""
+		host := options.GetRouterIngressHost()
+		if host != "" {
+			hostInterRouter = types.InterRouterRouteName + "-" + van.Namespace + "." + host
+			hostEdge = types.EdgeRouteName + "-" + van.Namespace + "." + host
+		}
 		routes = append(routes, &routev1.Route{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",
@@ -933,6 +950,7 @@ func (cli *VanClient) GetRouterSpecFromOpts(options types.SiteConfigSpec, siteId
 			},
 			Spec: routev1.RouteSpec{
 				Path: "",
+				Host: hostInterRouter,
 				Port: &routev1.RoutePort{
 					TargetPort: intstr.FromString(types.InterRouterRole),
 				},
@@ -956,6 +974,7 @@ func (cli *VanClient) GetRouterSpecFromOpts(options types.SiteConfigSpec, siteId
 			},
 			Spec: routev1.RouteSpec{
 				Path: "",
+				Host: hostEdge,
 				Port: &routev1.RoutePort{
 					TargetPort: intstr.FromString(types.EdgeRole),
 				},
@@ -975,6 +994,10 @@ func (cli *VanClient) GetRouterSpecFromOpts(options types.SiteConfigSpec, siteId
 		if options.AuthMode == string(types.ConsoleAuthModeOpenshift) {
 			termination = routev1.TLSTerminationReencrypt
 		}
+		host := options.GetRouterIngressHost()
+		if host != "" {
+			host = types.RouterConsoleRouteName + "-" + van.Namespace + "." + host
+		}
 		routes = append(routes, &routev1.Route{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",
@@ -985,6 +1008,7 @@ func (cli *VanClient) GetRouterSpecFromOpts(options types.SiteConfigSpec, siteId
 			},
 			Spec: routev1.RouteSpec{
 				Path: "",
+				Host: host,
 				Port: &routev1.RoutePort{
 					TargetPort: intstr.FromString(types.ConsolePortName),
 				},

--- a/client/router_update.go
+++ b/client/router_update.go
@@ -1046,14 +1046,6 @@ func (cli *VanClient) createClaimsServerSecret(ctx context.Context, namespace st
 }
 
 func (cli *VanClient) createClaimsRedemptionRoute(ctx context.Context, namespace string) error {
-	siteConfig, err := cli.SiteConfigInspect(ctx, nil)
-	if err != nil {
-		return err
-	}
-	host := siteConfig.Spec.GetRouterIngressHost()
-	if host != "" {
-		host = types.ClaimRedemptionRouteName + "-" + namespace + "." + host
-	}
 	route := &routev1.Route{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -1064,7 +1056,6 @@ func (cli *VanClient) createClaimsRedemptionRoute(ctx context.Context, namespace
 		},
 		Spec: routev1.RouteSpec{
 			Path: "",
-			Host: host,
 			Port: &routev1.RoutePort{
 				TargetPort: intstr.FromString(types.ClaimRedemptionPortName),
 			},
@@ -1078,7 +1069,7 @@ func (cli *VanClient) createClaimsRedemptionRoute(ctx context.Context, namespace
 			},
 		},
 	}
-	_, err = kube.CreateRoute(route, namespace, cli.RouteClient)
+	_, err := kube.CreateRoute(route, namespace, cli.RouteClient)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}

--- a/client/router_update.go
+++ b/client/router_update.go
@@ -325,11 +325,6 @@ func (cli *VanClient) RouterUpdateVersionInNamespace(ctx context.Context, hup bo
 			// routes: skupper-controller -> skupper
 			original, err := cli.RouteClient.Routes(namespace).Get("skupper-controller", metav1.GetOptions{})
 			if err == nil {
-				siteConfig, err := cli.SiteConfigInspect(ctx, nil)
-				host := siteConfig.Spec.GetRouterIngressHost()
-				if host != "" {
-					host = types.ConsoleRouteName + "-" + namespace + "." + host
-				}
 				route := &routev1.Route{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "v1",
@@ -341,7 +336,6 @@ func (cli *VanClient) RouterUpdateVersionInNamespace(ctx context.Context, hup bo
 					},
 					Spec: routev1.RouteSpec{
 						Path: original.Spec.Path,
-						Host: host,
 						Port: original.Spec.Port,
 						TLS:  original.Spec.TLS,
 						To: routev1.RouteTargetReference{
@@ -350,7 +344,7 @@ func (cli *VanClient) RouterUpdateVersionInNamespace(ctx context.Context, hup bo
 						},
 					},
 				}
-				_, err = cli.RouteClient.Routes(namespace).Create(route)
+				_, err := cli.RouteClient.Routes(namespace).Create(route)
 				if err != nil && !errors.IsAlreadyExists(err) {
 					return false, err
 				}

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -412,7 +412,7 @@ installation that can then be connected to other skupper installations`,
 	cmd.Flags().StringVarP(&routerCreateOpts.Ingress, "ingress", "", "", "Setup Skupper ingress to one of: ["+strings.Join(types.ValidIngressOptions(), "|")+"]. If not specified route is used when available, otherwise loadbalancer is used.")
 	cmd.Flags().StringSliceVar(&ingressAnnotations, "ingress-annotations", []string{}, "Annotations to add to skupper ingress")
 	cmd.Flags().StringVarP(&routerCreateOpts.ConsoleIngress, "console-ingress", "", "", "Determines if/how console is exposed outside cluster. If not specified uses value of --ingress. One of: ["+strings.Join(types.ValidIngressOptions(), "|")+"].")
-	cmd.Flags().StringVarP(&routerCreateOpts.IngressHost, "ingress-host", "", "", "Hostname by which the ingress proxy can be reached")
+	cmd.Flags().StringVarP(&routerCreateOpts.IngressHost, "ingress-host", "", "", "Hostname or alias by which the ingress route or proxy can be reached")
 	cmd.Flags().StringVarP(&routerMode, "router-mode", "", string(types.TransportModeInterior), "Skupper router-mode")
 
 	cmd.Flags().StringSliceVar(&annotations, "annotations", []string{}, "Annotations to add to skupper pods")


### PR DESCRIPTION
Customer request to provide custom host name for the route rather than have OpenShift auto generate. The route host should be the concatenation of service name, namespace and host name suffix. Use the existing --ingress-host parameter to specify when ingress is type route.