### PR TITLE
Network command improvements

### DIFF
--- a/client/network_status.go
+++ b/client/network_status.go
@@ -41,12 +41,12 @@ func (cli *VanClient) NetworkStatus() ([]*types.SiteInfo, error) {
 		}
 
 		if len(site.Namespace) == 0 {
-			return nil, fmt.Errorf("temporarily unable to provide site information")
+			return nil, fmt.Errorf("site %s: unable to get site namespace from service-controller", site.Name)
 		}
 
 		siteConfig, err := cli.SiteConfigInspect(nil, nil)
 		if err != nil || siteConfig == nil {
-			return nil, fmt.Errorf("site configuration not available")
+			return nil, fmt.Errorf("skupper-site configuration not available")
 		}
 
 		currentSite := siteConfig.Reference.UID

--- a/cmd/skupper/skupper_cluster_test.go
+++ b/cmd/skupper/skupper_cluster_test.go
@@ -1538,7 +1538,7 @@ func TestNetworkStatusWithCluster(t *testing.T) {
 			expectedCapture: "",
 			expectedOutput:  "",
 			expectedError:   "",
-			outputRegExp:    "^Sites\\:\\n╰─\\s\\[local\\]\\s[0-9a-f-]*\\s-\\s.*\\n\\s{3}URL:\\s\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\n\\s{3}name:\\s.*\\n\\s{3}namespace:\\s.*\\n\\s{3}version:\\s.*\\n\\s{3}╰─\\sServices\\:\\n\\s{6}╰─\\sname:\\s.*\\n\\s{9}address:\\s.*\\:\\s\\d{4}\\n\\s{9}protocol:\\s.*\\n\\s{9}╰─\\sTargets\\:\\n\\s{12}╰─\\sname:\\s.*",
+			outputRegExp:    "^Sites\\:\\n╰─\\s\\[local\\]\\s[0-9a-f-]*\\s-\\s.*\\n\\s{3}URL:\\s\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\n\\s{3}mode:\\s.*\\n\\s{3}name:\\s.*\\n\\s{3}namespace:\\s.*\\n\\s{3}version:\\s.*\\n\\s{3}╰─\\sServices\\:\\n\\s{6}╰─\\sname:\\s.*\\n\\s{9}address:\\s.*\\:\\s\\d{4}\\n\\s{9}protocol:\\s.*\\n\\s{9}╰─\\sTargets\\:\\n\\s{12}╰─\\sname:\\s.*",
 			realCluster:     true,
 		},
 	}

--- a/cmd/skupper/skupper_network.go
+++ b/cmd/skupper/skupper_network.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -33,7 +34,7 @@ func NewCmdNetworkStatus(newClient cobraFunc) *cobra.Command {
 
 			var sites []*types.SiteInfo
 			var errStatus error
-			err := utils.RetryError(time.Second, 30, func() error {
+			err := utils.RetryError(time.Second, 5, func() error {
 				sites, errStatus = cli.NetworkStatus()
 
 				if errStatus != nil {
@@ -43,8 +44,19 @@ func NewCmdNetworkStatus(newClient cobraFunc) *cobra.Command {
 				return nil
 			})
 
+			loadOnlyLocalInformation := false
+
 			if err != nil {
 				fmt.Printf("Unable to retrieve network information: %s", err)
+				fmt.Println()
+				fmt.Println()
+				fmt.Println("Loading just local information:")
+				loadOnlyLocalInformation = true
+			}
+
+			vir, err := cli.RouterInspect(context.Background())
+			if err != nil || vir == nil {
+				fmt.Printf("The router configuration is not available: %s", err)
 				fmt.Println()
 				return nil
 			}
@@ -58,6 +70,19 @@ func NewCmdNetworkStatus(newClient cobraFunc) *cobra.Command {
 
 			currentSite := siteConfig.Reference.UID
 
+			if loadOnlyLocalInformation {
+				printLocalStatus(vir.Status.TransportReadyReplicas, vir.Status.ConnectedSites.Warnings, vir.Status.ConnectedSites.Total, vir.Status.ConnectedSites.Direct, vir.ExposedServices)
+
+				serviceInterfaces, err := cli.ServiceInterfaceList(context.Background())
+				if err != nil {
+					fmt.Printf("Service local configuration is not available: %s", err)
+					fmt.Println()
+					return nil
+				}
+
+				sites = getLocalSiteInfo(serviceInterfaces, currentSite, vir.Status.SiteName, cli.GetNamespace(), vir.ControllerVersion)
+			}
+
 			if sites != nil && len(sites) > 0 {
 				siteList := formatter.NewList()
 				siteList.Item("Sites:")
@@ -69,6 +94,7 @@ func NewCmdNetworkStatus(newClient cobraFunc) *cobra.Command {
 
 					location := "remote"
 					siteVersion := site.Version
+					detailsMap := map[string]string{"name": site.Name, "namespace": site.Namespace, "URL": site.Url, "version": siteVersion}
 
 					if len(site.MinimumVersion) > 0 {
 						siteVersion = fmt.Sprintf("%s (minimum version required %s)", site.Version, site.MinimumVersion)
@@ -76,12 +102,12 @@ func NewCmdNetworkStatus(newClient cobraFunc) *cobra.Command {
 
 					if site.SiteId == currentSite {
 						location = "local"
+						detailsMap["mode"] = vir.Status.Mode
 					}
 
 					newItem := fmt.Sprintf("[%s] %s - %s ", location, site.SiteId[:7], site.Name)
 
 					newItem = newItem + fmt.Sprintln()
-					detailsMap := map[string]string{"name": site.Name, "namespace": site.Namespace, "URL": site.Url, "version": siteVersion}
 
 					if len(site.Links) > 0 {
 						detailsMap["sites linked to"] = fmt.Sprint(strings.Join(site.Links, ", "))
@@ -90,7 +116,7 @@ func NewCmdNetworkStatus(newClient cobraFunc) *cobra.Command {
 					serviceLevel := siteList.NewChildWithDetail(newItem, detailsMap)
 					if len(site.Services) > 0 {
 						services := serviceLevel.NewChild("Services:")
-						addresses := []string{}
+						var addresses []string
 						svcAuth := map[string]bool{}
 						for _, svc := range site.Services {
 							addresses = append(addresses, svc.Name)
@@ -135,4 +161,79 @@ func NewCmdNetworkStatus(newClient cobraFunc) *cobra.Command {
 
 	return cmd
 
+}
+
+func printLocalStatus(readyreplicas int32, warnings []string, totalConnectedSites int, directConnectedSites int, exposedServices int) {
+
+	if readyreplicas == 0 {
+		fmt.Printf(" Status pending...")
+	} else {
+		if len(warnings) > 0 {
+			for _, w := range warnings {
+				fmt.Printf("Warning: %s", w)
+				fmt.Println()
+			}
+		}
+		if totalConnectedSites == 0 {
+			fmt.Printf(" It is not connected to any other sites.")
+		} else if totalConnectedSites == 1 {
+			fmt.Printf(" It is connected to 1 other site.")
+		} else if totalConnectedSites == directConnectedSites {
+			fmt.Printf(" It is connected to %d other sites.", totalConnectedSites)
+		} else {
+			fmt.Printf(" It is connected to %d other sites (%d indirectly).", totalConnectedSites, directConnectedSites)
+		}
+	}
+	fmt.Printf(" Number of exposed services: %d", exposedServices)
+	fmt.Println()
+}
+
+func getLocalSiteInfo(serviceInterfaces []*types.ServiceInterface, siteId string, siteName string, namespace string, version string) []*types.SiteInfo {
+
+	var localServices []types.ServiceInfo
+
+	if len(serviceInterfaces) > 0 {
+		for _, service := range serviceInterfaces {
+
+			var localTargets []types.TargetInfo
+			if len(service.Targets) > 0 {
+				for _, target := range service.Targets {
+					targetInfo := types.TargetInfo{
+						Name:   target.Name,
+						SiteId: siteId,
+					}
+
+					localTargets = append(localTargets, targetInfo)
+				}
+			}
+			var portStr string
+			if len(service.Ports) > 0 {
+				for _, port := range service.Ports {
+					portStr += fmt.Sprintf(" %d", port)
+				}
+			}
+
+			serviceInfo := types.ServiceInfo{
+				Name:     service.Address,
+				Address:  service.Address + ":" + portStr,
+				Protocol: service.Protocol,
+				Targets:  localTargets,
+			}
+
+			localServices = append(localServices, serviceInfo)
+		}
+	}
+
+	localSiteInfo := types.SiteInfo{
+		Name:      siteName,
+		Namespace: namespace,
+		SiteId:    siteId,
+		Version:   version,
+		Services:  localServices,
+	}
+
+	var sites []*types.SiteInfo
+	sites = append(sites, &localSiteInfo)
+
+	return sites
 }

--- a/cmd/skupper/skupper_network.go
+++ b/cmd/skupper/skupper_network.go
@@ -34,7 +34,7 @@ func NewCmdNetworkStatus(newClient cobraFunc) *cobra.Command {
 
 			var sites []*types.SiteInfo
 			var errStatus error
-			err := utils.RetryError(time.Second, 5, func() error {
+			err := utils.RetryError(time.Second, 3, func() error {
 				sites, errStatus = cli.NetworkStatus()
 
 				if errStatus != nil {
@@ -80,7 +80,7 @@ func NewCmdNetworkStatus(newClient cobraFunc) *cobra.Command {
 					return nil
 				}
 
-				sites = getLocalSiteInfo(serviceInterfaces, currentSite, vir.Status.SiteName, cli.GetNamespace(), vir.ControllerVersion)
+				sites = getLocalSiteInfo(serviceInterfaces, currentSite, vir.Status.SiteName, cli.GetNamespace(), vir.TransportVersion)
 			}
 
 			if sites != nil && len(sites) > 0 {

--- a/pkg/utils/formatter/list.go
+++ b/pkg/utils/formatter/list.go
@@ -88,6 +88,11 @@ func printDetails(detailsMap map[string]string, level int, last map[int]bool) {
 	sort.Strings(keys)
 
 	for index, key := range keys {
+
+		if len(detailsMap[key]) == 0 {
+			continue
+		}
+
 		for i := 1; i <= level; i++ {
 			if !last[i] {
 				fmt.Printf("│  ")

--- a/pkg/utils/retry.go
+++ b/pkg/utils/retry.go
@@ -78,6 +78,28 @@ func RetryError(interval time.Duration, maxRetries int, f CheckedFunc) error {
 	}
 }
 
+type Result struct {
+	Value interface{}
+	Error error
+}
+
+type ResultFunc func() Result
+
+func TryUntil(maxWindowTime time.Duration, f ResultFunc) (interface{}, error) {
+
+	result := make(chan Result, 1)
+
+	go func() {
+		result <- f()
+	}()
+	select {
+	case <-time.After(maxWindowTime):
+		return nil, fmt.Errorf("timed out")
+	case result := <-result:
+		return result.Value, result.Error
+	}
+}
+
 // RetryWithContext retries f every interval until the specified context times out.
 func RetryWithContext(ctx context.Context, interval time.Duration, f ConditionFunc) error {
 	tick := time.NewTicker(interval)


### PR DESCRIPTION
- Add timeout when calling the service-controller
- Show at least local configuration if the service-controller is not available
- Add more detail to error messages

How to test this change manually:
1. Set up two clusters (public1 and public2) on minikube
2. Set up a third cluster (private1) on [kind](https://kind.sigs.k8s.io/) (initialise skupper with ingress none)
3. Link the three sites and then deploy and expose a service in private1 cluster
4. Check that everything is configured correctly executing `skupper network status`
5. Stop minikube cluster and execute `skupper network status` on private1 cluster inmediately after. The call to the service controller should time out and then skupper should show information about the local site
