### PR TITLE
HipsterShop failures investigation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,8 @@ commands:
           path: /tmp/artifacts
           destination: test-artifacts
       - run:
-          command: minikube kubectl cluster-info dump | grep -i oom
+          # We do not fail the build whether oom was found or not
+          command: minikube kubectl cluster-info dump | grep -i oom; true
           when: always
 
   run_cluster_policy_tests:
@@ -181,7 +182,8 @@ commands:
           path: /tmp/policy-artifacts
           destination: policy-test-artifacts
       - run:
-          command: minikube kubectl cluster-info dump | grep -i oom
+          # We do not fail the build whether oom was found or not
+          command: minikube kubectl cluster-info dump | grep -i oom; true
           when: always
 
   compile_go_program:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,14 +77,18 @@ commands:
           background: true
 
   # By default, we grep for oom (out of memory) messages.  To get the
-  # full output, just remove that pipe
+  # full output, just set the argument 're' to '.'
   minikube-logs:
-    description: Show minikube logs, continuously
+    description: Tail minikube logs, grepping for something (by default, OOM)
+    parameters:
+      re:
+        default: "(oom|error)"
+        type: string
     steps:
-      - run:
-          command: minikube logs -f | grep -i oom
-          name: List minikube logs
-          background: true
+    - run:
+        name: Tail'n'grep minikube logs
+        command: minikube logs -f | egrep -i "<<parameters.re>>"
+        background: true
 
   prepare_for_local_cluster_tests:
     description: install right versions of go, docker, kubectl, and also build
@@ -110,6 +114,36 @@ commands:
       - kube-orb/install-kubectl
       - run: make
 
+  system_monitor:
+    description: shows continuous system state
+    steps:
+    - run:
+        name: sar info
+        command: sar -h -q ALL -P all -r -S -u -W 60
+        background: true
+    - run:
+        name: vmstat info
+        command: vmstat -w -n 1
+        background: true
+
+  system_status:
+    description: shows some point-in-time system status
+    parameters:
+      cluster_dump_re:
+        default: "(oom|error)"
+        type: string
+    steps:
+    - run:
+        name: point-in-time system status
+        command: |
+          set +e
+          cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
+          free -m
+          uptime
+          minikube kubectl cluster-info dump | grep -i "<<parameters.cluster_dump_re>>"
+          true
+        when: always
+
   run_cluster_tests:
     description: run all e2e tests inside the current KUBECONFIG configured cluster
     parameters:
@@ -117,6 +151,7 @@ commands:
         default: ""
         type: string
     steps:
+      - system_status # before the tests
       - run:
           name: Creating artifacts directory
           command: mkdir /tmp/artifacts
@@ -136,14 +171,7 @@ commands:
       - run:
           name: Run site-controller tests in real cluster
           command: go test -v -count=1 ./cmd/site-controller -use-cluster
-      - run:
-          name: system information at job finish time
-          command: |
-            set +e
-            cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
-            free -m
-            uptime
-          when: always
+      - system_status
       - run:
           name: Archiving test artifacts
           command: |
@@ -152,14 +180,6 @@ commands:
       - store_artifacts:
           path: /tmp/artifacts
           destination: test-artifacts
-      - run:
-          name: OOM information from cluster-info dump
-          # We do not fail the build whether oom was found or not
-          command: |
-            set +e
-            minikube kubectl cluster-info dump | grep -i oom
-            true
-          when: always
 
   run_cluster_policy_tests:
     description: run all e2e policy tests inside the current KUBECONFIG configured cluster
@@ -168,6 +188,7 @@ commands:
         default: ""
         type: string
     steps:
+      - system_status
       - run:
           name: Creating policy artifacts directory
           command: mkdir /tmp/policy-artifacts
@@ -177,14 +198,7 @@ commands:
           command: |
             make build-cmd && sudo install skupper /usr/local/bin
             go test -tags=policy -timeout=60m -v ./test/integration/...
-      - run:
-          name: system information at job finish time
-          command: |
-            set +e
-            cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
-            free -m
-            uptime
-          when: always
+      - system_status
       - run:
           name: Archiving policy test artifacts
           command: |
@@ -193,14 +207,6 @@ commands:
       - store_artifacts:
           path: /tmp/policy-artifacts
           destination: policy-test-artifacts
-      - run:
-          name: OOM information from cluster-info dump
-          # We do not fail the build whether oom was found or not
-          command: |
-            set +e
-            minikube kubectl cluster-info dump | grep -i oom
-            true
-          when: always
 
   compile_go_program:
     description: Compile specified platform.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,6 +370,7 @@ jobs:
       - minikube-install
       - minikube-start
       - minikube-start-load-balancer
+      - minikube-logs
       - run: kubectl cluster-info
       - run_cluster_tests
 
@@ -380,6 +381,7 @@ jobs:
       - minikube-install
       - minikube-start
       - minikube-start-load-balancer
+      - minikube-logs
       - run: kubectl cluster-info
       - run_cluster_policy_tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,14 @@ commands:
           name: Start Minikube Tunnel
           background: true
 
+  minikube-logs:
+    description: Show minikube logs, continuously
+    steps:
+      - run:
+          command: minikube logs -f
+          name: List minikube logs
+          background: true
+
   prepare_for_local_cluster_tests:
     description: install right versions of go, docker, kubectl, and also build
     steps:
@@ -108,6 +116,9 @@ commands:
           command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
           when: always
       - run:
+          command: uptime
+          when: always
+      - run:
           name: Archiving test artifacts
           command: |
             find ./ -name "*.tar.gz" -o -name "*.log" -o -name "*.json" | tar -c -T - | tar -C /tmp/artifacts -xv
@@ -115,6 +126,9 @@ commands:
       - store_artifacts:
           path: /tmp/artifacts
           destination: test-artifacts
+      - run:
+          command: minikube kubectl cluster-info dump
+          when: always
 
   run_cluster_policy_tests:
     description: run all e2e policy tests inside the current KUBECONFIG configured cluster
@@ -136,6 +150,9 @@ commands:
           command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
           when: always
       - run:
+          command: uptime
+          when: always
+      - run:
           name: Archiving policy test artifacts
           command: |
             find ./ -name "*.tar.gz" -o -name "*.log" -o -name "*.json" | tar -c -T - | tar -C /tmp/policy-artifacts -xv
@@ -143,6 +160,9 @@ commands:
       - store_artifacts:
           path: /tmp/policy-artifacts
           destination: policy-test-artifacts
+      - run:
+          command: minikube kubectl cluster-info dump
+          when: always
 
   compile_go_program:
     description: Compile specified platform.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,7 @@ commands:
           command: |
             set +e
             cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
+            free -m
             uptime
           when: always
       - run:
@@ -177,6 +178,7 @@ commands:
           command: |
             set +e
             cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
+            free -m
             uptime
           when: always
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,8 +232,8 @@ yaml-templates:
     requires:
       - build-all
       - test
-      - minikube_local_cluster_tests
-      - minikube_local_cluster_policy_tests
+      - main_tests_minikube_local_cluster
+      - policy_tests_minikube_local_cluster
 
 workflows:
   version: 2.1
@@ -246,7 +246,7 @@ workflows:
       - build_and_push_test_images:
           <<: *run_for_all_branches_and_numeric_tags
 
-      - minikube_local_cluster_tests:
+      - main_tests_minikube_local_cluster:
           <<: *run_for_all_branches_and_numeric_tags
           pre-steps:
             - prepare_for_local_cluster_tests
@@ -254,7 +254,7 @@ workflows:
             - test
             - build_and_push_test_images
 
-      - minikube_local_cluster_policy_tests:
+      - policy_tests_minikube_local_cluster:
           <<: *run_for_all_branches_and_numeric_tags
           pre-steps:
             - prepare_for_local_cluster_tests
@@ -277,8 +277,8 @@ workflows:
       - remove_from_registry: # will not run for tags, by default
           requires:
             - test
-            - minikube_local_cluster_policy_tests
-            - minikube_local_cluster_tests
+            - policy_tests_minikube_local_cluster
+            - main_tests_minikube_local_cluster
 
 jobs:
   test:
@@ -387,7 +387,7 @@ jobs:
           paths:
               - dist
 
-  minikube_local_cluster_tests:
+  main_tests_minikube_local_cluster:
     executor: local_cluster_test_executor
     steps:
       - run: echo "skupper_image = ${SKUPPER_SERVICE_CONTROLLER_IMAGE}"
@@ -398,7 +398,7 @@ jobs:
       - run: kubectl cluster-info
       - run_cluster_tests
 
-  minikube_local_cluster_policy_tests:
+  policy_tests_minikube_local_cluster:
     executor: local_cluster_policy_test_executor
     steps:
       - run: echo "skupper_image = ${SKUPPER_SERVICE_CONTROLLER_IMAGE}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ commands:
         background: true
     - run:
         name: vmstat info
-        command: vmstat -w 10
+        command: vmstat -w -t 10
         background: true
 
   system_status:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,18 +76,18 @@ commands:
           name: Start Minikube Tunnel
           background: true
 
-  # By default, we grep for oom (out of memory) messages.  To get the
-  # full output, just set the argument 're' to '.'
+  # By default, we grep for out of memory messages.  To get the full output,
+  # just set the argument 're' to '.'
   minikube-logs:
     description: Tail minikube logs, grepping for something (by default, OOM)
     parameters:
       re:
         # This is for egrep, so you can do things like "(oom|error)"
-        default: "oom"
+        default: "(out of memory|oom.?kill)"
         type: string
     steps:
     - run:
-        name: Tail'n'grep minikube logs
+        name: Tail and grep minikube logs
         command: minikube logs -f | egrep -i "<<parameters.re>>"
         background: true
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,8 @@ commands:
     description: Tail minikube logs, grepping for something (by default, OOM)
     parameters:
       re:
-        default: "(oom|error)"
+        # This is for egrep, so you can do things like "(oom|error)"
+        default: "oom"
         type: string
     steps:
     - run:
@@ -119,11 +120,11 @@ commands:
     steps:
     - run:
         name: sar info
-        command: sar -h -q ALL -P all -r -S -u -W 60
+        command: sar -h -q -r -u 60
         background: true
     - run:
         name: vmstat info
-        command: vmstat -w -n 1
+        command: vmstat -w 10
         background: true
 
   system_status:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,9 @@ commands:
           name: Start Minikube Tunnel
           background: true
 
+  # By default, this is disabled on the jobs, as it generates a lot of
+  # output.  Activate to investigate kubernetes or environment issues
+  # (such as memory pressure).
   minikube-logs:
     description: Show minikube logs, continuously
     steps:
@@ -126,9 +129,9 @@ commands:
       - store_artifacts:
           path: /tmp/artifacts
           destination: test-artifacts
-      - run:
-          command: minikube kubectl cluster-info dump
-          when: always
+#      - run:
+#          command: minikube kubectl cluster-info dump
+#          when: always
 
   run_cluster_policy_tests:
     description: run all e2e policy tests inside the current KUBECONFIG configured cluster
@@ -160,9 +163,9 @@ commands:
       - store_artifacts:
           path: /tmp/policy-artifacts
           destination: policy-test-artifacts
-      - run:
-          command: minikube kubectl cluster-info dump
-          when: always
+#      - run:
+#          command: minikube kubectl cluster-info dump
+#          when: always
 
   compile_go_program:
     description: Compile specified platform.
@@ -370,7 +373,7 @@ jobs:
       - minikube-install
       - minikube-start
       - minikube-start-load-balancer
-      - minikube-logs
+      # - minikube-logs
       - run: kubectl cluster-info
       - run_cluster_tests
 
@@ -381,7 +384,7 @@ jobs:
       - minikube-install
       - minikube-start
       - minikube-start-load-balancer
-      - minikube-logs
+      # - minikube-logs
       - run: kubectl cluster-info
       - run_cluster_policy_tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,16 @@ executors:
   local_cluster_test_executor:
     machine:
       image: ubuntu-2004:current
+    resource_class: large
+
+  local_cluster_policy_test_executor:
+    machine:
+      image: ubuntu-2004:current
+    # Policy tests run all in sequence.  So, there is no benefit in adding more
+    # CPU or memory.  Within the tests, there is paralellism, but on goroutines,
+    # so they'd not use the additional CPUs.  The only thing a running policy
+    # test competes with is the other system processes
+    # resource_class: medium (the default)
 
 commands:
   minikube-install:
@@ -239,7 +249,8 @@ workflows:
           pre-steps:
             - prepare_for_local_cluster_tests
           requires:
-            - minikube_local_cluster_tests
+            - test
+            - build_and_push_test_images
 
       - publish-github-release-artifacts:
           <<: *run_for_numeric_tags
@@ -372,18 +383,18 @@ jobs:
       - minikube-install
       - minikube-start
       - minikube-start-load-balancer
-      # - minikube-logs
+      - minikube-logs
       - run: kubectl cluster-info
       - run_cluster_tests
 
   minikube_local_cluster_policy_tests:
-    executor: local_cluster_test_executor
+    executor: local_cluster_policy_test_executor
     steps:
       - run: echo "skupper_image = ${SKUPPER_SERVICE_CONTROLLER_IMAGE}"
       - minikube-install
       - minikube-start
       - minikube-start-load-balancer
-      # - minikube-logs
+      - minikube-logs
       - run: kubectl cluster-info
       - run_cluster_policy_tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,12 +48,20 @@ commands:
             mv minikube /usr/local/bin/
           name: Install Minikube Executable
 
-  minikube-start:
-    description: Starts the minikube service.
+  minikube-start-medium:
+    description: Starts the minikube service, with 2 CPU and 2 GiB
     steps:
       - run:
           command: >-
             minikube start --vm-driver=docker --cpus 2 --memory 2048
+          name: Start Minikube Cluster
+
+  minikube-start-large:
+    description: Starts the minikube service, with 4 CPU and 6GiB
+    steps:
+      - run:
+          command: >-
+            minikube start --vm-driver=docker --cpus 4 --memory 6144
           name: Start Minikube Cluster
 
   minikube-start-load-balancer:
@@ -382,7 +390,7 @@ jobs:
     steps:
       - run: echo "skupper_image = ${SKUPPER_SERVICE_CONTROLLER_IMAGE}"
       - minikube-install
-      - minikube-start
+      - minikube-start-large
       - minikube-start-load-balancer
       - minikube-logs
       - run: kubectl cluster-info
@@ -393,7 +401,7 @@ jobs:
     steps:
       - run: echo "skupper_image = ${SKUPPER_SERVICE_CONTROLLER_IMAGE}"
       - minikube-install
-      - minikube-start
+      - minikube-start-medium
       - minikube-start-load-balancer
       - minikube-logs
       - run: kubectl cluster-info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,6 +417,7 @@ jobs:
       - minikube-start-large
       - minikube-start-load-balancer
       - minikube-logs
+      - system_monitor
       - run: kubectl cluster-info
       - run_cluster_tests
 
@@ -428,6 +429,7 @@ jobs:
       - minikube-start-medium
       - minikube-start-load-balancer
       - minikube-logs
+      - system_monitor
       - run: kubectl cluster-info
       - run_cluster_policy_tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,14 +54,13 @@ commands:
           name: Start Minikube Tunnel
           background: true
 
-  # By default, this is disabled on the jobs, as it generates a lot of
-  # output.  Activate to investigate kubernetes or environment issues
-  # (such as memory pressure).
+  # By default, we grep for oom (out of memory) messages.  To get the
+  # full output, just remove that pipe
   minikube-logs:
     description: Show minikube logs, continuously
     steps:
       - run:
-          command: minikube logs -f
+          command: minikube logs -f | grep -i oom
           name: List minikube logs
           background: true
 
@@ -129,9 +128,9 @@ commands:
       - store_artifacts:
           path: /tmp/artifacts
           destination: test-artifacts
-#      - run:
-#          command: minikube kubectl cluster-info dump
-#          when: always
+      - run:
+          command: minikube kubectl cluster-info dump | grep -i oom
+          when: always
 
   run_cluster_policy_tests:
     description: run all e2e policy tests inside the current KUBECONFIG configured cluster
@@ -163,9 +162,9 @@ commands:
       - store_artifacts:
           path: /tmp/policy-artifacts
           destination: policy-test-artifacts
-#      - run:
-#          command: minikube kubectl cluster-info dump
-#          when: always
+      - run:
+          command: minikube kubectl cluster-info dump | grep -i oom
+          when: always
 
   compile_go_program:
     description: Compile specified platform.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,9 @@ commands:
           name: Run site-controller tests in real cluster
           command: go test -v -count=1 ./cmd/site-controller -use-cluster
       - run:
+          command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
+          when: always
+      - run:
           name: Archiving test artifacts
           command: |
             find ./ -name "*.tar.gz" -o -name "*.log" -o -name "*.json" | tar -c -T - | tar -C /tmp/artifacts -xv
@@ -129,6 +132,9 @@ commands:
           command: |
             make build-cmd && sudo install skupper /usr/local/bin
             go test -tags=policy -timeout=60m -v ./test/integration/...
+      - run:
+          command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
+          when: always
       - run:
           name: Archiving policy test artifacts
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,6 +268,7 @@ workflows:
           requires:
             - test
             - minikube_local_cluster_policy_tests
+            - minikube_local_cluster_tests
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,10 +133,11 @@ commands:
           name: Run site-controller tests in real cluster
           command: go test -v -count=1 ./cmd/site-controller -use-cluster
       - run:
-          command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
-          when: always
-      - run:
-          command: uptime
+          name: system information at job finish time
+          command: |
+            set +e
+            cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
+            uptime
           when: always
       - run:
           name: Archiving test artifacts
@@ -147,8 +148,12 @@ commands:
           path: /tmp/artifacts
           destination: test-artifacts
       - run:
+          name: OOM information from cluster-info dump
           # We do not fail the build whether oom was found or not
-          command: minikube kubectl cluster-info dump | grep -i oom; true
+          command: |
+            set +e
+            minikube kubectl cluster-info dump | grep -i oom
+            true
           when: always
 
   run_cluster_policy_tests:
@@ -168,10 +173,11 @@ commands:
             make build-cmd && sudo install skupper /usr/local/bin
             go test -tags=policy -timeout=60m -v ./test/integration/...
       - run:
-          command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
-          when: always
-      - run:
-          command: uptime
+          name: system information at job finish time
+          command: |
+            set +e
+            cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
+            uptime
           when: always
       - run:
           name: Archiving policy test artifacts
@@ -182,8 +188,12 @@ commands:
           path: /tmp/policy-artifacts
           destination: policy-test-artifacts
       - run:
+          name: OOM information from cluster-info dump
           # We do not fail the build whether oom was found or not
-          command: minikube kubectl cluster-info dump | grep -i oom; true
+          command: |
+            set +e
+            minikube kubectl cluster-info dump | grep -i oom
+            true
           when: always
 
   compile_go_program:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,10 @@ commands:
             minikube start --vm-driver=docker --cpus 2 --memory 2048
           name: Start Minikube Cluster
 
+  # We're using only 6 GiB out of the available 15 GiB of the linux/large
+  # CircleCI executor.  This allows us some leeway to grow within this
+  # resource class when memory issues happen, so we can prepare for the
+  # next resource class with plenty of time, when required.
   minikube-start-large:
     description: Starts the minikube service, with 4 CPU and 6GiB
     steps:

--- a/test/integration/examples/custom/hipstershop/hipstershop.go
+++ b/test/integration/examples/custom/hipstershop/hipstershop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"strings"
 	"testing"
 
@@ -167,11 +168,11 @@ func DeployResources(t *testing.T, testRunner base.ClusterTestRunner) {
 			}
 			return true, nil
 		})
-		t.Logf("Pod status at %s:", cluster.Namespace)
+		log.Printf("Pod status at %s:", cluster.Namespace)
 		cluster.KubectlExec("get pods")
 		// If an error has occurred, verify the events as well
 		if err != nil {
-			t.Logf("Latest events")
+			log.Printf("Latest events")
 			cluster.KubectlExec("get events")
 		}
 		return err

--- a/test/integration/examples/custom/hipstershop/hipstershop_test.go
+++ b/test/integration/examples/custom/hipstershop/hipstershop_test.go
@@ -95,6 +95,7 @@ func TestHipsterShop(t *testing.T) {
 				if err != nil || !jobSucceeded {
 					// retrieving job logs
 					log, err := k8s.GetJobsLogs(cluster.Namespace, cluster.VanClient.KubeClient, job.Name, true)
+					// TODO review this.  After the assertion, nothing will be shown
 					assert.Assert(t, err)
 					t.Logf("Job %s has failed. Job log:\n%s", job.Name, log)
 				}

--- a/test/integration/examples/custom/hipstershop/hipstershop_test.go
+++ b/test/integration/examples/custom/hipstershop/hipstershop_test.go
@@ -94,10 +94,9 @@ func TestHipsterShop(t *testing.T) {
 				jobSucceeded := job.Status.Succeeded == 1
 				if err != nil || !jobSucceeded {
 					// retrieving job logs
-					log, err := k8s.GetJobLogs(cluster.Namespace, cluster.VanClient.KubeClient, job.Name)
+					log, err := k8s.GetJobsLogs(cluster.Namespace, cluster.VanClient.KubeClient, job.Name, true)
 					assert.Assert(t, err)
-					t.Logf("Job %s has failed. Job log:", job.Name)
-					t.Logf(log)
+					t.Logf("Job %s has failed. Job log:\n%s", job.Name, log)
 				}
 				if err != nil {
 					testRunner.DumpTestInfo(cluster.Namespace)

--- a/test/integration/examples/custom/hipstershop/hipstershop_test.go
+++ b/test/integration/examples/custom/hipstershop/hipstershop_test.go
@@ -5,6 +5,7 @@ package hipstershop
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"testing"
 
@@ -44,6 +45,9 @@ func TestHipsterShop(t *testing.T) {
 	// removes namespaces and cancels context
 	tearDownFn := func() {
 		t.Logf("entering teardown")
+		if t.Failed() {
+			testRunner.DumpTestInfo("TestHipsterShop")
+		}
 		err := base.RemoveNamespacesForContexts(testRunner, []int{1, 2}, []int{1})
 		if err != nil {
 			t.Logf("Error removing namespaces = %s", err)
@@ -94,13 +98,11 @@ func TestHipsterShop(t *testing.T) {
 				jobSucceeded := job.Status.Succeeded == 1
 				if err != nil || !jobSucceeded {
 					// retrieving job logs
-					log, err := k8s.GetJobsLogs(cluster.Namespace, cluster.VanClient.KubeClient, job.Name, true)
-					// TODO review this.  After the assertion, nothing will be shown
-					assert.Assert(t, err)
-					t.Logf("Job %s has failed. Job log:\n%s", job.Name, log)
-				}
-				if err != nil {
-					testRunner.DumpTestInfo(cluster.Namespace)
+					jobLog, logErr := k8s.GetJobsLogs(cluster.Namespace, cluster.VanClient.KubeClient, job.Name, true)
+					if logErr != nil {
+						log.Printf("Failed fetching logs for job: %v", logErr)
+					}
+					t.Logf("Job error or failure on %s. Job log:\n%s", job.Name, jobLog)
 				}
 				assert.Assert(t, err)
 				assert.Assert(t, jobSucceeded)

--- a/test/utils/base/cluster_context.go
+++ b/test/utils/base/cluster_context.go
@@ -158,4 +158,10 @@ func (cc *ClusterContext) DumpTestInfo(dirName string) {
 		log.Printf("failed non-running job info: %v", err)
 	}
 	log.Printf("non-running job info: \n%v", string(out))
+	//	out, err = cc.KubectlExec("get events")
+	//	if err != nil {
+	//		log.Printf("Failed getting events from %v: %v", cc.Namespace, err)
+	//		return
+	//	}
+	//	log.Printf("kube events for %v:\n%s", cc.Namespace, string(out))
 }

--- a/test/utils/base/cluster_context.go
+++ b/test/utils/base/cluster_context.go
@@ -153,11 +153,11 @@ func (cc *ClusterContext) DumpTestInfo(dirName string) {
 		log.Printf("failed getting kube info: %v", err)
 	}
 	log.Printf("kube info: \n%v", string(out))
-	out, err = cc.KubectlExec("get pods --field-selector status.phase!=Running -o yaml")
+	out, err = cc.KubectlExec(`get pods -o=jsonpath="{.items[*].status.containerStatuses[?(@.ready==false)]}"`)
 	if err != nil {
-		log.Printf("failed non-running job info: %v", err)
+		log.Printf("failed gathering non-ready pod info: %v", err)
 	}
-	log.Printf("non-running job info: \n%v", string(out))
+	log.Printf("non-ready pod info: \n%v", string(out))
 	//	out, err = cc.KubectlExec("get events")
 	//	if err != nil {
 	//		log.Printf("Failed getting events from %v: %v", cc.Namespace, err)

--- a/test/utils/base/cluster_context.go
+++ b/test/utils/base/cluster_context.go
@@ -158,10 +158,59 @@ func (cc *ClusterContext) DumpTestInfo(dirName string) {
 	// These may be up and running now (and their output will show that).  However,
 	// the last time they _terminated_, it was with a non-zero return, and that
 	// may be valuable information for investigations.
-	log.Printf("containers whose last termination was non-zero:")
-	_, err = cc.KubectlExec(`get pods -o=jsonpath="{.items[*].status.containerStatuses[?(@.lastState.terminated.exitCode!=0)]}"`)
+	//
+	// Here, we first get their pod and container names, and show some debugging
+	// information...
+	log.Printf("pod container whose last termination was non-zero:")
+	out, err := cc.KubectlExec(`get pod -o go-template='
+	    {{- range .items -}} 
+	      {{- with $pod := . -}} 
+		{{- range $pod.status.containerStatuses -}} 
+		  {{- with $cs := . -}} 
+		    {{- /* do we have a lastStae with exitCode on this cs? */ -}}
+		    {{- if $cs.lastState.terminated.exitCode -}}
+		      {{-  if ne $cs.lastState.terminated.exitCode 0 -}} 
+			{{ $pod.metadata.name }}{{ " " -}}
+			{{ $cs.name }}{{ " " -}}
+			lastExitCode: {{- $cs.lastState.terminated.exitCode }}{{ " " -}}
+			lastReason: {{- $cs.lastState.terminated.reason }}{{ " " -}}
+			lastStart: {{- $cs.lastState.terminated.startedAt }}{{ " " -}}
+			lastFinish: {{- $cs.lastState.terminated.finishedAt }}{{ " " -}}
+			restartCount: {{- $cs.restartCount }}{{ " " -}}
+			started: {{- $cs.started }}{{ " " -}}
+			podReady: {{- $cs.ready }}{{ "\n" -}}
+		      {{- end  -}}
+		    {{- end -}}
+		  {{- end -}}
+		{{- end -}}
+	      {{- end -}}
+	    {{- end -}}'
+	`)
 	if err != nil {
 		log.Printf("failed gathering information on containers: %v", err)
+	} else {
+
+		lines := strings.Split(string(out), "\n")
+		for _, line := range lines {
+
+			if line == "" {
+				continue
+			}
+
+			tokens := strings.Split(line, " ")
+
+			if len(tokens) < 2 {
+				fmt.Printf("The line %q is malformed for this process", line)
+				continue
+			}
+
+			logCmd := fmt.Sprintf("logs %s -c %s -p --tail=2000 --timestamps", tokens[0], tokens[1])
+			_, err = cc.KubectlExec(logCmd)
+			if err != nil {
+				log.Print("Failed fetching logs")
+			}
+
+		}
 	}
 
 	// On a healthy node, it will only report that it is ready.  If it faces any

--- a/test/utils/base/cluster_context.go
+++ b/test/utils/base/cluster_context.go
@@ -153,4 +153,9 @@ func (cc *ClusterContext) DumpTestInfo(dirName string) {
 		log.Printf("failed getting kube info: %v", err)
 	}
 	log.Printf("kube info: \n%v", string(out))
+	out, err = cc.KubectlExec("get pods --field-selector status.phase!=Running -o yaml")
+	if err != nil {
+		log.Printf("failed non-running job info: %v", err)
+	}
+	log.Printf("non-running job info: \n%v", string(out))
 }

--- a/test/utils/base/cluster_context.go
+++ b/test/utils/base/cluster_context.go
@@ -148,16 +148,24 @@ func (cc *ClusterContext) DumpTestInfo(dirName string) {
 	} else {
 		log.Printf("error dumping test info: %v", err)
 	}
+
 	out, err := cc.KubectlExec("get -o wide job,pod,service,event")
 	if err != nil {
 		log.Printf("failed getting kube info: %v", err)
 	}
 	log.Printf("kube info: \n%v", string(out))
+
 	out, err = cc.KubectlExec(`get pods -o=jsonpath="{.items[*].status.containerStatuses[?(@.ready==false)]}"`)
 	if err != nil {
 		log.Printf("failed gathering non-ready pod info: %v", err)
 	}
 	log.Printf("non-ready pod info: \n%v", string(out))
+
+	out, err = cc.KubectlExec(`get node -o jsonpath="{.items[*].status.conditions[?(@.status=='True')]}"`)
+	if err != nil {
+		log.Printf("failed gathering node pod info: %v", err)
+	}
+	log.Printf("node info: \n%v", string(out))
 	//	out, err = cc.KubectlExec("get events")
 	//	if err != nil {
 	//		log.Printf("Failed getting events from %v: %v", cc.Namespace, err)

--- a/test/utils/base/cluster_context.go
+++ b/test/utils/base/cluster_context.go
@@ -149,27 +149,21 @@ func (cc *ClusterContext) DumpTestInfo(dirName string) {
 		log.Printf("error dumping test info: %v", err)
 	}
 
-	out, err := cc.KubectlExec("get -o wide job,pod,service,event")
+	log.Printf("kube info:")
+	_, err = cc.KubectlExec("get -o wide job,pod,service,event")
 	if err != nil {
 		log.Printf("failed getting kube info: %v", err)
 	}
-	log.Printf("kube info: \n%v", string(out))
 
-	out, err = cc.KubectlExec(`get pods -o=jsonpath="{.items[*].status.containerStatuses[?(@.ready==false)]}"`)
+	log.Printf("non-ready pod info:")
+	_, err = cc.KubectlExec(`get pods -o=jsonpath="{.items[*].status.containerStatuses[?(@.ready==false)]}"`)
 	if err != nil {
 		log.Printf("failed gathering non-ready pod info: %v", err)
 	}
-	log.Printf("non-ready pod info: \n%v", string(out))
 
-	out, err = cc.KubectlExec(`get node -o jsonpath="{.items[*].status.conditions[?(@.status=='True')]}"`)
+	log.Printf("node info:")
+	_, err = cc.KubectlExec(`get node -o jsonpath="{.items[*].status.conditions[?(@.status=='True')]}"`)
 	if err != nil {
 		log.Printf("failed gathering node pod info: %v", err)
 	}
-	log.Printf("node info: \n%v", string(out))
-	//	out, err = cc.KubectlExec("get events")
-	//	if err != nil {
-	//		log.Printf("Failed getting events from %v: %v", cc.Namespace, err)
-	//		return
-	//	}
-	//	log.Printf("kube events for %v:\n%s", cc.Namespace, string(out))
 }

--- a/test/utils/base/cluster_context.go
+++ b/test/utils/base/cluster_context.go
@@ -148,7 +148,7 @@ func (cc *ClusterContext) DumpTestInfo(dirName string) {
 	} else {
 		log.Printf("error dumping test info: %v", err)
 	}
-	out, err := cc.KubectlExec("get -o wide job,pod,service")
+	out, err := cc.KubectlExec("get -o wide job,pod,service,event")
 	if err != nil {
 		log.Printf("failed getting kube info: %v", err)
 	}


### PR DESCRIPTION
These changes are result of two investigations on HipsterShop errors on the CIs:

- Out of memory errors on CircleCI
- Cartservice failing intermittently and causing the tests to fail

Only the Out of Memory error is fixed by this PR, but the additional debugging information added for both investigations are part of this PR.  The root cause for the Cartservice error has already been identified, but it will be dealt with on a separate PR.

On this PR:

- CircleCI
  - The main tests now run on a Linux/Large executor in CircleCI, which fixes the out of memory conditions; the minikube instance has been updated to use the additional resources, moving to 4 CPUs and 6 GiB memory
  - The main tests and policy tests now run in parallel, whereas previously policy waited for the main tests to finish; the interdependencies have been updated to reflect this new parallelism
  - The job names have been changed, so they're more easily identifiable on the CircleCI UI (`minikube_local_cluster_tests` became `main_tests_minikube_local_cluster`, and `minikube_local_cluster_policy_tests` became `policy_tests_minikube_local_cluster`.  In other words, the identifying words were moved to the begining of the name)
  - Additional debug output, chiefly targeted at OOM situations has been added: 
    - minikube logs are output continuously during the job run, and grepped for OOM
    - `free -m`, `uptime` and `cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes` are executed at the end of the job
    - In a separate instruction, `minikube kubectl cluster-info dump | grep -i oom` is also run at the end of the job
- HipsterShop
  - Instances of `t.Logf` have been replaced by `log.Printf`; those logs were being printed only out of context on the test summary output
  - The `testRunner.DumpTestInfo` call was moved from within a clusters-loop to the tearDown function, as `testRunner.DumpTestInfo` itself already has a cluster-loop within it, duplicating the output
  - The call to `k8s.GetJobLogs` has been replaced with `k8s.GetJobsLogs`, to provide logs for earlier, failed job runs.  
  - `testRunner.DumpTestInfo` previously would not run when there were errors to get job logs; now it just reports the error and continues
- `testRunner.DumpTestInfo`
  - events were added to the per-namespace output
  - Logs for the latest previously failed run of a pod's container are now shown on the output, as long as the pod still exists
  - Some simple reporting on node status has also been added, which will allow to glimpse into memory, disk and PID pressures on the nodes.