### PR TITLE
Information dump in case of annotation test errors

### DIFF
--- a/test/integration/acceptance/annotated_resource_test.go
+++ b/test/integration/acceptance/annotated_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -110,7 +111,7 @@ func TestAnnotatedResources(t *testing.T) {
 
 	// Iterate through test table and run each test
 	for _, test := range testTable {
-		t.Run(test.name, func(t *testing.T) {
+		testResult := t.Run(test.name, func(t *testing.T) {
 			var err error
 
 			// 4.1. If test expects modifications to be performed, run them
@@ -201,6 +202,11 @@ func TestAnnotatedResources(t *testing.T) {
 				}
 			}
 		})
+		if !testResult {
+			log.Printf("Test %s failed: gathering info dump", test.name)
+			testRunner.DumpTestInfo(filepath.Join(t.Name(), test.name))
+		}
+
 	}
 
 	// Undeploying resources

--- a/test/integration/acceptance/annotated_resource_test.go
+++ b/test/integration/acceptance/annotated_resource_test.go
@@ -185,15 +185,16 @@ func TestAnnotatedResources(t *testing.T) {
 					var resp *tools.CurlResponse
 					log.Printf("validating communication with service %s through %s", svc, cluster.Namespace)
 					// reaching service through service-controller's pod (with some attempts to make sure bridge is connected)
+					var lastErr error
 					err = utils.Retry(backoff.Duration, backoff.Steps, func() (bool, error) {
 						endpoint := fmt.Sprintf("http://%s:8080", svc)
-						resp, err = tools.Curl(cluster.KubeClient, cluster.RestConfig, cluster.Namespace, "", endpoint, tools.CurlOpts{Timeout: 10})
-						if err != nil {
+						resp, lastErr = tools.Curl(cluster.KubeClient, cluster.RestConfig, cluster.Namespace, "", endpoint, tools.CurlOpts{Timeout: 10})
+						if lastErr != nil {
 							return false, nil
 						}
 						return resp.StatusCode == 200, nil
 					})
-					assert.Assert(t, err, "unable to reach service %s through %s", svc, cluster.Namespace)
+					assert.Assert(t, err, "unable to reach service %s through %s: %s", svc, cluster.Namespace, lastErr)
 					assert.Equal(t, resp.StatusCode, 200, "bad response received from service %s through %s", svc, cluster.Namespace)
 					assert.Assert(t, resp.Body != "", "empty response body received from service %s through %s", svc, cluster.Namespace)
 					log.Printf("successfully communicated with service %s through %s", svc, cluster.Namespace)

--- a/test/utils/base/cluster_context.go
+++ b/test/utils/base/cluster_context.go
@@ -111,7 +111,7 @@ func (cc *ClusterContext) DumpTestInfo(dirName string) {
 	} else {
 		log.Printf("error dumping test info: %v", err)
 	}
-	out, err := cc.KubectlExec("get -o wide pod,service")
+	out, err := cc.KubectlExec("get -o wide job,pod,service")
 	if err != nil {
 		log.Printf("failed getting kube info: %v", err)
 	}

--- a/test/utils/base/cluster_context.go
+++ b/test/utils/base/cluster_context.go
@@ -110,7 +110,6 @@ func (cc *ClusterContext) DumpTestInfo(dirName string) {
 		log.Printf("Saved: %s", absPath)
 	} else {
 		log.Printf("error dumping test info: %v", err)
-		return
 	}
 	out, err := cc.KubectlExec("get -o wide pod,service")
 	if err != nil {

--- a/test/utils/base/cluster_context.go
+++ b/test/utils/base/cluster_context.go
@@ -112,4 +112,9 @@ func (cc *ClusterContext) DumpTestInfo(dirName string) {
 		log.Printf("error dumping test info: %v", err)
 		return
 	}
+	out, err := cc.KubectlExec("get -o wide pod,service")
+	if err != nil {
+		log.Printf("failed getting kube info: %v", err)
+	}
+	log.Printf("kube info: \n%v", string(out))
 }


### PR DESCRIPTION
When an error happens on one of the tests in `TestAnnotatedResources`, this PR:

- Shows the last error that happened within the `Retry`
- Calls `testRunner.DumpTestInfo` so we have something to look at
- Adds `kubectl get -o wide pod,service` to the output of `ClusterContext.DumpTestInfo`

This all should help in investigations for that test.