### PR TITLE
Skipping container test due to known issue #713

### DIFF
--- a/test/integration/acceptance/gateway_test.go
+++ b/test/integration/acceptance/gateway_test.go
@@ -58,10 +58,14 @@ func testLocalGatewayService(t *testing.T) {
 }
 
 func testLocalGatewayDocker(t *testing.T) {
+	// these two lines should exist only on the 0.8 branch
+	t.Skip("Skipping container test due to known issue #713")
 	testLocalGateway(t, "docker")
 }
 
 func testLocalGatewayPodman(t *testing.T) {
+	// these two lines should exist only on the 0.8 branch
+	t.Skip("Skipping container test due to known issue #713")
 	testLocalGateway(t, "podman")
 }
 


### PR DESCRIPTION
There is a known issue described in #713 that has already been fixed on master.  The issue impacts only container images that specify a user to run the entry point, which is not the case for upstream.

This PR skips the tests affected by that issue, so they do no break testing downstream.

Signed-off-by: Danilo Gonzalez Hashimoto <dhashimo@redhat.com>