### PR TITLE
Get logs for all job runs, instead of only the last one

### DIFF
--- a/test/integration/examples/mongodb/job/mongojob_test.go
+++ b/test/integration/examples/mongodb/job/mongojob_test.go
@@ -132,7 +132,7 @@ func DropAllPosts(client *mongo.Client, ctx context.Context) error {
 	collection := client.Database(DB_NAME).Collection(COLLECTION_NAME)
 	err := collection.Drop(ctx)
 	if err != nil {
-		fmt.Println("error dropping collection:", err)
+		log.Println("error dropping collection:", err)
 		return err
 	}
 

--- a/test/integration/examples/mongodb/mongo.go
+++ b/test/integration/examples/mongodb/mongo.go
@@ -35,7 +35,7 @@ func RunTests(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) 
 	_, err = k8s.CreateTestJob(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, jobName, jobCmd)
 	assert.Assert(t, err)
 	job, err := k8s.WaitForJob(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, jobName, constants.ImagePullingAndResourceCreationTimeout)
-	jobLogs, _ := k8s.GetJobLogs(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, jobName)
+	jobLogs, _ := k8s.GetJobsLogs(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, jobName, true)
 	t.Logf("%s logs:", jobName)
 	t.Logf(jobLogs)
 	if err != nil {


### PR DESCRIPTION
Often, the last one will be still running when the test timeout
kicks in, and the logs will be empty or incomplete, where the
previous runs will have information on what cause them to fail.

Signed-off-by: Danilo Gonzalez Hashimoto <dhashimo@redhat.com>