### PR TITLE
Test: An http2 service with TLS feature enabled

### DIFF
--- a/test/integration/examples/http/http.go
+++ b/test/integration/examples/http/http.go
@@ -44,6 +44,14 @@ var http2service = types.ServiceInterface{
 	Ports:    []int{8443},
 }
 
+var http2TlsService = types.ServiceInterface{
+	Address:        "nghttp2tls",
+	Protocol:       "http2",
+	Ports:          []int{443},
+	EnableTls:      true,
+	TlsCredentials: "skupper-tls-nghttp2tls",
+}
+
 var nginxDep = &appsv1.Deployment{
 	TypeMeta: metav1.TypeMeta{
 		APIVersion: "apps/v1",
@@ -137,6 +145,140 @@ var nghttp2Dep = &appsv1.Deployment{
 						},
 						VolumeMounts: []apiv1.VolumeMount{
 							{Name: "index-html", MountPath: "/webroot", ReadOnly: true},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var nghttp2TlsDep = &appsv1.Deployment{
+	TypeMeta: metav1.TypeMeta{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "nghttp2tls",
+	},
+	Spec: appsv1.DeploymentSpec{
+		Replicas: int32Ptr(1),
+		Selector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"application": "nghttp2tls"},
+		},
+		Template: apiv1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"application": "nghttp2tls",
+				},
+			},
+			Spec: apiv1.PodSpec{
+				Volumes: []apiv1.Volume{
+					{
+						Name: "index-html",
+						VolumeSource: apiv1.VolumeSource{
+							ConfigMap: &apiv1.ConfigMapVolumeSource{
+								LocalObjectReference: apiv1.LocalObjectReference{
+									Name: "index-html",
+								},
+							},
+						},
+					},
+				},
+				Containers: []apiv1.Container{
+					{
+						Name:            "nghttp2tls",
+						Image:           "docker.io/svagi/nghttp2",
+						ImagePullPolicy: apiv1.PullIfNotPresent,
+						Ports: []apiv1.ContainerPort{
+							{
+								Name:          "nghttp2tls",
+								Protocol:      apiv1.ProtocolTCP,
+								ContainerPort: 443,
+							},
+						},
+						Command: []string{
+							"nghttpd",
+							"--no-tls",
+							"-v",
+							"443",
+							"-d",
+							"/webroot/",
+						},
+						VolumeMounts: []apiv1.VolumeMount{
+							{Name: "index-html", MountPath: "/webroot", ReadOnly: true},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var nghttp2TlsDepWithCertFiles = &appsv1.Deployment{
+	TypeMeta: metav1.TypeMeta{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "nghttp2tls",
+	},
+	Spec: appsv1.DeploymentSpec{
+		Replicas: int32Ptr(1),
+		Selector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"application": "nghttp2tls"},
+		},
+		Template: apiv1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"application": "nghttp2tls",
+				},
+			},
+			Spec: apiv1.PodSpec{
+				Volumes: []apiv1.Volume{
+					{
+						Name: "index-html",
+						VolumeSource: apiv1.VolumeSource{
+							ConfigMap: &apiv1.ConfigMapVolumeSource{
+								LocalObjectReference: apiv1.LocalObjectReference{
+									Name: "index-html",
+								},
+							},
+						},
+					},
+					{
+						Name: "certs",
+						VolumeSource: apiv1.VolumeSource{
+							Secret: &apiv1.SecretVolumeSource{
+								SecretName: "skupper-tls-nghttp2tls",
+							},
+						},
+					},
+				},
+				Containers: []apiv1.Container{
+					{
+						Name:            "nghttp2tls",
+						Image:           "docker.io/svagi/nghttp2",
+						ImagePullPolicy: apiv1.PullIfNotPresent,
+						Ports: []apiv1.ContainerPort{
+							{
+								Name:          "nghttp2tls",
+								Protocol:      apiv1.ProtocolTCP,
+								ContainerPort: 443,
+							},
+						},
+						Command: []string{
+							"nghttpd",
+							"-v",
+							"-d",
+							"/webroot/",
+							"443",
+							"/certs/tls.key",
+							"/certs/tls.crt",
+						},
+						VolumeMounts: []apiv1.VolumeMount{
+							{Name: "index-html", MountPath: "/webroot", ReadOnly: true},
+							{Name: "certs", MountPath: "/certs", ReadOnly: true},
 						},
 					},
 				},
@@ -305,11 +447,14 @@ func runTests(t *testing.T, r base.ClusterTestRunner) {
 	_, err = k8s.WaitForSkupperServiceToBeCreatedAndReadyToUse(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, "nghttp2")
 	assert.Assert(t, err)
 
+	_, err = k8s.WaitForSkupperServiceToBeCreatedAndReadyToUse(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, "nghttp2tls")
+	assert.Assert(t, err)
+
 	runJob := func(cc *base.ClusterContext, jobName, testName string) {
 		t.Helper()
 		jobCmd := []string{"/app/http_test", "-test.run", testName}
 
-		_, err = k8s.CreateTestJob(cc.Namespace, cc.VanClient.KubeClient, jobName, jobCmd)
+		_, err = k8s.CreateTestJobWithSecret(cc.Namespace, cc.VanClient.KubeClient, jobName, jobCmd, types.ServiceClientSecret)
 		assert.Assert(t, err)
 	}
 
@@ -334,6 +479,12 @@ func runTests(t *testing.T, r base.ClusterTestRunner) {
 	t.Run("http2", func(t *testing.T) {
 		runJob(pubCluster1, "http2", "TestHttp2Job")
 		waitJob(pubCluster1, "http2")
+	})
+
+	// Send GET requests via HTTPD2
+	t.Run("http2tls", func(t *testing.T) {
+		runJob(pubCluster1, "http2tls", "TestHttp2TlsJob")
+		waitJob(pubCluster1, "http2tls")
 	})
 
 	// Send a huge load for HTTPD2
@@ -389,6 +540,9 @@ func setup(ctx context.Context, t *testing.T, r base.ClusterTestRunner) {
 	// Create the deployment for HTTP2
 	createDeploymentInPrivateSite(nghttp2Dep)
 
+	// Create the deployment for HTTP2 with TLS enabled
+	createDeploymentInPrivateSite(nghttp2TlsDep)
+
 	err = prv1Cluster.VanClient.ServiceInterfaceCreate(ctx, &service)
 	assert.Assert(t, err)
 
@@ -399,6 +553,16 @@ func setup(ctx context.Context, t *testing.T, r base.ClusterTestRunner) {
 	assert.Assert(t, err)
 
 	err = prv1Cluster.VanClient.ServiceInterfaceBind(ctx, &http2service, "deployment", "nghttp2", "http2", map[int]int{})
+	assert.Assert(t, err)
+
+	err = prv1Cluster.VanClient.ServiceInterfaceCreate(ctx, &http2TlsService)
+	assert.Assert(t, err)
+
+	err = prv1Cluster.VanClient.ServiceInterfaceBind(ctx, &http2TlsService, "deployment", "nghttp2tls", "http2", map[int]int{})
+	assert.Assert(t, err)
+
+	//update tls service with cert files
+	_, err = prv1Cluster.VanClient.KubeClient.AppsV1().Deployments(prv1Cluster.Namespace).Update(nghttp2TlsDepWithCertFiles)
 	assert.Assert(t, err)
 
 	http21service := types.ServiceInterface{
@@ -427,6 +591,7 @@ func tearDown(ctx context.Context, r base.ClusterTestRunner) {
 	// Deleting Skupper services
 	_ = prv1Cluster.VanClient.ServiceInterfaceRemove(ctx, service.Address)
 	_ = prv1Cluster.VanClient.ServiceInterfaceRemove(ctx, http2service.Address)
+	_ = prv1Cluster.VanClient.ServiceInterfaceRemove(ctx, http2TlsService.Address)
 
 	// Deleting deployments
 	depCli := prv1Cluster.VanClient.KubeClient.AppsV1().Deployments(prv1Cluster.Namespace)

--- a/test/integration/examples/http/job/httpjob_test.go
+++ b/test/integration/examples/http/job/httpjob_test.go
@@ -6,12 +6,14 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
+	"crypto/x509"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/tsenart/vegeta/v12/lib"
 	"golang.org/x/net/http2"
@@ -52,6 +54,48 @@ func TestHttp2Job(t *testing.T) {
 	body := string(_body)
 	assert.Assert(t, strings.Contains(body, "A simple HTTP Request &amp; Response Service."), body)
 	assert.Assert(t, resp.Status == "200 OK", resp.Status)
+}
+
+func TestHttp2TlsJob(t *testing.T) {
+
+	//Load CA cert
+	caCert, err := ioutil.ReadFile("/tmp/certs/skupper-service-client/ca.crt")
+	if err != nil {
+		log.Fatal(err)
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	// Setup HTTPS client
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: false,
+		RootCAs:            caCertPool,
+	}
+
+	transport := &http2.Transport{
+		TLSClientConfig:    tlsConfig,
+		DisableCompression: true,
+		AllowHTTP:          false,
+	}
+
+	client := http.Client{
+		Transport: transport,
+	}
+
+	resp, err := client.Get("https://nghttp2tls:443/")
+
+	assert.Assert(t, err)
+	fmt.Printf("Client Proto: %d\n", resp.ProtoMajor)
+	fmt.Println("Client Header:", resp.Header)
+
+	defer resp.Body.Close()
+	_body, err := ioutil.ReadAll(resp.Body)
+	assert.Assert(t, err)
+
+	body := string(_body)
+	assert.Assert(t, strings.Contains(body, "A simple HTTP Request &amp; Response Service."), body)
+	assert.Assert(t, resp.Status == "200 OK", resp.Status)
+
 }
 
 func testHttpJob(t *testing.T, url string) {

--- a/test/utils/k8s/job.go
+++ b/test/utils/k8s/job.go
@@ -18,7 +18,7 @@ import (
 func GetTestImage() string {
 	testImage := os.Getenv("TEST_IMAGE")
 	if testImage == "" {
-		testImage = "quay.io/nluaces/skupper-tests:latest"
+		testImage = "quay.io/skupper/skupper-tests:latest"
 	}
 	return testImage
 }

--- a/test/utils/k8s/job.go
+++ b/test/utils/k8s/job.go
@@ -18,7 +18,7 @@ import (
 func GetTestImage() string {
 	testImage := os.Getenv("TEST_IMAGE")
 	if testImage == "" {
-		testImage = "quay.io/skupper/skupper-tests:master"
+		testImage = "quay.io/nluaces/skupper-tests:latest"
 	}
 	return testImage
 }
@@ -68,6 +68,63 @@ func CreateTestJob(ns string, kubeClient kubernetes.Interface, name string, comm
 	jobsClient := kubeClient.BatchV1().Jobs(namespace)
 
 	job, err := jobsClient.Create(job)
+
+	if err != nil {
+		return nil, err
+	}
+	return job, nil
+}
+
+func CreateTestJobWithSecret(ns string, kubeClient kubernetes.Interface, name string, command []string, secretname string) (*batchv1.Job, error) {
+
+	namespace := ns
+	testImage := GetTestImage()
+
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(secretname, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"job": name,
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: int32Ptr(3),
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+					Labels: map[string]string{
+						"job": name,
+					},
+				},
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Name:    name,
+							Image:   testImage,
+							Command: command,
+							Env: []apiv1.EnvVar{
+								{Name: "JOB", Value: name},
+							},
+							ImagePullPolicy: apiv1.PullAlways,
+						},
+					},
+					RestartPolicy: apiv1.RestartPolicyNever,
+				},
+			},
+		},
+	}
+
+	AppendSecretVolume(&job.Spec.Template.Spec.Volumes, &job.Spec.Template.Spec.Containers[0].VolumeMounts, secret.Name, "/tmp/certs/"+secretname+"/")
+
+	jobsClient := kubeClient.BatchV1().Jobs(namespace)
+
+	job, err = jobsClient.Create(job)
 
 	if err != nil {
 		return nil, err
@@ -186,4 +243,19 @@ func NewJob(name, namespace string, opts JobOpts) *batchv1.Job {
 	}
 
 	return job
+}
+
+func AppendSecretVolume(volumes *[]apiv1.Volume, mounts *[]apiv1.VolumeMount, name string, path string) {
+	*volumes = append(*volumes, apiv1.Volume{
+		Name: name,
+		VolumeSource: apiv1.VolumeSource{
+			Secret: &apiv1.SecretVolumeSource{
+				SecretName: name,
+			},
+		},
+	})
+	*mounts = append(*mounts, apiv1.VolumeMount{
+		Name:      name,
+		MountPath: path,
+	})
 }

--- a/test/utils/k8s/job.go
+++ b/test/utils/k8s/job.go
@@ -18,7 +18,7 @@ import (
 func GetTestImage() string {
 	testImage := os.Getenv("TEST_IMAGE")
 	if testImage == "" {
-		testImage = "quay.io/skupper/skupper-tests:latest"
+		testImage = "quay.io/skupper/skupper-tests:master"
 	}
 	return testImage
 }


### PR DESCRIPTION
- Deploy the http2 service without cert files.
- Expose service with htt2 mapping and enabling TLS feature.
- Append to the deployment the cert files created in previous step.
- Call the service using the certification authority which was used to create service's certification files.