### PR TITLE
Switch command

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -100,6 +100,7 @@ type SiteConfigSpec struct {
 	Router              RouterOptions
 	Controller          ControllerOptions
 	ConfigSync          ConfigSyncOptions
+	Platform            Platform
 }
 
 const (
@@ -162,15 +163,20 @@ func (s *SiteConfigSpec) getConsoleIngress() string {
 	return s.ConsoleIngress
 }
 
-func ValidIngressOptions() []string {
-	return []string{IngressRouteString, IngressLoadBalancerString, IngressNodePortString, IngressNginxIngressString, IngressContourHttpProxyString, IngressKubernetes, IngressNoneString}
+func ValidIngressOptions(platform Platform) []string {
+	switch platform {
+	case PlatformPodman:
+		return []string{}
+	default:
+		return []string{IngressRouteString, IngressLoadBalancerString, IngressNodePortString, IngressNginxIngressString, IngressContourHttpProxyString, IngressKubernetes, IngressNoneString}
+	}
 }
 
-func isValidIngress(ingress string) bool {
+func isValidIngress(platform Platform, ingress string) bool {
 	if ingress == "" {
 		return true
 	}
-	for _, value := range ValidIngressOptions() {
+	for _, value := range ValidIngressOptions(platform) {
 		if ingress == value {
 			return true
 		}
@@ -179,14 +185,14 @@ func isValidIngress(ingress string) bool {
 }
 
 func (s *SiteConfigSpec) CheckIngress() error {
-	if !isValidIngress(s.Ingress) {
+	if !isValidIngress(s.Platform, s.Ingress) {
 		return fmt.Errorf("Invalid value for ingress: %s", s.Ingress)
 	}
 	return nil
 }
 
 func (s *SiteConfigSpec) CheckConsoleIngress() error {
-	if !isValidIngress(s.ConsoleIngress) {
+	if !isValidIngress(s.Platform, s.ConsoleIngress) {
 		return fmt.Errorf("Invalid value for console-ingress: %s", s.ConsoleIngress)
 	}
 	return nil

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -9,6 +9,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	ENV_PLATFORM = "SKUPPER_PLATFORM"
+)
+
 type ConnectorCreateOptions struct {
 	SkupperNamespace string
 	Name             string
@@ -318,4 +322,5 @@ type VanClientInterface interface {
 	GetIngressDefault() string
 	RevokeAccess(ctx context.Context) error
 	NetworkStatus() ([]*SiteInfo, error)
+	//	Platform() Platform
 }

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -328,5 +328,4 @@ type VanClientInterface interface {
 	GetIngressDefault() string
 	RevokeAccess(ctx context.Context) error
 	NetworkStatus() ([]*SiteInfo, error)
-	//	Platform() Platform
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -209,6 +209,13 @@ const (
 	RouterConsoleServiceName               string = "skupper-router-console"
 )
 
+type Platform string
+
+const (
+	PlatformKubernetes Platform = "kubernetes"
+	PlatformPodman              = "podman"
+)
+
 type ConsoleAuthMode string
 
 const (

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -389,10 +389,6 @@ installation that can then be connected to other skupper installations`,
 
 	cmd.Flags().IntVar(&routerCreateOpts.Routers, "routers", 0, "Number of router replicas to start")
 
-	cmd.Flags().IntVar(&routerCreateOpts.Router.MaxFrameSize, "xp-router-max-frame-size", types.RouterMaxFrameSizeDefault, "Set  max frame size on inter-router listeners/connectors")
-	cmd.Flags().IntVar(&routerCreateOpts.Router.MaxSessionFrames, "xp-router-max-session-frames", types.RouterMaxSessionFramesDefault, "Set  max session frames on inter-router listeners/connectors")
-	hideFlag(cmd, "xp-router-max-frame-size")
-	hideFlag(cmd, "xp-router-max-session-frames")
 	cmd.Flags().SortFlags = false
 
 	// platform specific flags

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -42,7 +42,6 @@ type SkupperSiteClient interface {
 	UpdateFlags(cmd *cobra.Command)
 	Version(cmd *cobra.Command, args []string) error
 	RevokeAccess(cmd *cobra.Command, args []string) error
-	SkupperClientCommon
 }
 
 type SkupperServiceClient interface {
@@ -56,7 +55,6 @@ type SkupperServiceClient interface {
 	ExposeArgs(cmd *cobra.Command, args []string) error
 	ExposeFlags(cmd *cobra.Command)
 	Unexpose(cmd *cobra.Command, args []string) error
-	SkupperClientCommon
 }
 
 type SkupperDebugClient interface {
@@ -68,7 +66,6 @@ type SkupperDebugClient interface {
 
 type SkupperLinkClient interface {
 	SkupperClientManager
-	SkupperClientCommon
 }
 
 type SkupperTokenClient interface {

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -435,45 +435,6 @@ func NewCmdUpdate(skupperCli SkupperSiteClient) *cobra.Command {
 
 var clientIdentity string
 
-func NewCmdConnectionToken(skupperClient SkupperTokenClient) *cobra.Command {
-	cmd := NewCmdTokenCreate(skupperClient, "client-identity")
-	cmd.Use = "connection-token <output-file>"
-	cmd.Short = "Create a connection token.  The 'connect' command uses the token to establish a connection from a remote Skupper site."
-	return cmd
-}
-
-func NewCmdConnect(skupperClient SkupperLinkClient) *cobra.Command {
-	cmd := NewCmdLinkCreate(skupperClient, "connection-name")
-	cmd.Use = "connect <connection-token-file>"
-	cmd.Short = "Connect this skupper installation to that which issued the specified connectionToken"
-	return cmd
-
-}
-func NewCmdDisconnect(skupperClient SkupperLinkClient) *cobra.Command {
-	cmd := NewCmdLinkDelete(skupperClient)
-	cmd.Use = "disconnect <name>"
-	cmd.Short = "Remove specified connection"
-	return cmd
-
-}
-func NewCmdCheckConnection(skupperClient SkupperLinkClient) *cobra.Command {
-	cmd := NewCmdLinkStatus(skupperClient)
-	cmd.Use = "check-connection all|<connection-name>"
-	cmd.Short = "Check whether a connection to another Skupper site is active"
-	return cmd
-}
-
-func NewCmdListConnectors(skupperClient SkupperLinkClient) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "list-connectors",
-		Short:  "List configured outgoing connections",
-		Args:   cobra.NoArgs,
-		PreRun: skupperClient.NewClient,
-		RunE:   skupperClient.List,
-	}
-	return cmd
-}
-
 func NewCmdStatus(skupperCli SkupperSiteClient) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "status",
@@ -517,12 +478,6 @@ func NewCmdUnexpose(skupperCli SkupperServiceClient) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&unexposeAddress, "address", "", "Skupper address the target was exposed as")
 
-	return cmd
-}
-
-func NewCmdListExposed(skupperClient SkupperServiceClient) *cobra.Command {
-	cmd := NewCmdServiceStatus(skupperClient)
-	cmd.Use = "list-exposed"
 	return cmd
 }
 
@@ -904,13 +859,10 @@ func init() {
 	cmdStatus := NewCmdStatus(skupperCli.Site())
 	cmdExpose := NewCmdExpose(skupperCli.Service())
 	cmdUnexpose := NewCmdUnexpose(skupperCli.Service())
-	cmdListExposed := NewCmdListExposed(skupperCli.Service())
 	cmdCreateService := NewCmdCreateService(skupperCli.Service())
 	cmdDeleteService := NewCmdDeleteService(skupperCli.Service())
 	cmdStatusService := NewCmdServiceStatus(skupperCli.Service())
 	cmdLabelsService := NewCmdServiceLabel(skupperCli.Service())
-	cmdBind := NewCmdBind(skupperCli.Service())
-	cmdUnbind := NewCmdUnbind(skupperCli.Service())
 
 	cmdVersion := NewCmdVersion(skupperCli.Site())
 	cmdDebugDump := NewCmdDebugDump(skupperCli.Debug())
@@ -921,7 +873,6 @@ func init() {
 	cmdGateway := NewCmdGateway()
 	if skupperKube, ok := skupperCli.(*SkupperKube); ok {
 		cmdInitGateway := NewCmdInitGateway(skupperKube)
-		cmdDownloadGateway := NewCmdDownloadGateway(skupperKube)
 		cmdExportConfigGateway := NewCmdExportConfigGateway(skupperKube)
 		cmdGenerateBundleGateway := NewCmdGenerateBundleGateway(skupperKube)
 		cmdDeleteGateway := NewCmdDeleteGateway(skupperKube)
@@ -933,11 +884,7 @@ func init() {
 		cmdForwardGateway := NewCmdForwardGateway(skupperKube)
 		cmdUnforwardGateway := NewCmdUnforwardGateway(skupperKube)
 
-		cmdDownloadGateway.Hidden = true
-		cmdDownloadGateway.Deprecated = "please use 'skupper gateway export-config' instead."
-
 		cmdGateway.AddCommand(cmdInitGateway)
-		cmdGateway.AddCommand(cmdDownloadGateway)
 		cmdGateway.AddCommand(cmdExportConfigGateway)
 		cmdGateway.AddCommand(cmdGenerateBundleGateway)
 		cmdGateway.AddCommand(cmdDeleteGateway)
@@ -949,38 +896,6 @@ func init() {
 		cmdGateway.AddCommand(cmdForwardGateway)
 		cmdGateway.AddCommand(cmdUnforwardGateway)
 	}
-
-	// backwards compatibility commands hidden
-	deprecatedMessage := "please use 'skupper service [bind|unbind]' instead"
-	cmdBind.Hidden = true
-	cmdBind.Deprecated = deprecatedMessage
-	cmdUnbind.Deprecated = deprecatedMessage
-	cmdUnbind.Hidden = true
-
-	cmdListConnectors := NewCmdListConnectors(skupperCli.Link()) // listconnectors just keeped
-	cmdListConnectors.Hidden = true
-	cmdListConnectors.Deprecated = "please use 'skupper link status'"
-
-	linkDeprecationMessage := "please use 'skupper link [create|delete|status]' instead."
-
-	cmdConnect := NewCmdConnect(skupperCli.Link())
-	cmdConnect.Hidden = true
-	cmdConnect.Deprecated = linkDeprecationMessage
-
-	cmdDisconnect := NewCmdDisconnect(skupperCli.Link())
-	cmdDisconnect.Hidden = true
-	cmdDisconnect.Deprecated = linkDeprecationMessage
-
-	cmdCheckConnection := NewCmdCheckConnection(skupperCli.Link())
-	cmdCheckConnection.Hidden = true
-	cmdCheckConnection.Deprecated = linkDeprecationMessage
-
-	cmdConnectionToken := NewCmdConnectionToken(skupperCli.Token())
-	cmdConnectionToken.Hidden = true
-	cmdConnectionToken.Deprecated = "please use 'skupper token create' instead."
-
-	cmdListExposed.Hidden = true
-	cmdListExposed.Deprecated = "please use 'skupper service status' instead."
 
 	// setup subcommands
 	cmdService := NewCmdService()

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -506,70 +506,6 @@ func NewCmdServiceStatus(skupperClient SkupperClient) *cobra.Command {
 	return cmd
 }
 
-func listServices(vsis []*types.ServiceInterface, showLabels bool) {
-	if len(vsis) == 0 {
-		fmt.Println("No services defined")
-	} else {
-		l := formatter.NewList()
-		l.Item("Services exposed through Skupper:")
-		addresses := []string{}
-		for _, si := range vsis {
-			addresses = append(addresses, si.Address)
-		}
-		svcAuth := map[string]bool{}
-		for _, addr := range addresses {
-			svcAuth[addr] = true
-		}
-		if vc, ok := cli.(*client.VanClient); ok {
-			policy := client.NewPolicyValidatorAPI(vc)
-			res, _ := policy.Services(addresses...)
-			for addr, auth := range res {
-				svcAuth[addr] = auth.Allowed
-			}
-		}
-
-		for _, si := range vsis {
-			portStr := "port"
-			if len(si.Ports) > 1 {
-				portStr = "ports"
-			}
-			for _, port := range si.Ports {
-				portStr += fmt.Sprintf(" %d", port)
-			}
-			authSuffix := ""
-			if !svcAuth[si.Address] {
-				authSuffix = " - not authorized"
-			}
-			svc := l.NewChild(fmt.Sprintf("%s (%s %s)%s", si.Address, si.Protocol, portStr, authSuffix))
-			if len(si.Targets) > 0 {
-				targets := svc.NewChild("Targets:")
-				for _, t := range si.Targets {
-					var name string
-					if t.Name != "" {
-						name = fmt.Sprintf("name=%s", t.Name)
-					}
-					targetInfo := ""
-					if t.Selector != "" {
-						targetInfo = fmt.Sprintf("%s %s", t.Selector, name)
-					} else if t.Service != "" {
-						targetInfo = fmt.Sprintf("%s %s", t.Service, name)
-					} else {
-						targetInfo = fmt.Sprintf("%s (no selector)", name)
-					}
-					targets.NewChild(targetInfo)
-				}
-			}
-			if showLabels && len(si.Labels) > 0 {
-				labels := svc.NewChild("Labels:")
-				for k, v := range si.Labels {
-					labels.NewChild(fmt.Sprintf("%s=%s", k, v))
-				}
-			}
-		}
-		l.Print()
-	}
-}
-
 var addLabels, removeLabels []string
 
 func NewCmdServiceLabel(skupperClient SkupperClient) *cobra.Command {
@@ -895,9 +831,6 @@ the .bash_profile. i.e.: $ source <(skupper completion)
 type cobraFunc func(cmd *cobra.Command, args []string)
 
 var rootCmd *cobra.Command
-
-// TODO Remove after refactor is complete
-var cli types.VanClientInterface
 
 func isSupported(skupperCli SkupperClient, cmd string) bool {
 	return utils.StringSliceContains(skupperCli.SupportedCommands(), cmd)

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	time2 "time"
+	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/skupperproject/skupper/pkg/utils/formatter"
@@ -320,7 +320,7 @@ func asMap(entries []string) map[string]string {
 	return result
 }
 
-var LoadBalancerTimeout time2.Duration
+var LoadBalancerTimeout time.Duration
 
 type InitFlags struct {
 	routerMode string
@@ -390,7 +390,7 @@ func NewCmdUpdate(skupperCli SkupperClient) *cobra.Command {
 		Long:   "Update the skupper site to " + client.Version,
 		Args:   cobra.NoArgs,
 		PreRun: skupperCli.NewClient,
-		RunE:   skupperCli.Delete,
+		RunE:   skupperCli.Update,
 	}
 	cmd.Flags().BoolVarP(&forceHup, "force-restart", "", false, "Restart skupper daemons even if image tag is not updated")
 	return cmd
@@ -845,7 +845,13 @@ func addCommands(skupperCli SkupperClient, rootCmd *cobra.Command, cmds ...*cobr
 }
 
 func init() {
+	rootCmd = &cobra.Command{Use: "skupper"}
 	routev1.AddToScheme(scheme.Scheme)
+
+	rootCmd.PersistentFlags().StringVarP(&config.Platform, "platform", "", "", "The platform type to use")
+	platformFlag := rootCmd.Flag("platform")
+	platformFlag.Hidden = true
+	rootCmd.ParseFlags(os.Args)
 
 	var skupperCli SkupperClient
 	switch config.GetPlatform() {
@@ -969,8 +975,8 @@ func init() {
 	cmdNetwork.AddCommand(NewCmdNetworkStatus(skupperCli))
 
 	cmdSwitch := NewCmdSwitch()
+	cmdSwitch.Hidden = true
 
-	rootCmd = &cobra.Command{Use: "skupper"}
 	addCommands(skupperCli, rootCmd,
 		cmdInit,
 		cmdDelete,
@@ -990,7 +996,7 @@ func init() {
 
 	rootCmd.AddCommand(cmdSwitch)
 	skupperCli.Options(rootCmd)
-	rootCmd.PersistentFlags().StringVarP(&config.Platform, "platform", "", "", "The platform type to use")
+
 }
 
 func main() {

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -24,6 +24,16 @@ import (
 	"github.com/skupperproject/skupper/pkg/utils"
 )
 
+type SkupperClient interface {
+	NewClient(cmd *cobra.Command, args []string)
+	Platform() types.Platform
+	SupportedCommands() []string
+	Options(cmd *cobra.Command)
+	Init(cmd *cobra.Command, args []string) error
+	InitFlags(cmd *cobra.Command)
+	DebugDump(cmd *cobra.Command, args []string) error
+}
+
 type ExposeOptions struct {
 	Protocol                 string
 	Address                  string
@@ -328,168 +338,44 @@ func asMap(entries []string) map[string]string {
 
 var LoadBalancerTimeout time2.Duration
 
-func NewCmdInit(newClient cobraFunc) *cobra.Command {
-	var routerMode string
-	annotations := []string{}
-	ingressAnnotations := []string{}
-	routerServiceAnnotations := []string{}
-	controllerServiceAnnotations := []string{}
-	labels := []string{}
+type InitFlags struct {
+	routerMode string
+	labels     []string
+}
 
+var initFlags InitFlags
+
+func NewCmdInit(skupperCli SkupperClient) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialise skupper installation",
 		Long: `Setup a router and other supporting objects to provide a functional skupper
 installation that can then be connected to other skupper installations`,
 		Args:   cobra.NoArgs,
-		PreRun: newClient,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO: should cli allow init to diff ns?
-			silenceCobra(cmd)
-			ns := cli.GetNamespace()
-
-			routerModeFlag := cmd.Flag("router-mode")
-
-			if routerModeFlag.Changed {
-				options := []string{string(types.TransportModeInterior), string(types.TransportModeEdge)}
-				if !utils.StringSliceContains(options, routerMode) {
-					return fmt.Errorf(`invalid "--router-mode=%v", it must be one of "%v"`, routerMode, strings.Join(options, ", "))
-				}
-				routerCreateOpts.RouterMode = routerMode
-			} else {
-				routerCreateOpts.RouterMode = string(types.TransportModeInterior)
-			}
-
-			routerIngressFlag := cmd.Flag("ingress")
-
-			if !routerIngressFlag.Changed {
-				routerCreateOpts.Ingress = cli.GetIngressDefault()
-			}
-			if routerCreateOpts.Ingress == types.IngressNodePortString && routerCreateOpts.IngressHost == "" && routerCreateOpts.Router.IngressHost == "" {
-				return fmt.Errorf(`One of --ingress-host or --router-ingress-host option is required when using "--ingress nodeport"`)
-			}
-			if routerCreateOpts.Ingress == types.IngressContourHttpProxyString && routerCreateOpts.IngressHost == "" {
-				return fmt.Errorf(`--ingress-host option is required when using "--ingress contour-http-proxy"`)
-			}
-			routerCreateOpts.Annotations = asMap(annotations)
-			routerCreateOpts.Labels = asMap(labels)
-			routerCreateOpts.IngressAnnotations = asMap(ingressAnnotations)
-			routerCreateOpts.Router.ServiceAnnotations = asMap(routerServiceAnnotations)
-			routerCreateOpts.Router.MaxFrameSize = types.RouterMaxFrameSizeDefault
-			routerCreateOpts.Router.MaxSessionFrames = types.RouterMaxSessionFramesDefault
-			routerCreateOpts.Controller.ServiceAnnotations = asMap(controllerServiceAnnotations)
-			if err := routerCreateOpts.CheckIngress(); err != nil {
-				return err
-			}
-			if err := routerCreateOpts.CheckConsoleIngress(); err != nil {
-				return err
-			}
-
-			routerCreateOpts.SkupperNamespace = ns
-			siteConfig, err := cli.SiteConfigInspect(context.Background(), nil)
-			if err != nil {
-				return err
-			}
-			if routerLogging != "" {
-				logConfig, err := client.ParseRouterLogConfig(routerLogging)
-				if err != nil {
-					return fmt.Errorf("Bad value for --router-logging: %s", err)
-				}
-				routerCreateOpts.Router.Logging = logConfig
-			}
-			if routerCreateOpts.Router.DebugMode != "" {
-				if routerCreateOpts.Router.DebugMode != "asan" && routerCreateOpts.Router.DebugMode != "gdb" {
-					return fmt.Errorf("Bad value for --router-debug-mode: %s (use 'asan' or 'gdb')", routerCreateOpts.Router.DebugMode)
-				}
-			}
-
-			if LoadBalancerTimeout.Seconds() <= 0 {
-				return fmt.Errorf(`invalid timeout value`)
-			}
-
-			if siteConfig == nil {
-				siteConfig, err = cli.SiteConfigCreate(context.Background(), routerCreateOpts)
-				if err != nil {
-					return err
-				}
-			} else {
-				updated, err := cli.SiteConfigUpdate(context.Background(), routerCreateOpts)
-				if err != nil {
-					return fmt.Errorf("Error while trying to update router configuration: %s", err)
-				}
-				if len(updated) > 0 {
-					for _, i := range updated {
-						fmt.Println("Updated", i)
-					}
-				}
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), LoadBalancerTimeout)
-			defer cancel()
-
-			err = cli.RouterCreate(ctx, *siteConfig)
-			if err != nil {
-				err2 := cli.SiteConfigRemove(context.Background())
-				if err2 != nil {
-					fmt.Println("Failed to cleanup site: ", err2)
-				}
-				return err
-			}
-			fmt.Println("Skupper is now installed in namespace '" + ns + "'.  Use 'skupper status' to get more information.")
-
-			return nil
-		},
+		PreRun: skupperCli.NewClient,
+		RunE:   skupperCli.Init,
 	}
+	platform := skupperCli.Platform()
 	routerCreateOpts.EnableController = true
 	cmd.Flags().StringVarP(&routerCreateOpts.SkupperName, "site-name", "", "", "Provide a specific name for this skupper installation")
-	cmd.Flags().BoolVarP(&routerCreateOpts.EnableConsole, "enable-console", "", true, "Enable skupper console")
-	cmd.Flags().BoolVarP(&routerCreateOpts.CreateNetworkPolicy, "create-network-policy", "", false, "Create network policy to restrict access to skupper services exposed through this site to current pods in namespace")
-	cmd.Flags().StringVarP(&routerCreateOpts.AuthMode, "console-auth", "", "", "Authentication mode for console(s). One of: 'openshift', 'internal', 'unsecured'")
-	cmd.Flags().StringVarP(&routerCreateOpts.User, "console-user", "", "", "Skupper console user. Valid only when --console-auth=internal")
-	cmd.Flags().StringVarP(&routerCreateOpts.Password, "console-password", "", "", "Skupper console user. Valid only when --console-auth=internal")
-	cmd.Flags().StringVarP(&routerCreateOpts.Ingress, "ingress", "", "", "Setup Skupper ingress to one of: ["+strings.Join(types.ValidIngressOptions(), "|")+"]. If not specified route is used when available, otherwise loadbalancer is used.")
-	cmd.Flags().StringSliceVar(&ingressAnnotations, "ingress-annotations", []string{}, "Annotations to add to skupper ingress")
-	cmd.Flags().StringVarP(&routerCreateOpts.ConsoleIngress, "console-ingress", "", "", "Determines if/how console is exposed outside cluster. If not specified uses value of --ingress. One of: ["+strings.Join(types.ValidIngressOptions(), "|")+"].")
+	cmd.Flags().StringVarP(&routerCreateOpts.Ingress, "ingress", "", "", "Setup Skupper ingress to one of: ["+strings.Join(types.ValidIngressOptions(platform), "|")+"]. If not specified route is used when available, otherwise loadbalancer is used.")
 	cmd.Flags().StringVarP(&routerCreateOpts.IngressHost, "ingress-host", "", "", "Hostname or alias by which the ingress route or proxy can be reached")
-	cmd.Flags().StringVarP(&routerMode, "router-mode", "", string(types.TransportModeInterior), "Skupper router-mode")
+	cmd.Flags().StringVarP(&initFlags.routerMode, "router-mode", "", string(types.TransportModeInterior), "Skupper router-mode")
 
-	cmd.Flags().StringSliceVar(&annotations, "annotations", []string{}, "Annotations to add to skupper pods")
-	cmd.Flags().StringSliceVar(&labels, "labels", []string{}, "Labels to add to skupper pods")
-	cmd.Flags().BoolVarP(&routerCreateOpts.EnableServiceSync, "enable-service-sync", "", true, "Participate in cross-site service synchronization")
+	cmd.Flags().StringSliceVar(&initFlags.labels, "labels", []string{}, "Labels to add to skupper pods")
 	cmd.Flags().StringVarP(&routerLogging, "router-logging", "", "", "Logging settings for router. 'trace', 'debug', 'info' (default), 'notice', 'warning', and 'error' are valid values.")
 	cmd.Flags().StringVarP(&routerCreateOpts.Router.DebugMode, "router-debug-mode", "", "", "Enable debug mode for router ('asan' or 'gdb' are valid values)")
 
 	cmd.Flags().IntVar(&routerCreateOpts.Routers, "routers", 0, "Number of router replicas to start")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.Cpu, "router-cpu", "", "CPU request for router pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.Memory, "router-memory", "", "Memory request for router pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.CpuLimit, "router-cpu-limit", "", "CPU limit for router pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.MemoryLimit, "router-memory-limit", "", "Memory limit for router pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.NodeSelector, "router-node-selector", "", "Node selector to control placement of router pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.Affinity, "router-pod-affinity", "", "Pod affinity label matches to control placement of router pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.AntiAffinity, "router-pod-antiaffinity", "", "Pod antiaffinity label matches to control placement of router pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.IngressHost, "router-ingress-host", "", "Host through which node is accessible when using nodeport as ingress.")
-	cmd.Flags().StringSliceVar(&routerServiceAnnotations, "router-service-annotations", []string{}, "Annotations to add to skupper router service")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.LoadBalancerIp, "router-load-balancer-ip", "", "Load balancer ip that will be used for router service, if supported by cloud provider")
 
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.Cpu, "controller-cpu", "", "CPU request for controller pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.Memory, "controller-memory", "", "Memory request for controller pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.CpuLimit, "controller-cpu-limit", "", "CPU limit for controller pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.MemoryLimit, "controller-memory-limit", "", "Memory limit for controller pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.NodeSelector, "controller-node-selector", "", "Node selector to control placement of controller pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.Affinity, "controller-pod-affinity", "", "Pod affinity label matches to control placement of controller pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.AntiAffinity, "controller-pod-antiaffinity", "", "Pod antiaffinity label matches to control placement of controller pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.IngressHost, "controller-ingress-host", "", "Host through which node is accessible when using nodeport as ingress.")
-	cmd.Flags().StringSliceVar(&controllerServiceAnnotations, "controller-service-annotation", []string{}, "Annotations to add to skupper controller service")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.LoadBalancerIp, "controller-load-balancer-ip", "", "Load balancer ip that will be used for controller service, if supported by cloud provider")
-
-	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.Cpu, "config-sync-cpu", "", "CPU request for config-sync pods")
-	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.Memory, "config-sync-memory", "", "Memory request for config-sync pods")
-	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.CpuLimit, "config-sync-cpu-limit", "", "CPU limit for config-sync pods")
-	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.MemoryLimit, "config-sync-memory-limit", "", "Memory limit for config-sync pods")
-
-	cmd.Flags().DurationVar(&LoadBalancerTimeout, "timeout", types.DefaultTimeoutDuration, "Configurable timeout for the ingress loadbalancer option.")
-
+	cmd.Flags().IntVar(&routerCreateOpts.Router.MaxFrameSize, "xp-router-max-frame-size", types.RouterMaxFrameSizeDefault, "Set  max frame size on inter-router listeners/connectors")
+	cmd.Flags().IntVar(&routerCreateOpts.Router.MaxSessionFrames, "xp-router-max-session-frames", types.RouterMaxSessionFramesDefault, "Set  max session frames on inter-router listeners/connectors")
+	hideFlag(cmd, "xp-router-max-frame-size")
+	hideFlag(cmd, "xp-router-max-session-frames")
 	cmd.Flags().SortFlags = false
+
+	// platform specific flags
+	skupperCli.InitFlags(cmd)
 
 	return cmd
 }
@@ -1504,22 +1390,13 @@ func NewCmdDebug() *cobra.Command {
 	return cmd
 }
 
-func NewCmdDebugDump(newClient cobraFunc) *cobra.Command {
+func NewCmdDebugDump(skupperCli SkupperClient) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "dump <filename>.tar.gz",
 		Short:  "Collect and store skupper logs, config, etc. to compressed archive file",
 		Args:   cobra.ExactArgs(1),
-		PreRun: newClient,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			silenceCobra(cmd)
-			file, err := cli.SkupperDump(context.Background(), args[0], client.Version, kubeConfigPath, kubeContext)
-			if err != nil {
-				return fmt.Errorf("Unable to save skupper dump details: %w", err)
-			} else {
-				fmt.Println("Skupper dump details written to compressed archive: ", file)
-			}
-			return nil
-		},
+		PreRun: skupperCli.NewClient,
+		RunE:   skupperCli.DebugDump,
 	}
 	return cmd
 }
@@ -1609,56 +1486,105 @@ the .bash_profile. i.e.: $ source <(skupper completion)
 
 type cobraFunc func(cmd *cobra.Command, args []string)
 
-func newClient(cmd *cobra.Command, args []string) {
-	cli = NewClient(namespace, kubeContext, kubeConfigPath)
-}
-
-func newClientSansExit(cmd *cobra.Command, args []string) {
-	cli = NewClientHandleError(namespace, kubeContext, kubeConfigPath, false)
-}
-
-var kubeContext string
-var namespace string
-var kubeConfigPath string
 var rootCmd *cobra.Command
 var cli types.VanClientInterface
+
+func isSupported(skupperCli SkupperClient, cmd string) bool {
+	return utils.StringSliceContains(skupperCli.SupportedCommands(), cmd)
+}
+
+func addCommands(skupperCli SkupperClient, rootCmd *cobra.Command, cmds ...*cobra.Command) {
+	for _, cmd := range cmds {
+		if isSupported(skupperCli, cmd.Name()) {
+			rootCmd.AddCommand(cmd)
+		}
+	}
+}
 
 func init() {
 	routev1.AddToScheme(scheme.Scheme)
 
-	cmdInit := NewCmdInit(newClient)
-	cmdDelete := NewCmdDelete(newClient)
-	cmdUpdate := NewCmdUpdate(newClient)
-	cmdStatus := NewCmdStatus(newClient)
-	cmdExpose := NewCmdExpose(newClient)
-	cmdUnexpose := NewCmdUnexpose(newClient)
-	cmdCreateService := NewCmdCreateService(newClient)
-	cmdDeleteService := NewCmdDeleteService(newClient)
-	cmdStatusService := NewCmdServiceStatus(newClient)
-	cmdLabelsService := NewCmdServiceLabel(newClient)
-	cmdVersion := NewCmdVersion(newClientSansExit)
-	cmdDebugDump := NewCmdDebugDump(newClient)
-	cmdDebugEvents := NewCmdDebugEvents(newClient)
-	cmdDebugService := NewCmdDebugService(newClient)
+	var skupperCli SkupperClient
+	switch config.GetPlatform() {
+	case types.PlatformKubernetes:
+		skupperCli = &SkupperKube{}
+	case types.PlatformPodman:
+		skupperCli = &SkupperPodman{}
+	}
 
-	cmdInitGateway := NewCmdInitGateway(newClient)
-	cmdExportConfigGateway := NewCmdExportConfigGateway(newClient)
-	cmdGenerateBundleGateway := NewCmdGenerateBundleGateway(newClient)
-	cmdDeleteGateway := NewCmdDeleteGateway(newClient)
-	cmdExposeGateway := NewCmdExposeGateway(newClient)
-	cmdUnexposeGateway := NewCmdUnexposeGateway(newClient)
-	cmdStatusGateway := NewCmdStatusGateway(newClient)
-	cmdBindGateway := NewCmdBindGateway(newClient)
-	cmdUnbindGateway := NewCmdUnbindGateway(newClient)
-	cmdForwardGateway := NewCmdForwardGateway(newClient)
-	cmdUnforwardGateway := NewCmdUnforwardGateway(newClient)
+	cmdInit := NewCmdInit(skupperCli)
+	// TODO
+	cmdDelete := NewCmdDelete(skupperCli.NewClient)
+	cmdUpdate := NewCmdUpdate(skupperCli.NewClient)
+	cmdStatus := NewCmdStatus(skupperCli.NewClient)
+	cmdExpose := NewCmdExpose(skupperCli.NewClient)
+	cmdUnexpose := NewCmdUnexpose(skupperCli.NewClient)
+	cmdListExposed := NewCmdListExposed(skupperCli.NewClient)
+	cmdCreateService := NewCmdCreateService(skupperCli.NewClient)
+	cmdDeleteService := NewCmdDeleteService(skupperCli.NewClient)
+	cmdStatusService := NewCmdServiceStatus(skupperCli.NewClient)
+	cmdLabelsService := NewCmdServiceLabel(skupperCli.NewClient)
+	cmdBind := NewCmdBind(skupperCli.NewClient)
+	cmdUnbind := NewCmdUnbind(skupperCli.NewClient)
+	cmdVersion := NewCmdVersion(skupperCli.NewClient)
+	cmdDebugDump := NewCmdDebugDump(skupperCli)
+	cmdDebugEvents := NewCmdDebugEvents(skupperCli.NewClient)
+	cmdDebugService := NewCmdDebugService(skupperCli.NewClient)
+
+	cmdInitGateway := NewCmdInitGateway(skupperCli.NewClient)
+	cmdDownloadGateway := NewCmdDownloadGateway(skupperCli.NewClient)
+	cmdExportConfigGateway := NewCmdExportConfigGateway(skupperCli.NewClient)
+	cmdGenerateBundleGateway := NewCmdGenerateBundleGateway(skupperCli.NewClient)
+	cmdDeleteGateway := NewCmdDeleteGateway(skupperCli.NewClient)
+	cmdExposeGateway := NewCmdExposeGateway(skupperCli.NewClient)
+	cmdUnexposeGateway := NewCmdUnexposeGateway(skupperCli.NewClient)
+	cmdStatusGateway := NewCmdStatusGateway(skupperCli.NewClient)
+	cmdBindGateway := NewCmdBindGateway(skupperCli.NewClient)
+	cmdUnbindGateway := NewCmdUnbindGateway(skupperCli.NewClient)
+	cmdForwardGateway := NewCmdForwardGateway(skupperCli.NewClient)
+	cmdUnforwardGateway := NewCmdUnforwardGateway(skupperCli.NewClient)
+
+	// backwards compatibility commands hidden
+	deprecatedMessage := "please use 'skupper service [bind|unbind]' instead"
+	cmdBind.Hidden = true
+	cmdBind.Deprecated = deprecatedMessage
+	cmdUnbind.Deprecated = deprecatedMessage
+	cmdUnbind.Hidden = true
+
+	cmdListConnectors := NewCmdListConnectors(skupperCli.NewClient) // listconnectors just keeped
+	cmdListConnectors.Hidden = true
+	cmdListConnectors.Deprecated = "please use 'skupper link status'"
+
+	linkDeprecationMessage := "please use 'skupper link [create|delete|status]' instead."
+
+	cmdConnect := NewCmdConnect(skupperCli.NewClient)
+	cmdConnect.Hidden = true
+	cmdConnect.Deprecated = linkDeprecationMessage
+
+	cmdDisconnect := NewCmdDisconnect(skupperCli.NewClient)
+	cmdDisconnect.Hidden = true
+	cmdDisconnect.Deprecated = linkDeprecationMessage
+
+	cmdCheckConnection := NewCmdCheckConnection(skupperCli.NewClient)
+	cmdCheckConnection.Hidden = true
+	cmdCheckConnection.Deprecated = linkDeprecationMessage
+
+	cmdConnectionToken := NewCmdConnectionToken(skupperCli.NewClient)
+	cmdConnectionToken.Hidden = true
+	cmdConnectionToken.Deprecated = "please use 'skupper token create' instead."
+
+	cmdListExposed.Hidden = true
+	cmdListExposed.Deprecated = "please use 'skupper service status' instead."
+
+	cmdDownloadGateway.Hidden = true
+	cmdDownloadGateway.Deprecated = "please use 'skupper gateway export-config' instead."
 
 	// setup subcommands
 	cmdService := NewCmdService()
 	cmdService.AddCommand(cmdCreateService)
 	cmdService.AddCommand(cmdDeleteService)
-	cmdService.AddCommand(NewCmdBind(newClient))
-	cmdService.AddCommand(NewCmdUnbind(newClient))
+	cmdService.AddCommand(NewCmdBind(skupperCli.NewClient))
+	cmdService.AddCommand(NewCmdUnbind(skupperCli.NewClient))
 	cmdService.AddCommand(cmdStatusService)
 	cmdService.AddCommand(cmdLabelsService)
 
@@ -1681,24 +1607,25 @@ func init() {
 	cmdDebug.AddCommand(cmdDebugService)
 
 	cmdLink := NewCmdLink()
-	cmdLink.AddCommand(NewCmdLinkCreate(newClient, ""))
-	cmdLink.AddCommand(NewCmdLinkDelete(newClient))
-	cmdLink.AddCommand(NewCmdLinkStatus(newClient))
+	cmdLink.AddCommand(NewCmdLinkCreate(skupperCli.NewClient, ""))
+	cmdLink.AddCommand(NewCmdLinkDelete(skupperCli.NewClient))
+	cmdLink.AddCommand(NewCmdLinkStatus(skupperCli.NewClient))
 
 	cmdToken := NewCmdToken()
-	cmdToken.AddCommand(NewCmdTokenCreate(newClient, ""))
+	cmdToken.AddCommand(NewCmdTokenCreate(skupperCli.NewClient, ""))
 
 	cmdCompletion := NewCmdCompletion()
 
-	cmdRevokeAll := NewCmdRevokeaccess(newClient)
+	cmdRevokeAll := NewCmdRevokeaccess(skupperCli.NewClient)
 
 	cmdNetwork := NewCmdNetwork()
-	cmdNetwork.AddCommand(NewCmdNetworkStatus(newClient))
+	cmdNetwork.AddCommand(NewCmdNetworkStatus(skupperCli.NewClient))
 
 	cmdSwitch := NewCmdSwitch()
 
 	rootCmd = &cobra.Command{Use: "skupper"}
-	rootCmd.AddCommand(cmdInit,
+	addCommands(skupperCli, rootCmd,
+		cmdInit,
 		cmdDelete,
 		cmdUpdate,
 		cmdToken,
@@ -1715,9 +1642,7 @@ func init() {
 		cmdNetwork,
 		cmdSwitch)
 
-	rootCmd.PersistentFlags().StringVarP(&kubeConfigPath, "kubeconfig", "", "", "Path to the kubeconfig file to use")
-	rootCmd.PersistentFlags().StringVarP(&kubeContext, "context", "c", "", "The kubeconfig context to use")
-	rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "The Kubernetes namespace to use")
+	skupperCli.Options(rootCmd)
 	rootCmd.PersistentFlags().StringVarP(&config.Platform, "platform", "", "", "The platform type to use")
 }
 

--- a/cmd/skupper/skupper_cluster_test.go
+++ b/cmd/skupper/skupper_cluster_test.go
@@ -89,7 +89,6 @@ func (s *SkupperTestClient) NewClient(cmd *cobra.Command, args []string) {
 	} else {
 		s.Cli = newMockClient(s.Namespace)
 	}
-	cli = s.Cli
 }
 
 func skupperInit(t *testing.T, args ...string) {
@@ -270,6 +269,7 @@ func TestInitInteriorWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(testClient.Namespace, c.KubeClient)
@@ -314,6 +314,7 @@ func TestDeleteWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(testClient.Namespace, c.KubeClient)
@@ -368,6 +369,7 @@ func TestConnectionTokenWithEdgeCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -423,6 +425,7 @@ func TestConnectionTokenWithInteriorCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -470,6 +473,7 @@ func TestConnectWithEdgeCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -516,6 +520,7 @@ func TestConnectWithInteriorCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -571,6 +576,7 @@ func TestDisconnectWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -641,6 +647,7 @@ func TestListConnectorsWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -719,6 +726,7 @@ func TestCheckConnectionWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -771,6 +779,7 @@ func TestStatusWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -937,6 +946,7 @@ func TestExposeWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1055,6 +1065,7 @@ func TestUnexposeWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1102,6 +1113,7 @@ func TestListExposedWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1184,6 +1196,7 @@ func TestCreateServiceWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1237,6 +1250,7 @@ func TestDeleteServiceWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1312,7 +1326,7 @@ func TestBindWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
-
+	cli := testClient.Cli
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
 		assert.Check(t, err)
@@ -1378,6 +1392,7 @@ func TestUnbindWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1438,6 +1453,7 @@ func TestVersionWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1491,6 +1507,7 @@ func TestDebugDumpWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1548,6 +1565,7 @@ func TestNetworkStatusWithCluster(t *testing.T) {
 		},
 	}
 	testClient.NewClient(nil, nil)
+	cli := testClient.Cli
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)

--- a/cmd/skupper/skupper_cluster_test.go
+++ b/cmd/skupper/skupper_cluster_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/skupperproject/skupper/pkg/utils"
 )
 
+var testClient *SkupperTestClient
+
 type testCase struct {
 	doc             string
 	args            []string
@@ -72,15 +74,26 @@ func newMockClient(namespace string) *client.VanClient {
 	}
 }
 
-func testClient(cmd *cobra.Command, args []string) {
+type SkupperTestClient struct {
+	*SkupperKube
+}
+
+func NewSkupperTestClient() *SkupperTestClient {
+	cli := &SkupperTestClient{&SkupperKube{}}
+	return cli
+}
+
+func (s *SkupperTestClient) NewClient(cmd *cobra.Command, args []string) {
 	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
+		s.Cli = NewClient(s.Namespace, s.KubeContext, s.KubeConfigPath)
 	} else {
-		cli = newMockClient(namespace)
+		s.Cli = newMockClient(s.Namespace)
 	}
+	cli = s.Cli
 }
 
 func skupperInit(t *testing.T, args ...string) {
+
 	initCmd := NewCmdInit(testClient)
 	silenceCobra(initCmd)
 
@@ -251,20 +264,17 @@ func TestInitInteriorWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "init-interior-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: "init-interior-cluster-test-" + strings.ToLower(utils.RandomId(4)),
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
-		_, err := kube.NewNamespace(namespace, c.KubeClient)
+		_, err := kube.NewNamespace(testClient.Namespace, c.KubeClient)
 		assert.Check(t, err)
-		defer kube.DeleteNamespace(namespace, c.KubeClient)
+		defer kube.DeleteNamespace(testClient.Namespace, c.KubeClient)
 	}
 
 	for _, tc := range testcases {
@@ -298,20 +308,17 @@ func TestDeleteWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-delete-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: "cmd-delete-cluster-test-" + strings.ToLower(utils.RandomId(4)),
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
-		_, err := kube.NewNamespace(namespace, c.KubeClient)
+		_, err := kube.NewNamespace(testClient.Namespace, c.KubeClient)
 		assert.Check(t, err)
-		defer kube.DeleteNamespace(namespace, c.KubeClient)
+		defer kube.DeleteNamespace(testClient.Namespace, c.KubeClient)
 	}
 	skupperInit(t, []string{"--router-mode=edge", "--console-ingress=none"}...)
 
@@ -354,15 +361,13 @@ func TestConnectionTokenWithEdgeCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-connection-token-edge-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-connection-token-edge-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -411,15 +416,13 @@ func TestConnectionTokenWithInteriorCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-connection-token-interior-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-connection-token-interior-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -460,15 +463,13 @@ func TestConnectWithEdgeCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-connect-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-connect-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -508,15 +509,13 @@ func TestConnectWithInteriorCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-connect-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-connect-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -565,15 +564,13 @@ func TestDisconnectWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-disconnect-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-disconnect-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -637,15 +634,13 @@ func TestListConnectorsWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-list-connectors-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-list-connectors-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -717,15 +712,13 @@ func TestCheckConnectionWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-check-connection-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-check-connection-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -771,15 +764,13 @@ func TestStatusWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-status-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-status-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -939,15 +930,13 @@ func TestExposeWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-expose-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-expose-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1059,15 +1048,13 @@ func TestUnexposeWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-unexpose-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-unexpose-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1108,15 +1095,13 @@ func TestListExposedWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-list-exposed-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-list-exposed-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1192,15 +1177,13 @@ func TestCreateServiceWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-create-service-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-create-service-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1247,15 +1230,13 @@ func TestDeleteServiceWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-delete-service-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-delete-service-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1324,15 +1305,13 @@ func TestBindWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-bind-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-bind-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1356,9 +1335,11 @@ func TestBindWithCluster(t *testing.T) {
 		if tc.realCluster && !*clusterRun {
 			continue
 		}
-		cmd := NewCmdBind(testClient)
-		silenceCobra(cmd)
-		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
+		t.Run(tc.doc, func(t *testing.T) {
+			cmd := NewCmdBind(testClient)
+			silenceCobra(cmd)
+			testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
+		})
 	}
 }
 
@@ -1390,15 +1371,13 @@ func TestUnbindWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-unbind-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-unbind-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1452,15 +1431,13 @@ func TestVersionWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-version-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-version-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1507,15 +1484,13 @@ func TestDebugDumpWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-debug-dump-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
-
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	namespace := "cmd-debug-dump-cluster-test-" + strings.ToLower(utils.RandomId(4))
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
 	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
@@ -1559,9 +1534,7 @@ func TestNetworkStatusWithCluster(t *testing.T) {
 		},
 	}
 
-	namespace = "cmd-debug-network-status-cluster-test-" + strings.ToLower(utils.RandomId(4))
-	kubeContext = ""
-	kubeConfigPath = ""
+	namespace := "cmd-debug-network-status-cluster-test-" + strings.ToLower(utils.RandomId(4))
 
 	if !*clusterRun {
 		lightRed := "\033[1;31m"
@@ -1569,7 +1542,12 @@ func TestNetworkStatusWithCluster(t *testing.T) {
 		t.Skip(fmt.Sprintf("%sSkipping: This test only works in real clusters.%s", string(lightRed), string(resetColor)))
 	}
 
-	cli = NewClient(namespace, kubeContext, kubeConfigPath)
+	testClient = &SkupperTestClient{
+		&SkupperKube{
+			Namespace: namespace,
+		},
+	}
+	testClient.NewClient(nil, nil)
 
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)

--- a/cmd/skupper/skupper_cluster_test.go
+++ b/cmd/skupper/skupper_cluster_test.go
@@ -386,7 +386,7 @@ func TestConnectionTokenWithEdgeCluster(t *testing.T) {
 			continue
 		}
 
-		cmd := NewCmdConnectionToken(testClient.Token())
+		cmd := NewCmdTokenCreate(testClient.Token(), "")
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -442,7 +442,7 @@ func TestConnectionTokenWithInteriorCluster(t *testing.T) {
 			continue
 		}
 
-		cmd := NewCmdConnectionToken(testClient.Token())
+		cmd := NewCmdTokenCreate(testClient.Token(), "")
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -454,7 +454,7 @@ func TestConnectWithEdgeCluster(t *testing.T) {
 			doc:             "connect-test1",
 			args:            []string{"--help"},
 			expectedCapture: "",
-			expectedOutput:  "Links this skupper site to the site that issued the token",
+			expectedOutput:  "Links this skupper installation to that which issued the specified token",
 			expectedError:   "",
 			realCluster:     false,
 		},
@@ -489,7 +489,7 @@ func TestConnectWithEdgeCluster(t *testing.T) {
 			continue
 		}
 
-		cmd := NewCmdConnect(testClient.Link())
+		cmd := NewCmdLinkCreate(testClient.Link(), "link")
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -501,7 +501,7 @@ func TestConnectWithInteriorCluster(t *testing.T) {
 			doc:             "connect-test1",
 			args:            []string{"--help"},
 			expectedCapture: "",
-			expectedOutput:  "Links this skupper site to the site that issued the token",
+			expectedOutput:  "Links this skupper installation to that which issued the specified token",
 			expectedError:   "",
 			realCluster:     false,
 		},
@@ -536,7 +536,7 @@ func TestConnectWithInteriorCluster(t *testing.T) {
 			continue
 		}
 
-		cmd := NewCmdConnect(testClient.Link())
+		cmd := NewCmdLinkCreate(testClient.Link(), "link")
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -605,7 +605,7 @@ func TestDisconnectWithCluster(t *testing.T) {
 				assert.Check(t, err)
 			}
 		}
-		cmd := NewCmdDisconnect(testClient.Link())
+		cmd := NewCmdLinkDelete(testClient.Link())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -665,12 +665,12 @@ func TestListConnectorsWithCluster(t *testing.T) {
 
 		// create a connection to list
 		if tc.createConn {
-			connectCmd := NewCmdConnect(testClient.Link())
+			connectCmd := NewCmdLinkCreate(testClient.Link(), "")
 			silenceCobra(connectCmd)
 			testCommand(t, connectCmd, tc.doc, "", "Site configured to link to", "", "", []string{"/tmp/foo.yaml"}...)
 		}
 
-		cmd := NewCmdListConnectors(testClient.Link())
+		cmd := NewCmdLinkStatus(testClient.Link())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -743,12 +743,12 @@ func TestCheckConnectionWithCluster(t *testing.T) {
 		}
 
 		if tc.createConn {
-			cmd := NewCmdConnect(testClient.Link())
+			cmd := NewCmdLinkCreate(testClient.Link(), "link")
 			silenceCobra(cmd)
 			testCommand(t, cmd, tc.doc, "", "Site configured to link to", "", "", []string{"/tmp/foo.yaml"}...)
 		}
 
-		cmd := NewCmdCheckConnection(testClient.Link())
+		cmd := NewCmdLinkStatus(testClient.Link())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -1140,7 +1140,7 @@ func TestListExposedWithCluster(t *testing.T) {
 		if tc.realCluster && !*clusterRun {
 			continue
 		}
-		cmd := NewCmdListExposed(testClient.Service())
+		cmd := NewCmdServiceStatus(testClient.Service())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}

--- a/cmd/skupper/skupper_cluster_test.go
+++ b/cmd/skupper/skupper_cluster_test.go
@@ -454,7 +454,7 @@ func TestConnectWithEdgeCluster(t *testing.T) {
 			doc:             "connect-test1",
 			args:            []string{"--help"},
 			expectedCapture: "",
-			expectedOutput:  "Links this skupper installation to that which issued the specified token",
+			expectedOutput:  "Links this skupper site to the site that issued the token",
 			expectedError:   "",
 			realCluster:     false,
 		},

--- a/cmd/skupper/skupper_cluster_test.go
+++ b/cmd/skupper/skupper_cluster_test.go
@@ -501,7 +501,7 @@ func TestConnectWithInteriorCluster(t *testing.T) {
 			doc:             "connect-test1",
 			args:            []string{"--help"},
 			expectedCapture: "",
-			expectedOutput:  "Links this skupper installation to that which issued the specified token",
+			expectedOutput:  "Links this skupper site to the site that issued the token",
 			expectedError:   "",
 			realCluster:     false,
 		},

--- a/cmd/skupper/skupper_cluster_test.go
+++ b/cmd/skupper/skupper_cluster_test.go
@@ -79,7 +79,7 @@ type SkupperTestClient struct {
 }
 
 func NewSkupperTestClient() *SkupperTestClient {
-	cli := &SkupperTestClient{&SkupperKube{}}
+	cli := &SkupperTestClient{SkupperKube: &SkupperKube{}}
 	return cli
 }
 
@@ -89,11 +89,12 @@ func (s *SkupperTestClient) NewClient(cmd *cobra.Command, args []string) {
 	} else {
 		s.Cli = newMockClient(s.Namespace)
 	}
+	s.common = s
 }
 
 func skupperInit(t *testing.T, args ...string) {
 
-	initCmd := NewCmdInit(testClient)
+	initCmd := NewCmdInit(testClient.Site())
 	silenceCobra(initCmd)
 
 	rescueStdout := os.Stdout
@@ -108,7 +109,7 @@ func skupperInit(t *testing.T, args ...string) {
 }
 
 func skupperExpose(t *testing.T, args ...string) {
-	exposeCmd := NewCmdExpose(testClient)
+	exposeCmd := NewCmdExpose(testClient.Service())
 	silenceCobra(exposeCmd)
 
 	rescueStdout := os.Stdout
@@ -264,7 +265,7 @@ func TestInitInteriorWithCluster(t *testing.T) {
 	}
 
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: "init-interior-cluster-test-" + strings.ToLower(utils.RandomId(4)),
 		},
 	}
@@ -282,7 +283,7 @@ func TestInitInteriorWithCluster(t *testing.T) {
 			continue
 		}
 
-		cmd := NewCmdInit(testClient)
+		cmd := NewCmdInit(testClient.Site())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -309,10 +310,11 @@ func TestDeleteWithCluster(t *testing.T) {
 	}
 
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: "cmd-delete-cluster-test-" + strings.ToLower(utils.RandomId(4)),
 		},
 	}
+	testClient.common = testClient
 	testClient.NewClient(nil, nil)
 	cli := testClient.Cli
 
@@ -328,7 +330,7 @@ func TestDeleteWithCluster(t *testing.T) {
 			continue
 		}
 
-		cmd := NewCmdDelete(testClient)
+		cmd := NewCmdDelete(testClient.Site())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -364,7 +366,7 @@ func TestConnectionTokenWithEdgeCluster(t *testing.T) {
 
 	namespace := "cmd-connection-token-edge-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -384,7 +386,7 @@ func TestConnectionTokenWithEdgeCluster(t *testing.T) {
 			continue
 		}
 
-		cmd := NewCmdTokenCreate(testClient, "")
+		cmd := NewCmdConnectionToken(testClient.Token())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -420,7 +422,7 @@ func TestConnectionTokenWithInteriorCluster(t *testing.T) {
 
 	namespace := "cmd-connection-token-interior-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -440,7 +442,7 @@ func TestConnectionTokenWithInteriorCluster(t *testing.T) {
 			continue
 		}
 
-		cmd := NewCmdTokenCreate(testClient, "")
+		cmd := NewCmdConnectionToken(testClient.Token())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -468,7 +470,7 @@ func TestConnectWithEdgeCluster(t *testing.T) {
 
 	namespace := "cmd-connect-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -487,7 +489,7 @@ func TestConnectWithEdgeCluster(t *testing.T) {
 			continue
 		}
 
-		cmd := NewCmdLinkCreate(testClient, "link")
+		cmd := NewCmdConnect(testClient.Link())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -515,7 +517,7 @@ func TestConnectWithInteriorCluster(t *testing.T) {
 
 	namespace := "cmd-connect-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -534,7 +536,7 @@ func TestConnectWithInteriorCluster(t *testing.T) {
 			continue
 		}
 
-		cmd := NewCmdLinkCreate(testClient, "link")
+		cmd := NewCmdConnect(testClient.Link())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -571,7 +573,7 @@ func TestDisconnectWithCluster(t *testing.T) {
 
 	namespace := "cmd-disconnect-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -603,7 +605,7 @@ func TestDisconnectWithCluster(t *testing.T) {
 				assert.Check(t, err)
 			}
 		}
-		cmd := NewCmdLinkDelete(testClient)
+		cmd := NewCmdDisconnect(testClient.Link())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -642,7 +644,7 @@ func TestListConnectorsWithCluster(t *testing.T) {
 
 	namespace := "cmd-list-connectors-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -663,12 +665,12 @@ func TestListConnectorsWithCluster(t *testing.T) {
 
 		// create a connection to list
 		if tc.createConn {
-			connectCmd := NewCmdLinkCreate(testClient, "")
+			connectCmd := NewCmdConnect(testClient.Link())
 			silenceCobra(connectCmd)
 			testCommand(t, connectCmd, tc.doc, "", "Site configured to link to", "", "", []string{"/tmp/foo.yaml"}...)
 		}
 
-		cmd := NewCmdLinkStatus(testClient)
+		cmd := NewCmdListConnectors(testClient.Link())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -721,7 +723,7 @@ func TestCheckConnectionWithCluster(t *testing.T) {
 
 	namespace := "cmd-check-connection-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -741,12 +743,12 @@ func TestCheckConnectionWithCluster(t *testing.T) {
 		}
 
 		if tc.createConn {
-			cmd := NewCmdLinkCreate(testClient, "link")
+			cmd := NewCmdConnect(testClient.Link())
 			silenceCobra(cmd)
 			testCommand(t, cmd, tc.doc, "", "Site configured to link to", "", "", []string{"/tmp/foo.yaml"}...)
 		}
 
-		cmd := NewCmdLinkStatus(testClient)
+		cmd := NewCmdCheckConnection(testClient.Link())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -774,7 +776,7 @@ func TestStatusWithCluster(t *testing.T) {
 
 	namespace := "cmd-status-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -793,7 +795,7 @@ func TestStatusWithCluster(t *testing.T) {
 			continue
 		}
 
-		cmd := NewCmdStatus(testClient)
+		cmd := NewCmdStatus(testClient.Site())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -941,7 +943,7 @@ func TestExposeWithCluster(t *testing.T) {
 
 	namespace := "cmd-expose-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -975,7 +977,7 @@ func TestExposeWithCluster(t *testing.T) {
 				c := cli.(*client.VanClient)
 				_, _ = kube.WaitServiceExists(tc.args[1], cli.GetNamespace(), c.KubeClient, time.Second*60, time.Second*5)
 			}
-			cmd := NewCmdExpose(testClient)
+			cmd := NewCmdExpose(testClient.Service())
 			silenceCobra(cmd)
 			testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 		})
@@ -1060,7 +1062,7 @@ func TestUnexposeWithCluster(t *testing.T) {
 
 	namespace := "cmd-unexpose-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -1079,7 +1081,7 @@ func TestUnexposeWithCluster(t *testing.T) {
 			continue
 		}
 
-		cmd := NewCmdUnexpose(testClient)
+		cmd := NewCmdUnexpose(testClient.Service())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -1108,7 +1110,7 @@ func TestListExposedWithCluster(t *testing.T) {
 
 	namespace := "cmd-list-exposed-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -1129,7 +1131,7 @@ func TestListExposedWithCluster(t *testing.T) {
 	skupperInit(t, []string{"--router-mode=edge", "--console-ingress=none"}...)
 
 	if *clusterRun {
-		exposeCmd := NewCmdExpose(testClient)
+		exposeCmd := NewCmdExpose(testClient.Service())
 		silenceCobra(exposeCmd)
 		testCommand(t, exposeCmd, "cmd-list-exposed-cluster-test", "", "deployment tcp-go-echo exposed as tcp-go-echo", "", "", []string{"deployment", "tcp-go-echo", "--port", "9090"}...)
 	}
@@ -1138,7 +1140,7 @@ func TestListExposedWithCluster(t *testing.T) {
 		if tc.realCluster && !*clusterRun {
 			continue
 		}
-		cmd := NewCmdServiceStatus(testClient)
+		cmd := NewCmdListExposed(testClient.Service())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -1191,7 +1193,7 @@ func TestCreateServiceWithCluster(t *testing.T) {
 
 	namespace := "cmd-create-service-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -1209,7 +1211,7 @@ func TestCreateServiceWithCluster(t *testing.T) {
 		if tc.realCluster && !*clusterRun {
 			continue
 		}
-		cmd := NewCmdCreateService(testClient)
+		cmd := NewCmdCreateService(testClient.Service())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -1245,7 +1247,7 @@ func TestDeleteServiceWithCluster(t *testing.T) {
 
 	namespace := "cmd-delete-service-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -1260,7 +1262,7 @@ func TestDeleteServiceWithCluster(t *testing.T) {
 	skupperInit(t, []string{"--router-mode=edge", "--console-ingress=none"}...)
 
 	if *clusterRun {
-		createCmd := NewCmdCreateService(testClient)
+		createCmd := NewCmdCreateService(testClient.Service())
 		silenceCobra(createCmd)
 		testCommand(t, createCmd, "", "", "", "", "", []string{"tcp-go-echo-b:9090"}...)
 	}
@@ -1269,7 +1271,7 @@ func TestDeleteServiceWithCluster(t *testing.T) {
 		if tc.realCluster && !*clusterRun {
 			continue
 		}
-		cmd := NewCmdDeleteService(testClient)
+		cmd := NewCmdDeleteService(testClient.Service())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -1321,7 +1323,7 @@ func TestBindWithCluster(t *testing.T) {
 
 	namespace := "cmd-bind-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -1340,7 +1342,7 @@ func TestBindWithCluster(t *testing.T) {
 	skupperInit(t, []string{"--router-mode=edge", "--console-ingress=none"}...)
 
 	if *clusterRun {
-		createCmd := NewCmdCreateService(testClient)
+		createCmd := NewCmdCreateService(testClient.Service())
 		silenceCobra(createCmd)
 		testCommand(t, createCmd, "", "", "", "", "", []string{"tcp-go-echo:9090"}...)
 	}
@@ -1350,7 +1352,7 @@ func TestBindWithCluster(t *testing.T) {
 			continue
 		}
 		t.Run(tc.doc, func(t *testing.T) {
-			cmd := NewCmdBind(testClient)
+			cmd := NewCmdBind(testClient.Service())
 			silenceCobra(cmd)
 			testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 		})
@@ -1387,7 +1389,7 @@ func TestUnbindWithCluster(t *testing.T) {
 
 	namespace := "cmd-unbind-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -1407,11 +1409,11 @@ func TestUnbindWithCluster(t *testing.T) {
 	skupperInit(t, []string{"--router-mode=edge", "--console-ingress=none"}...)
 
 	if *clusterRun {
-		createCmd := NewCmdCreateService(testClient)
+		createCmd := NewCmdCreateService(testClient.Service())
 		silenceCobra(createCmd)
 		testCommand(t, createCmd, "", "", "", "", "", []string{"tcp-go-echo:9090"}...)
 
-		bindCmd := NewCmdBind(testClient)
+		bindCmd := NewCmdBind(testClient.Service())
 		silenceCobra(bindCmd)
 		testCommand(t, bindCmd, "", "", "", "", "", []string{"tcp-go-echo", "deployment", "tcp-go-echo"}...)
 	}
@@ -1420,7 +1422,7 @@ func TestUnbindWithCluster(t *testing.T) {
 		if tc.realCluster && !*clusterRun {
 			continue
 		}
-		cmd := NewCmdUnbind(testClient)
+		cmd := NewCmdUnbind(testClient.Service())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -1448,7 +1450,7 @@ func TestVersionWithCluster(t *testing.T) {
 
 	namespace := "cmd-version-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -1466,7 +1468,7 @@ func TestVersionWithCluster(t *testing.T) {
 		if tc.realCluster && !*clusterRun {
 			continue
 		}
-		cmd := NewCmdVersion(testClient)
+		cmd := NewCmdVersion(testClient.Site())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -1502,7 +1504,7 @@ func TestDebugDumpWithCluster(t *testing.T) {
 
 	namespace := "cmd-debug-dump-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -1524,7 +1526,7 @@ func TestDebugDumpWithCluster(t *testing.T) {
 		if tc.realCluster && !*clusterRun {
 			continue
 		}
-		cmd := NewCmdDebugDump(testClient)
+		cmd := NewCmdDebugDump(testClient.Debug())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}
@@ -1560,7 +1562,7 @@ func TestNetworkStatusWithCluster(t *testing.T) {
 	}
 
 	testClient = &SkupperTestClient{
-		&SkupperKube{
+		SkupperKube: &SkupperKube{
 			Namespace: namespace,
 		},
 	}
@@ -1586,7 +1588,7 @@ func TestNetworkStatusWithCluster(t *testing.T) {
 		if tc.realCluster && !*clusterRun {
 			continue
 		}
-		cmd := NewCmdNetworkStatus(testClient)
+		cmd := NewCmdNetworkStatus(testClient.Network())
 		silenceCobra(cmd)
 		testCommand(t, cmd, tc.doc, tc.expectedError, tc.expectedCapture, tc.expectedOutput, tc.outputRegExp, tc.args...)
 	}

--- a/cmd/skupper/skupper_kube.go
+++ b/cmd/skupper/skupper_kube.go
@@ -87,8 +87,6 @@ type kubeInit struct {
 	ingressAnnotations           []string
 	routerServiceAnnotations     []string
 	controllerServiceAnnotations []string
-	clusterLocal                 bool
-	isEdge                       bool
 }
 
 func (s *SkupperKube) NewClient(cmd *cobra.Command, args []string) {

--- a/cmd/skupper/skupper_kube.go
+++ b/cmd/skupper/skupper_kube.go
@@ -1,18 +1,8 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"reflect"
-	"strings"
-	"time"
-
 	"github.com/skupperproject/skupper/api/types"
-	"github.com/skupperproject/skupper/client"
-	"github.com/skupperproject/skupper/pkg/utils"
-	"github.com/skupperproject/skupper/pkg/utils/formatter"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 var SkupperKubeCommands = []string{
@@ -27,311 +17,55 @@ type SkupperKube struct {
 	KubeContext    string
 	Namespace      string
 	KubeConfigPath string
-	kubeInit       kubeInit
+	site           *SkupperKubeSite
+	service        *SkupperKubeService
+	debug          *SkupperKubeDebug
+	link           *SkupperKubeLink
+	token          *SkupperKubeToken
+	network        *SkupperKubeNetwork
+	common         SkupperClientCommon
 }
 
-func (s *SkupperKube) TokenCreate(cmd *cobra.Command, args []string) error {
-	silenceCobra(cmd)
-	cli := s.Cli
-	switch tokenType {
-	case "cert":
-		err := cli.ConnectorTokenCreateFile(context.Background(), clientIdentity, args[0])
-		if err != nil {
-			return fmt.Errorf("Failed to create token: %w", err)
-		}
-		return nil
-	case "claim":
-		name := clientIdentity
-		if name == "skupper" {
-			name = ""
-		}
-		if password == "" {
-			password = utils.RandomId(24)
-		}
-		err := cli.TokenClaimCreateFile(context.Background(), name, []byte(password), expiry, uses, args[0])
-		if err != nil {
-			return fmt.Errorf("Failed to create token: %w", err)
-		}
-		return nil
-	default:
-		return fmt.Errorf("invalid token type. Specify cert or claim")
+func (s *SkupperKube) Site() SkupperSiteClient {
+	if s.site == nil {
+		s.site = &SkupperKubeSite{kube: s}
 	}
+	return s.site
 }
 
-func (s *SkupperKube) RevokeAccess(cmd *cobra.Command, args []string) error {
-	silenceCobra(cmd)
-	err := s.Cli.RevokeAccess(context.Background())
-	if err != nil {
-		return fmt.Errorf("Unable to revoke access: %w", err)
+func (s *SkupperKube) Service() SkupperServiceClient {
+	if s.service == nil {
+		s.service = &SkupperKubeService{kube: s}
 	}
-	return nil
+	return s.service
 }
 
-func (s *SkupperKube) NetworkStatus(cmd *cobra.Command, args []string) error {
-	silenceCobra(cmd)
-
-	var sites []*types.SiteInfo
-	var errStatus error
-	err := utils.RetryError(time.Second, 3, func() error {
-		sites, errStatus = s.Cli.NetworkStatus()
-
-		if errStatus != nil {
-			return errStatus
-		}
-
-		return nil
-	})
-
-	loadOnlyLocalInformation := false
-
-	if err != nil {
-		fmt.Printf("Unable to retrieve network information: %s", err)
-		fmt.Println()
-		fmt.Println()
-		fmt.Println("Loading just local information:")
-		loadOnlyLocalInformation = true
+func (s *SkupperKube) Debug() SkupperDebugClient {
+	if s.debug == nil {
+		s.debug = &SkupperKubeDebug{kube: s}
 	}
-
-	vir, err := s.Cli.RouterInspect(context.Background())
-	if err != nil || vir == nil {
-		fmt.Printf("The router configuration is not available: %s", err)
-		fmt.Println()
-		return nil
-	}
-
-	siteConfig, err := s.Cli.SiteConfigInspect(nil, nil)
-	if err != nil || siteConfig == nil {
-		fmt.Printf("The site configuration is not available: %s", err)
-		fmt.Println()
-		return nil
-	}
-
-	currentSite := siteConfig.Reference.UID
-
-	if loadOnlyLocalInformation {
-		printLocalStatus(vir.Status.TransportReadyReplicas, vir.Status.ConnectedSites.Warnings, vir.Status.ConnectedSites.Total, vir.Status.ConnectedSites.Direct, vir.ExposedServices)
-
-		serviceInterfaces, err := s.Cli.ServiceInterfaceList(context.Background())
-		if err != nil {
-			fmt.Printf("Service local configuration is not available: %s", err)
-			fmt.Println()
-			return nil
-		}
-
-		sites = getLocalSiteInfo(serviceInterfaces, currentSite, vir.Status.SiteName, s.Cli.GetNamespace(), vir.TransportVersion)
-	}
-
-	if sites != nil && len(sites) > 0 {
-		siteList := formatter.NewList()
-		siteList.Item("Sites:")
-		for _, site := range sites {
-
-			if site.Name != selectedSite && selectedSite != "all" {
-				continue
-			}
-
-			location := "remote"
-			siteVersion := site.Version
-			detailsMap := map[string]string{"name": site.Name, "namespace": site.Namespace, "URL": site.Url, "version": siteVersion}
-
-			if len(site.MinimumVersion) > 0 {
-				siteVersion = fmt.Sprintf("%s (minimum version required %s)", site.Version, site.MinimumVersion)
-			}
-
-			if site.SiteId == currentSite {
-				location = "local"
-				detailsMap["mode"] = vir.Status.Mode
-			}
-
-			newItem := fmt.Sprintf("[%s] %s - %s ", location, site.SiteId[:7], site.Name)
-
-			newItem = newItem + fmt.Sprintln()
-
-			if len(site.Links) > 0 {
-				detailsMap["sites linked to"] = fmt.Sprint(strings.Join(site.Links, ", "))
-			}
-
-			serviceLevel := siteList.NewChildWithDetail(newItem, detailsMap)
-			if len(site.Services) > 0 {
-				services := serviceLevel.NewChild("Services:")
-				var addresses []string
-				svcAuth := map[string]bool{}
-				for _, svc := range site.Services {
-					addresses = append(addresses, svc.Name)
-					svcAuth[svc.Name] = true
-				}
-				if vc, ok := s.Cli.(*client.VanClient); ok && site.Namespace == s.Cli.GetNamespace() {
-					policy := client.NewPolicyValidatorAPI(vc)
-					res, _ := policy.Services(addresses...)
-					for addr, auth := range res {
-						svcAuth[addr] = auth.Allowed
-					}
-				}
-				for _, svc := range site.Services {
-					authSuffix := ""
-					if !svcAuth[svc.Name] {
-						authSuffix = " - not authorized"
-					}
-					svcItem := "name: " + svc.Name + authSuffix + fmt.Sprintln()
-					detailsSvc := map[string]string{"protocol": svc.Protocol, "address": svc.Address}
-					targetLevel := services.NewChildWithDetail(svcItem, detailsSvc)
-
-					if len(svc.Targets) > 0 {
-						targets := targetLevel.NewChild("Targets:")
-						for _, target := range svc.Targets {
-							targets.NewChild("name: " + target.Name)
-
-						}
-					}
-
-				}
-			}
-		}
-
-		siteList.Print()
-	}
-
-	return nil
+	return s.debug
 }
 
-func (s *SkupperKube) ListConnectors(cmd *cobra.Command, args []string) error {
-	silenceCobra(cmd)
-	cli := s.Cli
-	connectors, err := cli.ConnectorList(context.Background())
-	if err == nil {
-		if len(connectors) == 0 {
-			fmt.Println("There are no connectors defined.")
-		} else {
-			fmt.Println("Connectors:")
-			for _, c := range connectors {
-				fmt.Printf("    %s (name=%s)", c.Url, c.Name)
-				fmt.Println()
-			}
-		}
-	} else if errors.IsNotFound(err) {
-		return SkupperNotInstalledError(cli.GetNamespace())
-	} else {
-		return fmt.Errorf("Unable to retrieve connections: %w", err)
+func (s *SkupperKube) Link() SkupperLinkClient {
+	if s.link == nil {
+		s.link = &SkupperKubeLink{kube: s}
 	}
-	return nil
+	return s.link
 }
 
-func (s *SkupperKube) Version(cmd *cobra.Command, args []string) error {
-	cli := s.Cli
-	if !IsZero(reflect.ValueOf(cli)) {
-		fmt.Printf("%-30s %s\n", "transport version", cli.GetVersion(types.TransportComponentName, types.TransportContainerName))
-		fmt.Printf("%-30s %s\n", "controller version", cli.GetVersion(types.ControllerComponentName, types.ControllerContainerName))
-		fmt.Printf("%-30s %s\n", "config-sync version", cli.GetVersion(types.TransportComponentName, types.ConfigSyncContainerName))
-	} else {
-		fmt.Printf("%-30s %s\n", "transport version", "not-found (no configuration has been provided)")
-		fmt.Printf("%-30s %s\n", "controller version", "not-found (no configuration has been provided)")
+func (s *SkupperKube) Token() SkupperTokenClient {
+	if s.token == nil {
+		s.token = &SkupperKubeToken{kube: s}
 	}
-	return nil
+	return s.token
 }
 
-func (s *SkupperKube) Status(cmd *cobra.Command, args []string) error {
-	silenceCobra(cmd)
-	cli := s.Cli
-	vir, err := cli.RouterInspect(context.Background())
-	if err == nil {
-		ns := cli.GetNamespace()
-		var modedesc string = " in interior mode"
-		if vir.Status.Mode == string(types.TransportModeEdge) {
-			modedesc = " in edge mode"
-		}
-		sitename := ""
-		if vir.Status.SiteName != "" && vir.Status.SiteName != ns {
-			sitename = fmt.Sprintf(" with site name %q", vir.Status.SiteName)
-		}
-		policyStr := ""
-		if vanClient, ok := cli.(*client.VanClient); ok {
-			p := client.NewPolicyValidatorAPI(vanClient)
-			r, err := p.IncomingLink()
-			if err == nil && r.Enabled {
-				policyStr = " (with policies)"
-			}
-		}
-		fmt.Printf("Skupper is enabled for namespace %q%s%s%s.", ns, sitename, modedesc, policyStr)
-		if vir.Status.TransportReadyReplicas == 0 {
-			fmt.Printf(" Status pending...")
-		} else {
-			if len(vir.Status.ConnectedSites.Warnings) > 0 {
-				for _, w := range vir.Status.ConnectedSites.Warnings {
-					fmt.Printf("Warning: %s", w)
-					fmt.Println()
-				}
-			}
-			if vir.Status.ConnectedSites.Total == 0 {
-				fmt.Printf(" It is not connected to any other sites.")
-			} else if vir.Status.ConnectedSites.Total == 1 {
-				fmt.Printf(" It is connected to 1 other site.")
-			} else if vir.Status.ConnectedSites.Total == vir.Status.ConnectedSites.Direct {
-				fmt.Printf(" It is connected to %d other sites.", vir.Status.ConnectedSites.Total)
-			} else {
-				fmt.Printf(" It is connected to %d other sites (%d indirectly).", vir.Status.ConnectedSites.Total, vir.Status.ConnectedSites.Indirect)
-			}
-		}
-		if vir.ExposedServices == 0 {
-			fmt.Printf(" It has no exposed services.")
-		} else if vir.ExposedServices == 1 {
-			fmt.Printf(" It has 1 exposed service.")
-		} else {
-			fmt.Printf(" It has %d exposed services.", vir.ExposedServices)
-		}
-		fmt.Println()
-		if vir.ConsoleUrl != "" {
-			fmt.Println("The site console url is: ", vir.ConsoleUrl)
-			siteConfig, err := cli.SiteConfigInspect(context.Background(), nil)
-			if err != nil {
-				return err
-			}
-			if siteConfig.Spec.AuthMode == "internal" {
-				fmt.Println("The credentials for internal console-auth mode are held in secret: 'skupper-console-users'")
-			}
-		}
-	} else {
-		if vir == nil {
-			fmt.Printf("Skupper is not enabled in namespace '%s'\n", cli.GetNamespace())
-		} else {
-			return fmt.Errorf("Unable to retrieve skupper status: %w", err)
-		}
+func (s *SkupperKube) Network() SkupperNetworkClient {
+	if s.network == nil {
+		s.network = &SkupperKubeNetwork{kube: s}
 	}
-	return nil
-}
-
-func (s *SkupperKube) Update(cmd *cobra.Command, args []string) error {
-	silenceCobra(cmd)
-	cli := s.Cli
-
-	updated, err := cli.RouterUpdateVersion(context.Background(), forceHup)
-	if err != nil {
-		return err
-	}
-	if updated {
-		fmt.Println("Skupper is now updated in '" + cli.GetNamespace() + "'.")
-	} else {
-		fmt.Println("No update required in '" + cli.GetNamespace() + "'.")
-	}
-	return nil
-}
-
-func (s *SkupperKube) Delete(cmd *cobra.Command, args []string) error {
-	silenceCobra(cmd)
-	cli := s.Cli
-	gateways, err := cli.GatewayList(context.Background())
-	for _, gateway := range gateways {
-		cli.GatewayRemove(context.Background(), gateway.Name)
-	}
-	err = cli.SiteConfigRemove(context.Background())
-	if err != nil {
-		err = cli.RouterRemove(context.Background())
-	}
-	if err != nil {
-		return err
-	} else {
-		fmt.Println("Skupper is now removed from '" + cli.GetNamespace() + "'.")
-	}
-	return nil
+	return s.network
 }
 
 func (s *SkupperKube) SupportedCommands() []string {
@@ -358,173 +92,13 @@ type kubeInit struct {
 }
 
 func (s *SkupperKube) NewClient(cmd *cobra.Command, args []string) {
+	if s.common != nil {
+		s.common.NewClient(cmd, args)
+		return
+	}
 	exitOnError := true
 	if cmd.Name() == "version" {
 		exitOnError = false
 	}
 	s.Cli = NewClientHandleError(s.Namespace, s.KubeContext, s.KubeConfigPath, exitOnError)
-}
-
-func (s *SkupperKube) Init(cmd *cobra.Command, args []string) error {
-	cli := s.Cli
-
-	silenceCobra(cmd)
-	ns := cli.GetNamespace()
-
-	routerModeFlag := cmd.Flag("router-mode")
-	edgeFlag := cmd.Flag("edge")
-	if routerModeFlag.Changed && edgeFlag.Changed {
-		return fmt.Errorf("You can not use the deprecated --edge, and --router-mode together, use --router-mode")
-	}
-
-	if routerModeFlag.Changed {
-		options := []string{string(types.TransportModeInterior), string(types.TransportModeEdge)}
-		if !utils.StringSliceContains(options, initFlags.routerMode) {
-			return fmt.Errorf(`invalid "--router-mode=%v", it must be one of "%v"`, initFlags.routerMode, strings.Join(options, ", "))
-		}
-		routerCreateOpts.RouterMode = initFlags.routerMode
-	} else {
-		if s.kubeInit.isEdge {
-			routerCreateOpts.RouterMode = string(types.TransportModeEdge)
-		} else {
-			routerCreateOpts.RouterMode = string(types.TransportModeInterior)
-		}
-	}
-
-	routerIngressFlag := cmd.Flag("ingress")
-	routerClusterLocalFlag := cmd.Flag("cluster-local")
-	routerCreateOpts.Platform = s.Platform()
-
-	if routerIngressFlag.Changed && routerClusterLocalFlag.Changed {
-		return fmt.Errorf(`You can not use the deprecated --cluster-local, and --ingress together, use "--ingress none" as equivalent of --cluster-local`)
-	} else if routerClusterLocalFlag.Changed {
-		if s.kubeInit.clusterLocal { // this is redundant, because "if changed" it must be true, but it is also correct
-			routerCreateOpts.Ingress = types.IngressNoneString
-		}
-	} else if !routerIngressFlag.Changed {
-		routerCreateOpts.Ingress = cli.GetIngressDefault()
-	}
-	if routerCreateOpts.Ingress == types.IngressNodePortString && routerCreateOpts.IngressHost == "" && routerCreateOpts.Router.IngressHost == "" {
-		return fmt.Errorf(`One of --ingress-host or --router-ingress-host option is required when using "--ingress nodeport"`)
-	}
-	if routerCreateOpts.Ingress == types.IngressContourHttpProxyString && routerCreateOpts.IngressHost == "" {
-		return fmt.Errorf(`--ingress-host option is required when using "--ingress contour-http-proxy"`)
-	}
-	routerCreateOpts.Annotations = asMap(s.kubeInit.annotations)
-	routerCreateOpts.Labels = asMap(initFlags.labels)
-	routerCreateOpts.IngressAnnotations = asMap(s.kubeInit.ingressAnnotations)
-	routerCreateOpts.Router.ServiceAnnotations = asMap(s.kubeInit.routerServiceAnnotations)
-	routerCreateOpts.Controller.ServiceAnnotations = asMap(s.kubeInit.controllerServiceAnnotations)
-	if err := routerCreateOpts.CheckIngress(); err != nil {
-		return err
-	}
-	if err := routerCreateOpts.CheckConsoleIngress(); err != nil {
-		return err
-	}
-
-	routerCreateOpts.SkupperNamespace = ns
-	siteConfig, err := cli.SiteConfigInspect(context.Background(), nil)
-	if err != nil {
-		return err
-	}
-	if routerLogging != "" {
-		logConfig, err := client.ParseRouterLogConfig(routerLogging)
-		if err != nil {
-			return fmt.Errorf("Bad value for --router-logging: %s", err)
-		}
-		routerCreateOpts.Router.Logging = logConfig
-	}
-	if routerCreateOpts.Router.DebugMode != "" {
-		if routerCreateOpts.Router.DebugMode != "asan" && routerCreateOpts.Router.DebugMode != "gdb" {
-			return fmt.Errorf("Bad value for --router-debug-mode: %s (use 'asan' or 'gdb')", routerCreateOpts.Router.DebugMode)
-		}
-	}
-
-	if LoadBalancerTimeout.Seconds() <= 0 {
-		return fmt.Errorf(`invalid timeout value`)
-	}
-
-	if siteConfig == nil {
-		siteConfig, err = cli.SiteConfigCreate(context.Background(), routerCreateOpts)
-		if err != nil {
-			return err
-		}
-	} else {
-		updated, err := cli.SiteConfigUpdate(context.Background(), routerCreateOpts)
-		if err != nil {
-			return fmt.Errorf("Error while trying to update router configuration: %s", err)
-		}
-		if len(updated) > 0 {
-			for _, i := range updated {
-				fmt.Println("Updated", i)
-			}
-		}
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), LoadBalancerTimeout)
-	defer cancel()
-
-	err = cli.RouterCreate(ctx, *siteConfig)
-	if err != nil {
-		return err
-	}
-	fmt.Println("Skupper is now installed in namespace '" + ns + "'.  Use 'skupper status' to get more information.")
-
-	return nil
-}
-
-func (s *SkupperKube) InitFlags(cmd *cobra.Command) {
-	s.kubeInit = kubeInit{}
-	s.kubeInit.ingressAnnotations = []string{}
-	s.kubeInit.annotations = []string{}
-	s.kubeInit.routerServiceAnnotations = []string{}
-	s.kubeInit.controllerServiceAnnotations = []string{}
-	cmd.Flags().BoolVarP(&routerCreateOpts.EnableConsole, "enable-console", "", true, "Enable skupper console")
-	cmd.Flags().BoolVarP(&routerCreateOpts.CreateNetworkPolicy, "create-network-policy", "", false, "Create network policy to restrict access to skupper services exposed through this site to current pods in namespace")
-	cmd.Flags().StringVarP(&routerCreateOpts.AuthMode, "console-auth", "", "", "Authentication mode for console(s). One of: 'openshift', 'internal', 'unsecured'")
-	cmd.Flags().StringVarP(&routerCreateOpts.User, "console-user", "", "", "Skupper console user. Valid only when --console-auth=internal")
-	cmd.Flags().StringVarP(&routerCreateOpts.Password, "console-password", "", "", "Skupper console user. Valid only when --console-auth=internal")
-	cmd.Flags().StringVarP(&routerCreateOpts.ConsoleIngress, "console-ingress", "", "", "Determines if/how console is exposed outside cluster. If not specified uses value of --ingress. One of: ["+strings.Join(types.ValidIngressOptions(s.Platform()), "|")+"].")
-	cmd.Flags().StringSliceVar(&s.kubeInit.ingressAnnotations, "ingress-annotations", []string{}, "Annotations to add to skupper ingress")
-	cmd.Flags().StringSliceVar(&s.kubeInit.annotations, "annotations", []string{}, "Annotations to add to skupper pods")
-	cmd.Flags().StringSliceVar(&s.kubeInit.routerServiceAnnotations, "router-service-annotations", []string{}, "Annotations to add to skupper router service")
-	cmd.Flags().StringSliceVar(&s.kubeInit.controllerServiceAnnotations, "controller-service-annotation", []string{}, "Annotations to add to skupper controller service")
-	cmd.Flags().BoolVarP(&routerCreateOpts.EnableServiceSync, "enable-service-sync", "", true, "Participate in cross-site service synchronization")
-
-	cmd.Flags().StringVar(&routerCreateOpts.Router.Cpu, "router-cpu", "", "CPU request for router pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.Memory, "router-memory", "", "Memory request for router pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.CpuLimit, "router-cpu-limit", "", "CPU limit for router pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.MemoryLimit, "router-memory-limit", "", "Memory limit for router pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.NodeSelector, "router-node-selector", "", "Node selector to control placement of router pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.Affinity, "router-pod-affinity", "", "Pod affinity label matches to control placement of router pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.AntiAffinity, "router-pod-antiaffinity", "", "Pod antiaffinity label matches to control placement of router pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.IngressHost, "router-ingress-host", "", "Host through which node is accessible when using nodeport as ingress.")
-	cmd.Flags().StringVar(&routerCreateOpts.Router.LoadBalancerIp, "router-load-balancer-ip", "", "Load balancer ip that will be used for router service, if supported by cloud provider")
-
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.Cpu, "controller-cpu", "", "CPU request for controller pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.Memory, "controller-memory", "", "Memory request for controller pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.CpuLimit, "controller-cpu-limit", "", "CPU limit for controller pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.MemoryLimit, "controller-memory-limit", "", "Memory limit for controller pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.NodeSelector, "controller-node-selector", "", "Node selector to control placement of controller pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.Affinity, "controller-pod-affinity", "", "Pod affinity label matches to control placement of controller pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.AntiAffinity, "controller-pod-antiaffinity", "", "Pod antiaffinity label matches to control placement of controller pods")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.IngressHost, "controller-ingress-host", "", "Host through which node is accessible when using nodeport as ingress.")
-	cmd.Flags().StringVar(&routerCreateOpts.Controller.LoadBalancerIp, "controller-load-balancer-ip", "", "Load balancer ip that will be used for controller service, if supported by cloud provider")
-
-	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.Cpu, "config-sync-cpu", "", "CPU request for config-sync pods")
-	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.Memory, "config-sync-memory", "", "Memory request for config-sync pods")
-	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.CpuLimit, "config-sync-cpu-limit", "", "CPU limit for config-sync pods")
-	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.MemoryLimit, "config-sync-memory-limit", "", "Memory limit for config-sync pods")
-
-	cmd.Flags().DurationVar(&LoadBalancerTimeout, "timeout", types.DefaultTimeoutDuration, "Configurable timeout for the ingress loadbalancer option.")
-
-	cmd.Flags().BoolVarP(&s.kubeInit.clusterLocal, "cluster-local", "", false, "Set up Skupper to only accept links from within the local cluster.")
-	f := cmd.Flag("cluster-local")
-	f.Deprecated = "This flag is deprecated, use --ingress [" + strings.Join(types.ValidIngressOptions(s.Platform()), "|") + "]"
-	f.Hidden = true
-
-	cmd.Flags().BoolVarP(&s.kubeInit.isEdge, "edge", "", false, "Configure as an edge")
-	f = cmd.Flag("edge")
-	f.Deprecated = "This flag is deprecated, use --router-mode [interior|edge]"
-	f.Hidden = true
 }

--- a/cmd/skupper/skupper_kube.go
+++ b/cmd/skupper/skupper_kube.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/client"
+	"github.com/skupperproject/skupper/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var SkupperKubeCommands = []string{
+	"init", "delete", "update", "connection-token", "token", "link", "connect", "disconnect",
+	"check-connection", "status", "list-connectors", "expose", "unexpose", "list-exposed",
+	"service", "bind", "unbind", "version", "debug", "completion", "gateway", "revoke-access",
+	"network", "switch",
+}
+
+type SkupperKube struct {
+	cli            types.VanClientInterface
+	kubeContext    string
+	namespace      string
+	kubeConfigPath string
+	kubeInit       kubeInit
+}
+
+func (s *SkupperKube) SupportedCommands() []string {
+	return SkupperKubeCommands
+}
+
+func (s *SkupperKube) Platform() types.Platform {
+	return types.PlatformKubernetes
+}
+
+func (s *SkupperKube) Options(rootCmd *cobra.Command) {
+	rootCmd.PersistentFlags().StringVarP(&s.kubeConfigPath, "kubeconfig", "", "", "Path to the kubeconfig file to use")
+	rootCmd.PersistentFlags().StringVarP(&s.kubeContext, "context", "c", "", "The kubeconfig context to use")
+	rootCmd.PersistentFlags().StringVarP(&s.namespace, "namespace", "n", "", "The Kubernetes namespace to use")
+}
+
+type kubeInit struct {
+	annotations                  []string
+	ingressAnnotations           []string
+	routerServiceAnnotations     []string
+	controllerServiceAnnotations []string
+	clusterLocal                 bool
+	isEdge                       bool
+}
+
+func (s *SkupperKube) NewClient(cmd *cobra.Command, args []string) {
+	exitOnError := true
+	if cmd.Name() == "version" {
+		exitOnError = false
+	}
+	s.cli = NewClientHandleError(s.namespace, s.kubeContext, s.kubeConfigPath, exitOnError)
+	// TODO remove once all methods converted
+	cli = s.cli
+}
+
+func (s *SkupperKube) Init(cmd *cobra.Command, args []string) error {
+	cli := s.cli
+
+	// TODO: should cli allow init to diff ns?
+	silenceCobra(cmd)
+	ns := cli.GetNamespace()
+
+	routerModeFlag := cmd.Flag("router-mode")
+	edgeFlag := cmd.Flag("edge")
+	if routerModeFlag.Changed && edgeFlag.Changed {
+		return fmt.Errorf("You can not use the deprecated --edge, and --router-mode together, use --router-mode")
+	}
+
+	if routerModeFlag.Changed {
+		options := []string{string(types.TransportModeInterior), string(types.TransportModeEdge)}
+		if !utils.StringSliceContains(options, initFlags.routerMode) {
+			return fmt.Errorf(`invalid "--router-mode=%v", it must be one of "%v"`, initFlags.routerMode, strings.Join(options, ", "))
+		}
+		routerCreateOpts.RouterMode = initFlags.routerMode
+	} else {
+		if s.kubeInit.isEdge {
+			routerCreateOpts.RouterMode = string(types.TransportModeEdge)
+		} else {
+			routerCreateOpts.RouterMode = string(types.TransportModeInterior)
+		}
+	}
+
+	routerIngressFlag := cmd.Flag("ingress")
+	routerClusterLocalFlag := cmd.Flag("cluster-local")
+	routerCreateOpts.Platform = s.Platform()
+
+	if routerIngressFlag.Changed && routerClusterLocalFlag.Changed {
+		return fmt.Errorf(`You can not use the deprecated --cluster-local, and --ingress together, use "--ingress none" as equivalent of --cluster-local`)
+	} else if routerClusterLocalFlag.Changed {
+		if s.kubeInit.clusterLocal { // this is redundant, because "if changed" it must be true, but it is also correct
+			routerCreateOpts.Ingress = types.IngressNoneString
+		}
+	} else if !routerIngressFlag.Changed {
+		routerCreateOpts.Ingress = cli.GetIngressDefault()
+	}
+	if routerCreateOpts.Ingress == types.IngressNodePortString && routerCreateOpts.IngressHost == "" && routerCreateOpts.Router.IngressHost == "" {
+		return fmt.Errorf(`One of --ingress-host or --router-ingress-host option is required when using "--ingress nodeport"`)
+	}
+	if routerCreateOpts.Ingress == types.IngressContourHttpProxyString && routerCreateOpts.IngressHost == "" {
+		return fmt.Errorf(`--ingress-host option is required when using "--ingress contour-http-proxy"`)
+	}
+	routerCreateOpts.Annotations = asMap(s.kubeInit.annotations)
+	routerCreateOpts.Labels = asMap(initFlags.labels)
+	routerCreateOpts.IngressAnnotations = asMap(s.kubeInit.ingressAnnotations)
+	routerCreateOpts.Router.ServiceAnnotations = asMap(s.kubeInit.routerServiceAnnotations)
+	routerCreateOpts.Controller.ServiceAnnotations = asMap(s.kubeInit.controllerServiceAnnotations)
+	if err := routerCreateOpts.CheckIngress(); err != nil {
+		return err
+	}
+	if err := routerCreateOpts.CheckConsoleIngress(); err != nil {
+		return err
+	}
+
+	routerCreateOpts.SkupperNamespace = ns
+	siteConfig, err := cli.SiteConfigInspect(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	if routerLogging != "" {
+		logConfig, err := client.ParseRouterLogConfig(routerLogging)
+		if err != nil {
+			return fmt.Errorf("Bad value for --router-logging: %s", err)
+		}
+		routerCreateOpts.Router.Logging = logConfig
+	}
+	if routerCreateOpts.Router.DebugMode != "" {
+		if routerCreateOpts.Router.DebugMode != "asan" && routerCreateOpts.Router.DebugMode != "gdb" {
+			return fmt.Errorf("Bad value for --router-debug-mode: %s (use 'asan' or 'gdb')", routerCreateOpts.Router.DebugMode)
+		}
+	}
+
+	if LoadBalancerTimeout.Seconds() <= 0 {
+		return fmt.Errorf(`invalid timeout value`)
+	}
+
+	if siteConfig == nil {
+		siteConfig, err = cli.SiteConfigCreate(context.Background(), routerCreateOpts)
+		if err != nil {
+			return err
+		}
+	} else {
+		updated, err := cli.SiteConfigUpdate(context.Background(), routerCreateOpts)
+		if err != nil {
+			return fmt.Errorf("Error while trying to update router configuration: %s", err)
+		}
+		if len(updated) > 0 {
+			for _, i := range updated {
+				fmt.Println("Updated", i)
+			}
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), LoadBalancerTimeout)
+	defer cancel()
+
+	err = cli.RouterCreate(ctx, *siteConfig)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Skupper is now installed in namespace '" + ns + "'.  Use 'skupper status' to get more information.")
+
+	return nil
+}
+
+func (s *SkupperKube) InitFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(&routerCreateOpts.EnableConsole, "enable-console", "", true, "Enable skupper console")
+	cmd.Flags().BoolVarP(&routerCreateOpts.CreateNetworkPolicy, "create-network-policy", "", false, "Create network policy to restrict access to skupper services exposed through this site to current pods in namespace")
+	cmd.Flags().StringVarP(&routerCreateOpts.AuthMode, "console-auth", "", "", "Authentication mode for console(s). One of: 'openshift', 'internal', 'unsecured'")
+	cmd.Flags().StringVarP(&routerCreateOpts.User, "console-user", "", "", "Skupper console user. Valid only when --console-auth=internal")
+	cmd.Flags().StringVarP(&routerCreateOpts.Password, "console-password", "", "", "Skupper console user. Valid only when --console-auth=internal")
+	cmd.Flags().StringVarP(&routerCreateOpts.ConsoleIngress, "console-ingress", "", "", "Determines if/how console is exposed outside cluster. If not specified uses value of --ingress. One of: ["+strings.Join(types.ValidIngressOptions(s.Platform()), "|")+"].")
+	cmd.Flags().StringSliceVar(&s.kubeInit.ingressAnnotations, "ingress-annotations", []string{}, "Annotations to add to skupper ingress")
+	cmd.Flags().StringSliceVar(&s.kubeInit.annotations, "annotations", []string{}, "Annotations to add to skupper pods")
+	cmd.Flags().StringSliceVar(&s.kubeInit.routerServiceAnnotations, "router-service-annotations", []string{}, "Annotations to add to skupper router service")
+	cmd.Flags().StringSliceVar(&s.kubeInit.controllerServiceAnnotations, "controller-service-annotation", []string{}, "Annotations to add to skupper controller service")
+	cmd.Flags().BoolVarP(&routerCreateOpts.EnableServiceSync, "enable-service-sync", "", true, "Participate in cross-site service synchronization")
+
+	cmd.Flags().StringVar(&routerCreateOpts.Router.Cpu, "router-cpu", "", "CPU request for router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.Memory, "router-memory", "", "Memory request for router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.CpuLimit, "router-cpu-limit", "", "CPU limit for router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.MemoryLimit, "router-memory-limit", "", "Memory limit for router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.NodeSelector, "router-node-selector", "", "Node selector to control placement of router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.Affinity, "router-pod-affinity", "", "Pod affinity label matches to control placement of router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.AntiAffinity, "router-pod-antiaffinity", "", "Pod antiaffinity label matches to control placement of router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.IngressHost, "router-ingress-host", "", "Host through which node is accessible when using nodeport as ingress.")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.LoadBalancerIp, "router-load-balancer-ip", "", "Load balancer ip that will be used for router service, if supported by cloud provider")
+
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.Cpu, "controller-cpu", "", "CPU request for controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.Memory, "controller-memory", "", "Memory request for controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.CpuLimit, "controller-cpu-limit", "", "CPU limit for controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.MemoryLimit, "controller-memory-limit", "", "Memory limit for controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.NodeSelector, "controller-node-selector", "", "Node selector to control placement of controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.Affinity, "controller-pod-affinity", "", "Pod affinity label matches to control placement of controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.AntiAffinity, "controller-pod-antiaffinity", "", "Pod antiaffinity label matches to control placement of controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.IngressHost, "controller-ingress-host", "", "Host through which node is accessible when using nodeport as ingress.")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.LoadBalancerIp, "controller-load-balancer-ip", "", "Load balancer ip that will be used for controller service, if supported by cloud provider")
+
+	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.Cpu, "config-sync-cpu", "", "CPU request for config-sync pods")
+	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.Memory, "config-sync-memory", "", "Memory request for config-sync pods")
+	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.CpuLimit, "config-sync-cpu-limit", "", "CPU limit for config-sync pods")
+	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.MemoryLimit, "config-sync-memory-limit", "", "Memory limit for config-sync pods")
+
+	cmd.Flags().DurationVar(&LoadBalancerTimeout, "timeout", types.DefaultTimeoutDuration, "Configurable timeout for the ingress loadbalancer option.")
+
+	cmd.Flags().BoolVarP(&s.kubeInit.clusterLocal, "cluster-local", "", false, "Set up Skupper to only accept links from within the local cluster.")
+	f := cmd.Flag("cluster-local")
+	f.Deprecated = "This flag is deprecated, use --ingress [" + strings.Join(types.ValidIngressOptions(s.Platform()), "|") + "]"
+	f.Hidden = true
+
+	cmd.Flags().BoolVarP(&s.kubeInit.isEdge, "edge", "", false, "Configure as an edge")
+	f = cmd.Flag("edge")
+	f.Deprecated = "This flag is deprecated, use --router-mode [interior|edge]"
+	f.Hidden = true
+}
+
+func (s *SkupperKube) DebugDump(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+	file, err := cli.SkupperDump(context.Background(), args[0], client.Version, s.kubeConfigPath, s.kubeContext)
+	if err != nil {
+		return fmt.Errorf("Unable to save skupper dump details: %w", err)
+	} else {
+		fmt.Println("Skupper dump details written to compressed archive: ", file)
+	}
+	return nil
+}

--- a/cmd/skupper/skupper_kube_debug.go
+++ b/cmd/skupper/skupper_kube_debug.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/skupperproject/skupper/client"
+	"github.com/spf13/cobra"
+)
+
+func (s *SkupperKube) DebugEvents(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+	output, err := cli.SkupperEvents(verbose)
+	if err != nil {
+		return err
+	}
+	os.Stdout.Write(output.Bytes())
+	return nil
+}
+
+func (s *SkupperKube) DebugService(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+	output, err := cli.SkupperCheckService(args[0], verbose)
+	if err != nil {
+		return err
+	}
+	os.Stdout.Write(output.Bytes())
+	return nil
+}
+
+func (s *SkupperKube) DebugDump(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+	file, err := cli.SkupperDump(context.Background(), args[0], client.Version, s.KubeConfigPath, s.KubeContext)
+	if err != nil {
+		return fmt.Errorf("Unable to save skupper dump details: %w", err)
+	} else {
+		fmt.Println("Skupper dump details written to compressed archive: ", file)
+	}
+	return nil
+}

--- a/cmd/skupper/skupper_kube_debug.go
+++ b/cmd/skupper/skupper_kube_debug.go
@@ -11,7 +11,7 @@ import (
 
 func (s *SkupperKube) DebugEvents(cmd *cobra.Command, args []string) error {
 	silenceCobra(cmd)
-	output, err := cli.SkupperEvents(verbose)
+	output, err := s.Cli.SkupperEvents(verbose)
 	if err != nil {
 		return err
 	}
@@ -21,7 +21,7 @@ func (s *SkupperKube) DebugEvents(cmd *cobra.Command, args []string) error {
 
 func (s *SkupperKube) DebugService(cmd *cobra.Command, args []string) error {
 	silenceCobra(cmd)
-	output, err := cli.SkupperCheckService(args[0], verbose)
+	output, err := s.Cli.SkupperCheckService(args[0], verbose)
 	if err != nil {
 		return err
 	}
@@ -31,7 +31,7 @@ func (s *SkupperKube) DebugService(cmd *cobra.Command, args []string) error {
 
 func (s *SkupperKube) DebugDump(cmd *cobra.Command, args []string) error {
 	silenceCobra(cmd)
-	file, err := cli.SkupperDump(context.Background(), args[0], client.Version, s.KubeConfigPath, s.KubeContext)
+	file, err := s.Cli.SkupperDump(context.Background(), args[0], client.Version, s.KubeConfigPath, s.KubeContext)
 	if err != nil {
 		return fmt.Errorf("Unable to save skupper dump details: %w", err)
 	} else {

--- a/cmd/skupper/skupper_kube_debug.go
+++ b/cmd/skupper/skupper_kube_debug.go
@@ -5,37 +5,50 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/client"
 	"github.com/spf13/cobra"
 )
 
-func (s *SkupperKube) DebugEvents(cmd *cobra.Command, args []string) error {
-	silenceCobra(cmd)
-	output, err := s.Cli.SkupperEvents(verbose)
-	if err != nil {
-		return err
-	}
-	os.Stdout.Write(output.Bytes())
-	return nil
+type SkupperKubeDebug struct {
+	kube *SkupperKube
 }
 
-func (s *SkupperKube) DebugService(cmd *cobra.Command, args []string) error {
-	silenceCobra(cmd)
-	output, err := s.Cli.SkupperCheckService(args[0], verbose)
-	if err != nil {
-		return err
-	}
-	os.Stdout.Write(output.Bytes())
-	return nil
+func (s *SkupperKubeDebug) NewClient(cmd *cobra.Command, args []string) {
+	s.kube.NewClient(cmd, args)
 }
 
-func (s *SkupperKube) DebugDump(cmd *cobra.Command, args []string) error {
+func (s *SkupperKubeDebug) Platform() types.Platform {
+	return s.kube.Platform()
+}
+
+func (s *SkupperKubeDebug) Dump(cmd *cobra.Command, args []string) error {
 	silenceCobra(cmd)
-	file, err := s.Cli.SkupperDump(context.Background(), args[0], client.Version, s.KubeConfigPath, s.KubeContext)
+	file, err := s.kube.Cli.SkupperDump(context.Background(), args[0], client.Version, s.kube.KubeConfigPath, s.kube.KubeContext)
 	if err != nil {
 		return fmt.Errorf("Unable to save skupper dump details: %w", err)
 	} else {
 		fmt.Println("Skupper dump details written to compressed archive: ", file)
 	}
+	return nil
+}
+
+func (s *SkupperKubeDebug) Events(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+	output, err := s.kube.Cli.SkupperEvents(verbose)
+	if err != nil {
+		return err
+	}
+	os.Stdout.Write(output.Bytes())
+	return nil
+}
+
+func (s *SkupperKubeDebug) Service(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+	output, err := s.kube.Cli.SkupperCheckService(args[0], verbose)
+	if err != nil {
+		return err
+	}
+	os.Stdout.Write(output.Bytes())
 	return nil
 }

--- a/cmd/skupper/skupper_kube_expose.go
+++ b/cmd/skupper/skupper_kube_expose.go
@@ -67,7 +67,7 @@ func (s *SkupperKube) Expose(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--publish-not-ready-addresses option is only valid for headless services and deployments")
 	}
 
-	addr, err := expose(cli, context.Background(), targetType, targetName, exposeOpts)
+	addr, err := expose(s.Cli, context.Background(), targetType, targetName, exposeOpts)
 	if err == nil {
 		fmt.Printf("%s %s exposed as %s\n", targetType, targetName, addr)
 	}
@@ -104,7 +104,7 @@ func (s *SkupperKube) Unexpose(cmd *cobra.Command, args []string) error {
 
 	targetType, targetName := parseTargetTypeAndName(args)
 
-	err := cli.ServiceInterfaceUnbind(context.Background(), targetType, targetName, unexposeAddress, true)
+	err := s.Cli.ServiceInterfaceUnbind(context.Background(), targetType, targetName, unexposeAddress, true)
 	if err == nil {
 		fmt.Printf("%s %s unexposed\n", targetType, targetName)
 	} else {

--- a/cmd/skupper/skupper_kube_expose.go
+++ b/cmd/skupper/skupper_kube_expose.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var validExposeTargetsKube = []string{"deployment", "statefulset", "pods", "service"}
+
+func (s *SkupperKube) verifyTargetTypeFromArgs(args []string) error {
+	targetType, _ := parseTargetTypeAndName(args)
+	if !utils.StringSliceContains(validExposeTargetsKube, targetType) {
+		return fmt.Errorf("target type must be one of: [%s]", strings.Join(validExposeTargetsKube, ", "))
+	}
+	return nil
+}
+
+func (s *SkupperKube) Expose(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+
+	targetType, targetName := parseTargetTypeAndName(args)
+
+	// silence cobra may be moved below the "if" we want to print
+	// the usage message along with this error
+	if exposeOpts.Address == "" {
+		if targetType == "service" {
+			return fmt.Errorf("--address option is required for target type 'service'")
+		}
+		if !exposeOpts.Headless {
+			exposeOpts.Address = targetName
+		}
+	}
+	if !exposeOpts.Headless {
+		if exposeOpts.ProxyTuning.Cpu != "" {
+			return fmt.Errorf("--proxy-cpu option is only valid for headless services")
+		}
+		if exposeOpts.ProxyTuning.Memory != "" {
+			return fmt.Errorf("--proxy-memory option is only valid for headless services")
+		}
+		if exposeOpts.ProxyTuning.CpuLimit != "" {
+			return fmt.Errorf("--proxy-cpu-limit option is only valid for headless services")
+		}
+		if exposeOpts.ProxyTuning.MemoryLimit != "" {
+			return fmt.Errorf("--proxy-memory-limit option is only valid for headless services")
+		}
+		if exposeOpts.ProxyTuning.Affinity != "" {
+			return fmt.Errorf("--proxy-pod-affinity option is only valid for headless services")
+		}
+		if exposeOpts.ProxyTuning.AntiAffinity != "" {
+			return fmt.Errorf("--proxy-pod-antiaffinity option is only valid for headless services")
+		}
+		if exposeOpts.ProxyTuning.NodeSelector != "" {
+			return fmt.Errorf("--proxy-node-selector option is only valid for headless services")
+		}
+	}
+
+	if exposeOpts.EnableTls {
+		exposeOpts.TlsCredentials = types.SkupperServiceCertPrefix + exposeOpts.Address
+	}
+
+	if exposeOpts.PublishNotReadyAddresses && targetType == "service" {
+		return fmt.Errorf("--publish-not-ready-addresses option is only valid for headless services and deployments")
+	}
+
+	addr, err := expose(cli, context.Background(), targetType, targetName, exposeOpts)
+	if err == nil {
+		fmt.Printf("%s %s exposed as %s\n", targetType, targetName, addr)
+	}
+	return err
+}
+
+func (s *SkupperKube) ExposeArgs(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 || (!strings.Contains(args[0], "/") && len(args) < 2) {
+		return fmt.Errorf("expose target and name must be specified (e.g. 'skupper expose deployment <name>'")
+	}
+	if len(args) > 2 {
+		return fmt.Errorf("illegal argument: %s", args[2])
+	}
+	if len(args) > 1 && strings.Contains(args[0], "/") {
+		return fmt.Errorf("extra argument: %s", args[1])
+	}
+	return s.verifyTargetTypeFromArgs(args)
+}
+
+func (s *SkupperKube) ExposeFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&(exposeOpts.Headless), "headless", false, "Expose through a headless service (valid only for a statefulset target)")
+	cmd.Flags().StringVar(&exposeOpts.ProxyTuning.Cpu, "proxy-cpu", "", "CPU request for router pods")
+	cmd.Flags().StringVar(&exposeOpts.ProxyTuning.Memory, "proxy-memory", "", "Memory request for router pods")
+	cmd.Flags().StringVar(&exposeOpts.ProxyTuning.CpuLimit, "proxy-cpu-limit", "", "CPU limit for router pods")
+	cmd.Flags().StringVar(&exposeOpts.ProxyTuning.MemoryLimit, "proxy-memory-limit", "", "Memory limit for router pods")
+	cmd.Flags().StringVar(&exposeOpts.ProxyTuning.NodeSelector, "proxy-node-selector", "", "Node selector to control placement of router pods")
+	cmd.Flags().StringVar(&exposeOpts.ProxyTuning.Affinity, "proxy-pod-affinity", "", "Pod affinity label matches to control placement of router pods")
+	cmd.Flags().StringVar(&exposeOpts.ProxyTuning.AntiAffinity, "proxy-pod-antiaffinity", "", "Pod antiaffinity label matches to control placement of router pods")
+	cmd.Flags().BoolVar(&exposeOpts.PublishNotReadyAddresses, "publish-not-ready-addresses", false, "If specified, skupper will not wait for pods to be ready")
+}
+
+func (s *SkupperKube) Unexpose(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+
+	targetType, targetName := parseTargetTypeAndName(args)
+
+	err := cli.ServiceInterfaceUnbind(context.Background(), targetType, targetName, unexposeAddress, true)
+	if err == nil {
+		fmt.Printf("%s %s unexposed\n", targetType, targetName)
+	} else {
+		return fmt.Errorf("Unable to unbind skupper service: %w", err)
+	}
+	return nil
+}

--- a/cmd/skupper/skupper_kube_gateway.go
+++ b/cmd/skupper/skupper_kube_gateway.go
@@ -1,0 +1,474 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/client"
+	"github.com/skupperproject/skupper/pkg/utils/formatter"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdGateway() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gateway init or gateway delete",
+		Short: "Manage skupper gateway definitions",
+	}
+	return cmd
+}
+
+const gatewayName string = ""
+
+var gatewayConfigFile string
+var gatewayEndpoint types.GatewayEndpoint
+var gatewayType string
+var deprecatedName string
+var deprecatedExportOnly bool
+
+func NewCmdInitGateway(kube *SkupperKube) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "init",
+		Short:  "Initialize a gateway to the service network",
+		Args:   cobra.NoArgs,
+		PreRun: kube.NewClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+
+			if gatewayType != "" && gatewayType != "service" && gatewayType != "docker" && gatewayType != "podman" {
+				return fmt.Errorf("%s is not a valid gateway type. Choose 'service', 'docker' or 'podman'.", gatewayType)
+			}
+
+			actual, err := cli.GatewayInit(context.Background(), gatewayName, gatewayType, gatewayConfigFile)
+			if err != nil {
+				return fmt.Errorf("%w", err)
+			}
+			fmt.Println("Skupper gateway: '" + actual + "'. Use 'skupper gateway status' to get more information.")
+
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&gatewayType, "type", "", "service", "The gateway type one of: 'service', 'docker', 'podman'")
+	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of the gateway definition")
+	cmd.Flags().StringVar(&gatewayConfigFile, "config", "", "The gateway config file to use for initialization")
+	cmd.Flags().BoolVarP(&deprecatedExportOnly, "exportonly", "", false, "Gateway definition for export-config only (e.g. will not be started)")
+
+	f := cmd.Flag("exportonly")
+	f.Deprecated = "gateway will be started"
+	f.Hidden = true
+
+	f = cmd.Flag("name")
+	f.Deprecated = "default name will be used"
+	f.Hidden = true
+
+	return cmd
+}
+
+func NewCmdDeleteGateway(kube *SkupperKube) *cobra.Command {
+	verbose := false
+	cmd := &cobra.Command{
+		Use:    "delete",
+		Short:  "Stop the gateway instance and remove the definition",
+		Args:   cobra.NoArgs,
+		PreRun: kube.NewClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+
+			err := cli.GatewayRemove(context.Background(), gatewayName)
+			if err != nil && verbose {
+				l := formatter.NewList()
+				l.Item("Exception while removing gateway definition:")
+				parts := strings.Split(err.Error(), ",")
+				for _, part := range parts {
+					l.NewChild(fmt.Sprintf("%s", part))
+				}
+				l.Print()
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "More details on any exceptions during gateway removal")
+	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
+
+	f := cmd.Flag("name")
+	f.Deprecated = "default name will be used"
+	f.Hidden = true
+
+	return cmd
+}
+
+func NewCmdDownloadGateway(kube *SkupperKube) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "download <output-path>",
+		Short:  "Download a gateway definition to a directory",
+		Args:   cobra.ExactArgs(1),
+		PreRun: kube.NewClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+
+			fileName, err := cli.GatewayDownload(context.Background(), gatewayName, args[0])
+			if err != nil {
+				return fmt.Errorf("%w", err)
+			}
+			fmt.Println("Skupper gateway definition written to '" + fileName + "'")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
+
+	f := cmd.Flag("name")
+	f.Deprecated = "default name will be used"
+	f.Hidden = true
+
+	return cmd
+}
+
+func NewCmdExportConfigGateway(kube *SkupperKube) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "export-config <export-gateway-name> <output-path>",
+		Short:  "Export the configuration for a gateway definition",
+		Args:   cobra.ExactArgs(2),
+		PreRun: kube.NewClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+
+			// TODO: validate args must be non nil, etc.
+			fileName, err := cli.GatewayExportConfig(context.Background(), gatewayName, args[0], args[1])
+			if err != nil {
+				return fmt.Errorf("%w", err)
+			}
+			fmt.Println("Skupper gateway definition configuration written to '" + fileName + "'")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
+
+	f := cmd.Flag("name")
+	f.Deprecated = "default name will be used"
+	f.Hidden = true
+
+	return cmd
+}
+
+func NewCmdGenerateBundleGateway(kube *SkupperKube) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "generate-bundle <config-file> <output-path>",
+		Short:  "Generate an installation bundle using a gateway config file",
+		Args:   cobra.ExactArgs(2),
+		PreRun: kube.NewClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+
+			fileName, err := cli.GatewayGenerateBundle(context.Background(), args[0], args[1])
+			if err != nil {
+				return fmt.Errorf("%w", err)
+			}
+			fmt.Println("Skupper gateway bundle written to '" + fileName + "'")
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func NewCmdExposeGateway(kube *SkupperKube) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "expose <address> <host> <port...>",
+		Short:  "Expose a process to the service network (ensure gateway and cluster service)",
+		Args:   exposeGatewayArgs,
+		PreRun: kube.NewClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+
+			if gatewayType != "" && gatewayType != "service" && gatewayType != "docker" && gatewayType != "podman" {
+				return fmt.Errorf("%s is not a valid gateway type. Choose 'service', 'docker' or 'podman'.", gatewayType)
+			}
+
+			if len(args) == 2 {
+				parts := strings.Split(args[1], ":")
+				gatewayEndpoint.Host = parts[0]
+				port, _ := strconv.Atoi(parts[1])
+				gatewayEndpoint.Service.Ports = []int{port}
+			} else {
+				tPorts := []int{}
+				sPorts := []int{}
+				for _, v := range args[2:] {
+					ports := strings.Split(v, ":")
+					sPort, _ := strconv.Atoi(ports[0])
+					tPort := sPort
+					if len(ports) == 2 {
+						tPort, _ = strconv.Atoi(ports[1])
+					}
+					sPorts = append(sPorts, sPort)
+					tPorts = append(tPorts, tPort)
+				}
+				gatewayEndpoint.Host = args[1]
+				gatewayEndpoint.Service.Ports = sPorts
+				gatewayEndpoint.TargetPorts = tPorts
+			}
+			gatewayEndpoint.Service.Address = args[0]
+
+			_, err := cli.GatewayExpose(context.Background(), gatewayName, gatewayType, gatewayEndpoint)
+			if err != nil {
+				return fmt.Errorf("%w", err)
+			}
+
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&gatewayEndpoint.Service.Protocol, "protocol", "tcp", "The protocol to gateway (tcp, http or http2).")
+	cmd.Flags().StringVar(&gatewayEndpoint.Service.Aggregate, "aggregate", "", "The aggregation strategy to use. One of 'json' or 'multipart'. If specified requests to this service will be sent to all registered implementations and the responses aggregated.")
+	cmd.Flags().BoolVar(&gatewayEndpoint.Service.EventChannel, "event-channel", false, "If specified, this service will be a channel for multicast events.")
+	cmd.Flags().StringVarP(&gatewayType, "type", "", "service", "The gateway type one of: 'service', 'docker', 'podman'")
+	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
+
+	f := cmd.Flag("name")
+	f.Deprecated = "default name will be used"
+	f.Hidden = true
+
+	return cmd
+}
+
+var deleteLast bool
+
+func NewCmdUnexposeGateway(kube *SkupperKube) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "unexpose <address>",
+		Short:  "Unexpose a process previously exposed to the service network",
+		Args:   cobra.ExactArgs(1),
+		PreRun: kube.NewClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+
+			gatewayEndpoint.Service.Address = args[0]
+			err := cli.GatewayUnexpose(context.Background(), gatewayName, gatewayEndpoint, deleteLast)
+			if err != nil {
+				return fmt.Errorf("%w", err)
+			}
+
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&deleteLast, "delete-last", "", true, "Delete the gateway if no services remain")
+	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
+
+	f := cmd.Flag("name")
+	f.Deprecated = "default name will be used"
+	f.Hidden = true
+
+	return cmd
+}
+
+func NewCmdBindGateway(kube *SkupperKube) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "bind <address> <host> <port...>",
+		Short:  "Bind a process to the service network",
+		Args:   bindGatewayArgs,
+		PreRun: kube.NewClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+			if len(args) == 2 {
+				parts := strings.Split(args[1], ":")
+				port, _ := strconv.Atoi(parts[1])
+				gatewayEndpoint.Host = parts[0]
+				gatewayEndpoint.Service.Ports = []int{port}
+			} else {
+				ports := []int{}
+				for _, p := range args[2:] {
+					port, _ := strconv.Atoi(p)
+					ports = append(ports, port)
+				}
+				gatewayEndpoint.Host = args[1]
+				gatewayEndpoint.Service.Ports = ports
+			}
+			gatewayEndpoint.Service.Address = args[0]
+			gatewayEndpoint.Name = args[0]
+
+			err := cli.GatewayBind(context.Background(), gatewayName, gatewayEndpoint)
+			if err != nil {
+				return fmt.Errorf("%w", err)
+			}
+
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&gatewayEndpoint.Service.Protocol, "protocol", "tcp", "The mapping in use for this service address (currently on of tcp, http or http2).")
+	cmd.Flags().StringVar(&gatewayEndpoint.Service.Aggregate, "aggregate", "", "The aggregation strategy to use. One of 'json' or 'multipart'. If specified requests to this service will be sent to all registered implementations and the responses aggregated.")
+	cmd.Flags().BoolVar(&gatewayEndpoint.Service.EventChannel, "event-channel", false, "If specified, this service will be a channel for multicast events.")
+	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
+
+	f := cmd.Flag("name")
+	f.Deprecated = "default name will be used"
+	f.Hidden = true
+
+	f = cmd.Flag("protocol")
+	f.Deprecated = "protocol is derived from service definition"
+	f.Hidden = true
+
+	return cmd
+}
+
+func NewCmdUnbindGateway(kube *SkupperKube) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "unbind <address>",
+		Short:  "Unbind a process from the service network",
+		Args:   cobra.ExactArgs(1),
+		PreRun: kube.NewClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+
+			gatewayEndpoint.Service.Address = args[0]
+			err := cli.GatewayUnbind(context.Background(), gatewayName, gatewayEndpoint)
+			if err != nil {
+				return fmt.Errorf("%w", err)
+			}
+
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&gatewayEndpoint.Service.Protocol, "protocol", "tcp", "The protocol to gateway (tcp, http or http2).")
+	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
+
+	f := cmd.Flag("name")
+	f.Deprecated = "default name will be used"
+	f.Hidden = true
+
+	f = cmd.Flag("protocol")
+	f.Deprecated = "protocol is derived from service definition"
+	f.Hidden = true
+
+	return cmd
+}
+
+func NewCmdStatusGateway(kube *SkupperKube) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "status <gateway-name>",
+		Short:  "Report the status of the gateway(s) for the current skupper site",
+		Args:   cobra.MaximumNArgs(1),
+		PreRun: kube.NewClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+
+			gateways, err := cli.GatewayList(context.Background())
+			if err != nil {
+				return fmt.Errorf("%w", err)
+			}
+
+			if len(gateways) == 0 {
+				l := formatter.NewList()
+				l.Item("No gateway definition found on cluster")
+				gatewayType, err := client.GatewayDetectTypeIfPresent()
+				if err == nil {
+					if gatewayType != "" {
+						l.NewChild(fmt.Sprintf(" A gateway of type %s is detected on local host.", gatewayType))
+					}
+				}
+				l.Print()
+				return nil
+			}
+
+			l := formatter.NewList()
+			l.Item("Gateway Definition:")
+			for _, gateway := range gateways {
+				gw := l.NewChild(fmt.Sprintf("%s type:%s version:%s", gateway.Name, gateway.Type, gateway.Version))
+				if len(gateway.Connectors) > 0 {
+					listeners := gw.NewChild("Bindings:")
+					for _, connector := range gateway.Connectors {
+						listeners.NewChild(fmt.Sprintf("%s %s %s %s %d", strings.TrimPrefix(connector.Name, gateway.Name+"-egress-"), connector.Service.Protocol, connector.Service.Address, connector.Host, connector.Service.Ports[0]))
+					}
+				}
+				if len(gateway.Listeners) > 0 {
+					listeners := gw.NewChild("Forwards:")
+					for _, listener := range gateway.Listeners {
+						listeners.NewChild(fmt.Sprintf("%s %s %s %s %d:%s", strings.TrimPrefix(listener.Name, gateway.Name+"-ingress-"), listener.Service.Protocol, listener.Service.Address, listener.Host, listener.Service.Ports[0], listener.LocalPort))
+					}
+				}
+			}
+			l.Print()
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func NewCmdForwardGateway(kube *SkupperKube) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "forward <address> <port...>",
+		Short:  "Forward an address to the service network",
+		Args:   cobra.MinimumNArgs(2),
+		PreRun: kube.NewClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+
+			ports := []int{}
+			for _, p := range args[1:] {
+				port, err := strconv.Atoi(p)
+				if err != nil {
+					return fmt.Errorf("%s is not a valid forward port", p)
+				}
+				ports = append(ports, port)
+			}
+
+			gatewayEndpoint.Service.Address = args[0]
+			gatewayEndpoint.Service.Ports = ports
+
+			err := cli.GatewayForward(context.Background(), gatewayName, gatewayEndpoint)
+			if err != nil {
+				return fmt.Errorf("%w", err)
+			}
+
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&gatewayEndpoint.Service.Protocol, "protocol", "tcp", "The mapping in use for this service address (currently one of tcp, http or http2)")
+	cmd.Flags().StringVar(&gatewayEndpoint.Service.Aggregate, "aggregate", "", "The aggregation strategy to use. One of 'json' or 'multipart'. If specified requests to this service will be sent to all registered implementations and the responses aggregated.")
+	cmd.Flags().BoolVar(&gatewayEndpoint.Service.EventChannel, "event-channel", false, "If specified, this service will be a channel for multicast events.")
+	cmd.Flags().BoolVarP(&gatewayEndpoint.Loopback, "loopback", "", false, "Forward from loopback only")
+	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
+
+	f := cmd.Flag("name")
+	f.Deprecated = "default name will be used"
+	f.Hidden = true
+
+	f = cmd.Flag("protocol")
+	f.Deprecated = "protocol is derived from service definition"
+	f.Hidden = true
+
+	return cmd
+}
+
+func NewCmdUnforwardGateway(kube *SkupperKube) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "unforward <address>",
+		Short:  "Stop forwarding an address to the service network",
+		Args:   cobra.ExactArgs(1),
+		PreRun: kube.NewClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+
+			gatewayEndpoint.Service.Address = args[0]
+			err := cli.GatewayUnforward(context.Background(), gatewayName, gatewayEndpoint)
+			if err != nil {
+				return fmt.Errorf("%w", err)
+			}
+
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&gatewayEndpoint.Service.Protocol, "protocol", "tcp", "The protocol to gateway (tcp, http or http2).")
+	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
+
+	f := cmd.Flag("name")
+	f.Deprecated = "default name will be used"
+	f.Hidden = true
+
+	f = cmd.Flag("protocol")
+	f.Deprecated = "protocol is derived from service definition"
+	f.Hidden = true
+
+	return cmd
+}

--- a/cmd/skupper/skupper_kube_gateway.go
+++ b/cmd/skupper/skupper_kube_gateway.go
@@ -41,7 +41,7 @@ func NewCmdInitGateway(kube *SkupperKube) *cobra.Command {
 				return fmt.Errorf("%s is not a valid gateway type. Choose 'service', 'docker' or 'podman'.", gatewayType)
 			}
 
-			actual, err := cli.GatewayInit(context.Background(), gatewayName, gatewayType, gatewayConfigFile)
+			actual, err := kube.Cli.GatewayInit(context.Background(), gatewayName, gatewayType, gatewayConfigFile)
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}
@@ -76,7 +76,7 @@ func NewCmdDeleteGateway(kube *SkupperKube) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			silenceCobra(cmd)
 
-			err := cli.GatewayRemove(context.Background(), gatewayName)
+			err := kube.Cli.GatewayRemove(context.Background(), gatewayName)
 			if err != nil && verbose {
 				l := formatter.NewList()
 				l.Item("Exception while removing gateway definition:")
@@ -108,7 +108,7 @@ func NewCmdDownloadGateway(kube *SkupperKube) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			silenceCobra(cmd)
 
-			fileName, err := cli.GatewayDownload(context.Background(), gatewayName, args[0])
+			fileName, err := kube.Cli.GatewayDownload(context.Background(), gatewayName, args[0])
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}
@@ -135,7 +135,7 @@ func NewCmdExportConfigGateway(kube *SkupperKube) *cobra.Command {
 			silenceCobra(cmd)
 
 			// TODO: validate args must be non nil, etc.
-			fileName, err := cli.GatewayExportConfig(context.Background(), gatewayName, args[0], args[1])
+			fileName, err := kube.Cli.GatewayExportConfig(context.Background(), gatewayName, args[0], args[1])
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}
@@ -161,7 +161,7 @@ func NewCmdGenerateBundleGateway(kube *SkupperKube) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			silenceCobra(cmd)
 
-			fileName, err := cli.GatewayGenerateBundle(context.Background(), args[0], args[1])
+			fileName, err := kube.Cli.GatewayGenerateBundle(context.Background(), args[0], args[1])
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}
@@ -210,7 +210,7 @@ func NewCmdExposeGateway(kube *SkupperKube) *cobra.Command {
 			}
 			gatewayEndpoint.Service.Address = args[0]
 
-			_, err := cli.GatewayExpose(context.Background(), gatewayName, gatewayType, gatewayEndpoint)
+			_, err := kube.Cli.GatewayExpose(context.Background(), gatewayName, gatewayType, gatewayEndpoint)
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}
@@ -243,7 +243,7 @@ func NewCmdUnexposeGateway(kube *SkupperKube) *cobra.Command {
 			silenceCobra(cmd)
 
 			gatewayEndpoint.Service.Address = args[0]
-			err := cli.GatewayUnexpose(context.Background(), gatewayName, gatewayEndpoint, deleteLast)
+			err := kube.Cli.GatewayUnexpose(context.Background(), gatewayName, gatewayEndpoint, deleteLast)
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}
@@ -286,7 +286,7 @@ func NewCmdBindGateway(kube *SkupperKube) *cobra.Command {
 			gatewayEndpoint.Service.Address = args[0]
 			gatewayEndpoint.Name = args[0]
 
-			err := cli.GatewayBind(context.Background(), gatewayName, gatewayEndpoint)
+			err := kube.Cli.GatewayBind(context.Background(), gatewayName, gatewayEndpoint)
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}
@@ -320,7 +320,7 @@ func NewCmdUnbindGateway(kube *SkupperKube) *cobra.Command {
 			silenceCobra(cmd)
 
 			gatewayEndpoint.Service.Address = args[0]
-			err := cli.GatewayUnbind(context.Background(), gatewayName, gatewayEndpoint)
+			err := kube.Cli.GatewayUnbind(context.Background(), gatewayName, gatewayEndpoint)
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}
@@ -351,7 +351,7 @@ func NewCmdStatusGateway(kube *SkupperKube) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			silenceCobra(cmd)
 
-			gateways, err := cli.GatewayList(context.Background())
+			gateways, err := kube.Cli.GatewayList(context.Background())
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}
@@ -416,7 +416,7 @@ func NewCmdForwardGateway(kube *SkupperKube) *cobra.Command {
 			gatewayEndpoint.Service.Address = args[0]
 			gatewayEndpoint.Service.Ports = ports
 
-			err := cli.GatewayForward(context.Background(), gatewayName, gatewayEndpoint)
+			err := kube.Cli.GatewayForward(context.Background(), gatewayName, gatewayEndpoint)
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}
@@ -451,7 +451,7 @@ func NewCmdUnforwardGateway(kube *SkupperKube) *cobra.Command {
 			silenceCobra(cmd)
 
 			gatewayEndpoint.Service.Address = args[0]
-			err := cli.GatewayUnforward(context.Background(), gatewayName, gatewayEndpoint)
+			err := kube.Cli.GatewayUnforward(context.Background(), gatewayName, gatewayEndpoint)
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}

--- a/cmd/skupper/skupper_kube_gateway.go
+++ b/cmd/skupper/skupper_kube_gateway.go
@@ -25,8 +25,6 @@ const gatewayName string = ""
 var gatewayConfigFile string
 var gatewayEndpoint types.GatewayEndpoint
 var gatewayType string
-var deprecatedName string
-var deprecatedExportOnly bool
 
 func NewCmdInitGateway(kube *SkupperKube) *cobra.Command {
 	cmd := &cobra.Command{
@@ -51,17 +49,7 @@ func NewCmdInitGateway(kube *SkupperKube) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&gatewayType, "type", "", "service", "The gateway type one of: 'service', 'docker', 'podman'")
-	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of the gateway definition")
 	cmd.Flags().StringVar(&gatewayConfigFile, "config", "", "The gateway config file to use for initialization")
-	cmd.Flags().BoolVarP(&deprecatedExportOnly, "exportonly", "", false, "Gateway definition for export-config only (e.g. will not be started)")
-
-	f := cmd.Flag("exportonly")
-	f.Deprecated = "gateway will be started"
-	f.Hidden = true
-
-	f = cmd.Flag("name")
-	f.Deprecated = "default name will be used"
-	f.Hidden = true
 
 	return cmd
 }
@@ -90,37 +78,6 @@ func NewCmdDeleteGateway(kube *SkupperKube) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "More details on any exceptions during gateway removal")
-	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
-
-	f := cmd.Flag("name")
-	f.Deprecated = "default name will be used"
-	f.Hidden = true
-
-	return cmd
-}
-
-func NewCmdDownloadGateway(kube *SkupperKube) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "download <output-path>",
-		Short:  "Download a gateway definition to a directory",
-		Args:   cobra.ExactArgs(1),
-		PreRun: kube.NewClient,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			silenceCobra(cmd)
-
-			fileName, err := kube.Cli.GatewayDownload(context.Background(), gatewayName, args[0])
-			if err != nil {
-				return fmt.Errorf("%w", err)
-			}
-			fmt.Println("Skupper gateway definition written to '" + fileName + "'")
-			return nil
-		},
-	}
-	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
-
-	f := cmd.Flag("name")
-	f.Deprecated = "default name will be used"
-	f.Hidden = true
 
 	return cmd
 }
@@ -143,11 +100,6 @@ func NewCmdExportConfigGateway(kube *SkupperKube) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
-
-	f := cmd.Flag("name")
-	f.Deprecated = "default name will be used"
-	f.Hidden = true
 
 	return cmd
 }
@@ -222,11 +174,6 @@ func NewCmdExposeGateway(kube *SkupperKube) *cobra.Command {
 	cmd.Flags().StringVar(&gatewayEndpoint.Service.Aggregate, "aggregate", "", "The aggregation strategy to use. One of 'json' or 'multipart'. If specified requests to this service will be sent to all registered implementations and the responses aggregated.")
 	cmd.Flags().BoolVar(&gatewayEndpoint.Service.EventChannel, "event-channel", false, "If specified, this service will be a channel for multicast events.")
 	cmd.Flags().StringVarP(&gatewayType, "type", "", "service", "The gateway type one of: 'service', 'docker', 'podman'")
-	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
-
-	f := cmd.Flag("name")
-	f.Deprecated = "default name will be used"
-	f.Hidden = true
 
 	return cmd
 }
@@ -252,11 +199,6 @@ func NewCmdUnexposeGateway(kube *SkupperKube) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVarP(&deleteLast, "delete-last", "", true, "Delete the gateway if no services remain")
-	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
-
-	f := cmd.Flag("name")
-	f.Deprecated = "default name will be used"
-	f.Hidden = true
 
 	return cmd
 }
@@ -294,18 +236,8 @@ func NewCmdBindGateway(kube *SkupperKube) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&gatewayEndpoint.Service.Protocol, "protocol", "tcp", "The mapping in use for this service address (currently on of tcp, http or http2).")
 	cmd.Flags().StringVar(&gatewayEndpoint.Service.Aggregate, "aggregate", "", "The aggregation strategy to use. One of 'json' or 'multipart'. If specified requests to this service will be sent to all registered implementations and the responses aggregated.")
 	cmd.Flags().BoolVar(&gatewayEndpoint.Service.EventChannel, "event-channel", false, "If specified, this service will be a channel for multicast events.")
-	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
-
-	f := cmd.Flag("name")
-	f.Deprecated = "default name will be used"
-	f.Hidden = true
-
-	f = cmd.Flag("protocol")
-	f.Deprecated = "protocol is derived from service definition"
-	f.Hidden = true
 
 	return cmd
 }
@@ -328,16 +260,6 @@ func NewCmdUnbindGateway(kube *SkupperKube) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&gatewayEndpoint.Service.Protocol, "protocol", "tcp", "The protocol to gateway (tcp, http or http2).")
-	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
-
-	f := cmd.Flag("name")
-	f.Deprecated = "default name will be used"
-	f.Hidden = true
-
-	f = cmd.Flag("protocol")
-	f.Deprecated = "protocol is derived from service definition"
-	f.Hidden = true
 
 	return cmd
 }
@@ -424,19 +346,9 @@ func NewCmdForwardGateway(kube *SkupperKube) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&gatewayEndpoint.Service.Protocol, "protocol", "tcp", "The mapping in use for this service address (currently one of tcp, http or http2)")
 	cmd.Flags().StringVar(&gatewayEndpoint.Service.Aggregate, "aggregate", "", "The aggregation strategy to use. One of 'json' or 'multipart'. If specified requests to this service will be sent to all registered implementations and the responses aggregated.")
 	cmd.Flags().BoolVar(&gatewayEndpoint.Service.EventChannel, "event-channel", false, "If specified, this service will be a channel for multicast events.")
 	cmd.Flags().BoolVarP(&gatewayEndpoint.Loopback, "loopback", "", false, "Forward from loopback only")
-	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
-
-	f := cmd.Flag("name")
-	f.Deprecated = "default name will be used"
-	f.Hidden = true
-
-	f = cmd.Flag("protocol")
-	f.Deprecated = "protocol is derived from service definition"
-	f.Hidden = true
 
 	return cmd
 }
@@ -459,16 +371,6 @@ func NewCmdUnforwardGateway(kube *SkupperKube) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&gatewayEndpoint.Service.Protocol, "protocol", "tcp", "The protocol to gateway (tcp, http or http2).")
-	cmd.Flags().StringVar(&deprecatedName, "name", "", "The name of gateway definition to remove")
-
-	f := cmd.Flag("name")
-	f.Deprecated = "default name will be used"
-	f.Hidden = true
-
-	f = cmd.Flag("protocol")
-	f.Deprecated = "protocol is derived from service definition"
-	f.Hidden = true
 
 	return cmd
 }

--- a/cmd/skupper/skupper_kube_link.go
+++ b/cmd/skupper/skupper_kube_link.go
@@ -14,6 +14,7 @@ import (
 
 func (s *SkupperKube) LinkCreate(cmd *cobra.Command, args []string) error {
 	silenceCobra(cmd)
+	cli := s.Cli
 	siteConfig, err := cli.SiteConfigInspect(context.Background(), nil)
 	if err != nil {
 		fmt.Println("Unable to retrieve site config: ", err.Error())
@@ -52,6 +53,7 @@ func (s *SkupperKube) LinkCreate(cmd *cobra.Command, args []string) error {
 
 func (s *SkupperKube) LinkDelete(cmd *cobra.Command, args []string) error {
 	silenceCobra(cmd)
+	cli := s.Cli
 	connectorRemoveOpts.Name = args[0]
 	connectorRemoveOpts.SkupperNamespace = cli.GetNamespace()
 	connectorRemoveOpts.ForceCurrent = false
@@ -72,7 +74,7 @@ func (s *SkupperKube) LinkStatus(cmd *cobra.Command, args []string) error {
 			if i > 0 {
 				time.Sleep(time.Second)
 			}
-			link, err := cli.ConnectorInspect(context.Background(), args[0])
+			link, err := s.Cli.ConnectorInspect(context.Background(), args[0])
 			if errors.IsNotFound(err) {
 				fmt.Printf("No such link %q", args[0])
 				fmt.Println()
@@ -99,7 +101,7 @@ func (s *SkupperKube) LinkStatus(cmd *cobra.Command, args []string) error {
 			if i > 0 {
 				time.Sleep(time.Second)
 			}
-			links, err := cli.ConnectorList(context.Background())
+			links, err := s.Cli.ConnectorList(context.Background())
 			if err != nil {
 				fmt.Println(err)
 				break

--- a/cmd/skupper/skupper_kube_link.go
+++ b/cmd/skupper/skupper_kube_link.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (s *SkupperKube) LinkCreate(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+	siteConfig, err := cli.SiteConfigInspect(context.Background(), nil)
+	if err != nil {
+		fmt.Println("Unable to retrieve site config: ", err.Error())
+		os.Exit(1)
+	}
+	connectorCreateOpts.SkupperNamespace = cli.GetNamespace()
+	yaml, err := ioutil.ReadFile(args[0])
+	if err != nil {
+		return fmt.Errorf("Could not read connection token: %s", err.Error())
+	}
+	secret, err := cli.ConnectorCreateSecretFromData(context.Background(), yaml, connectorCreateOpts)
+	if err != nil {
+		return fmt.Errorf("Failed to create link: %w", err)
+	} else {
+		if secret.ObjectMeta.Labels[types.SkupperTypeQualifier] == types.TypeToken {
+			if siteConfig.Spec.RouterMode == string(types.TransportModeEdge) {
+				fmt.Printf("Site configured to link to %s:%s (name=%s)\n",
+					secret.ObjectMeta.Annotations["edge-host"],
+					secret.ObjectMeta.Annotations["edge-port"],
+					secret.ObjectMeta.Name)
+			} else {
+				fmt.Printf("Site configured to link to %s:%s (name=%s)\n",
+					secret.ObjectMeta.Annotations["inter-router-host"],
+					secret.ObjectMeta.Annotations["inter-router-port"],
+					secret.ObjectMeta.Name)
+			}
+		} else {
+			fmt.Printf("Site configured to link to %s (name=%s)\n",
+				secret.ObjectMeta.Annotations[types.ClaimUrlAnnotationKey],
+				secret.ObjectMeta.Name)
+		}
+	}
+	fmt.Println("Check the status of the link using 'skupper link status'.")
+	return nil
+}
+
+func (s *SkupperKube) LinkDelete(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+	connectorRemoveOpts.Name = args[0]
+	connectorRemoveOpts.SkupperNamespace = cli.GetNamespace()
+	connectorRemoveOpts.ForceCurrent = false
+	err := cli.ConnectorRemove(context.Background(), connectorRemoveOpts)
+	if err == nil {
+		fmt.Println("Link '" + args[0] + "' has been removed")
+	} else {
+		return fmt.Errorf("Failed to remove link: %w", err)
+	}
+	return nil
+}
+
+func (s *SkupperKube) LinkStatus(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+
+	if len(args) == 1 && args[0] != "all" {
+		for i := 0; ; i++ {
+			if i > 0 {
+				time.Sleep(time.Second)
+			}
+			link, err := cli.ConnectorInspect(context.Background(), args[0])
+			if errors.IsNotFound(err) {
+				fmt.Printf("No such link %q", args[0])
+				fmt.Println()
+				break
+			} else if err != nil {
+				fmt.Println(err)
+				break
+			} else if link.Connected {
+				fmt.Printf("Link %s is active", link.Name)
+				fmt.Println()
+				break
+			} else if i == waitFor {
+				if link.Description != "" {
+					fmt.Printf("Link %s not active (%s)", link.Name, link.Description)
+				} else {
+					fmt.Printf("Link %s not active", link.Name)
+				}
+				fmt.Println()
+				break
+			}
+		}
+	} else {
+		for i := 0; ; i++ {
+			if i > 0 {
+				time.Sleep(time.Second)
+			}
+			links, err := cli.ConnectorList(context.Background())
+			if err != nil {
+				fmt.Println(err)
+				break
+			} else if allConnected(links) || i == waitFor {
+				if len(links) == 0 {
+					fmt.Println("There are no links configured or active")
+				}
+				for _, link := range links {
+					if link.Connected {
+						fmt.Printf("Link %s is active", link.Name)
+						fmt.Println()
+					} else {
+						if link.Description != "" {
+							fmt.Printf("Link %s not active (%s)", link.Name, link.Description)
+						} else {
+							fmt.Printf("Link %s not active", link.Name)
+						}
+						fmt.Println()
+					}
+				}
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/skupper/skupper_kube_network.go
+++ b/cmd/skupper/skupper_kube_network.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/client"
+	"github.com/skupperproject/skupper/pkg/utils"
+	"github.com/skupperproject/skupper/pkg/utils/formatter"
+	"github.com/spf13/cobra"
+)
+
+type SkupperKubeNetwork struct {
+	kube *SkupperKube
+}
+
+func (s *SkupperKubeNetwork) NewClient(cmd *cobra.Command, args []string) {
+	s.kube.NewClient(cmd, args)
+}
+
+func (s *SkupperKubeNetwork) Platform() types.Platform {
+	return s.kube.Platform()
+}
+
+func (s *SkupperKubeNetwork) Status(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+
+	var sites []*types.SiteInfo
+	var errStatus error
+	err := utils.RetryError(time.Second, 3, func() error {
+		sites, errStatus = s.kube.Cli.NetworkStatus()
+
+		if errStatus != nil {
+			return errStatus
+		}
+
+		return nil
+	})
+
+	loadOnlyLocalInformation := false
+
+	if err != nil {
+		fmt.Printf("Unable to retrieve network information: %s", err)
+		fmt.Println()
+		fmt.Println()
+		fmt.Println("Loading just local information:")
+		loadOnlyLocalInformation = true
+	}
+
+	vir, err := s.kube.Cli.RouterInspect(context.Background())
+	if err != nil || vir == nil {
+		fmt.Printf("The router configuration is not available: %s", err)
+		fmt.Println()
+		return nil
+	}
+
+	siteConfig, err := s.kube.Cli.SiteConfigInspect(nil, nil)
+	if err != nil || siteConfig == nil {
+		fmt.Printf("The site configuration is not available: %s", err)
+		fmt.Println()
+		return nil
+	}
+
+	currentSite := siteConfig.Reference.UID
+
+	if loadOnlyLocalInformation {
+		printLocalStatus(vir.Status.TransportReadyReplicas, vir.Status.ConnectedSites.Warnings, vir.Status.ConnectedSites.Total, vir.Status.ConnectedSites.Direct, vir.ExposedServices)
+
+		serviceInterfaces, err := s.kube.Cli.ServiceInterfaceList(context.Background())
+		if err != nil {
+			fmt.Printf("Service local configuration is not available: %s", err)
+			fmt.Println()
+			return nil
+		}
+
+		sites = getLocalSiteInfo(serviceInterfaces, currentSite, vir.Status.SiteName, s.kube.Cli.GetNamespace(), vir.TransportVersion)
+	}
+
+	if sites != nil && len(sites) > 0 {
+		siteList := formatter.NewList()
+		siteList.Item("Sites:")
+		for _, site := range sites {
+
+			if site.Name != selectedSite && selectedSite != "all" {
+				continue
+			}
+
+			location := "remote"
+			siteVersion := site.Version
+			detailsMap := map[string]string{"name": site.Name, "namespace": site.Namespace, "URL": site.Url, "version": siteVersion}
+
+			if len(site.MinimumVersion) > 0 {
+				siteVersion = fmt.Sprintf("%s (minimum version required %s)", site.Version, site.MinimumVersion)
+			}
+
+			if site.SiteId == currentSite {
+				location = "local"
+				detailsMap["mode"] = vir.Status.Mode
+			}
+
+			newItem := fmt.Sprintf("[%s] %s - %s ", location, site.SiteId[:7], site.Name)
+
+			newItem = newItem + fmt.Sprintln()
+
+			if len(site.Links) > 0 {
+				detailsMap["sites linked to"] = fmt.Sprint(strings.Join(site.Links, ", "))
+			}
+
+			serviceLevel := siteList.NewChildWithDetail(newItem, detailsMap)
+			if len(site.Services) > 0 {
+				services := serviceLevel.NewChild("Services:")
+				var addresses []string
+				svcAuth := map[string]bool{}
+				for _, svc := range site.Services {
+					addresses = append(addresses, svc.Name)
+					svcAuth[svc.Name] = true
+				}
+				if vc, ok := s.kube.Cli.(*client.VanClient); ok && site.Namespace == s.kube.Cli.GetNamespace() {
+					policy := client.NewPolicyValidatorAPI(vc)
+					res, _ := policy.Services(addresses...)
+					for addr, auth := range res {
+						svcAuth[addr] = auth.Allowed
+					}
+				}
+				for _, svc := range site.Services {
+					authSuffix := ""
+					if !svcAuth[svc.Name] {
+						authSuffix = " - not authorized"
+					}
+					svcItem := "name: " + svc.Name + authSuffix + fmt.Sprintln()
+					detailsSvc := map[string]string{"protocol": svc.Protocol, "address": svc.Address}
+					targetLevel := services.NewChildWithDetail(svcItem, detailsSvc)
+
+					if len(svc.Targets) > 0 {
+						targets := targetLevel.NewChild("Targets:")
+						for _, target := range svc.Targets {
+							targets.NewChild("name: " + target.Name)
+
+						}
+					}
+
+				}
+			}
+		}
+
+		siteList.Print()
+	}
+
+	return nil
+}
+
+func (s *SkupperKubeNetwork) StatusFlags(cmd *cobra.Command) {}

--- a/cmd/skupper/skupper_kube_service.go
+++ b/cmd/skupper/skupper_kube_service.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func (s *SkupperKube) bindArgs(cmd *cobra.Command, args []string) error {
+	if len(args) < 2 || (!strings.Contains(args[1], "/") && len(args) < 3) {
+		return fmt.Errorf("Service name, target type and target name must all be specified (e.g. 'skupper bind <service-name> <target-type> <target-name>')")
+	}
+	if len(args) > 3 {
+		return fmt.Errorf("illegal argument: %s", args[3])
+	}
+	if len(args) > 2 && strings.Contains(args[1], "/") {
+		return fmt.Errorf("extra argument: %s", args[2])
+	}
+	return s.verifyTargetTypeFromArgs(args[1:])
+}
+
+func (s *SkupperKube) ServiceCreate(cmd *cobra.Command, args []string) error {
+	err := cli.ServiceInterfaceCreate(context.Background(), &serviceToCreate)
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+	return nil
+}
+
+func (s *SkupperKube) ServiceDelete(cmd *cobra.Command, args []string) error {
+	err := cli.ServiceInterfaceRemove(context.Background(), args[0])
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+	return nil
+}
+
+func (s *SkupperKube) ServiceStatus(cmd *cobra.Command, args []string) error {
+	vsis, err := cli.ServiceInterfaceList(context.Background())
+	if err == nil {
+		listServices(vsis, showLabels)
+	} else {
+		return fmt.Errorf("Could not retrieve services: %w", err)
+	}
+	return nil
+}
+
+func (s *SkupperKube) ServiceLabel(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	si, err := cli.ServiceInterfaceInspect(context.Background(), name)
+	if si == nil {
+		return fmt.Errorf("invalid service name")
+	}
+	if err != nil {
+		return fmt.Errorf("error retrieving service: %v", err)
+	}
+	if showLabels {
+		showServiceLabels(si, name)
+		return nil
+	}
+	updateServiceLabels(si)
+	err = cli.ServiceInterfaceUpdate(context.Background(), si)
+	if err != nil {
+		return fmt.Errorf("error updating service labels: %v", err)
+	}
+	return nil
+}
+
+func (s *SkupperKube) ServiceBind(cmd *cobra.Command, args []string) error {
+	targetType, targetName := parseTargetTypeAndName(args[1:])
+
+	if publishNotReadyAddresses && targetType == "service" {
+		return fmt.Errorf("--publish-not-ready-addresses option is only valid for headless services and deployments")
+	}
+
+	service, err := cli.ServiceInterfaceInspect(context.Background(), args[0])
+
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	} else if service == nil {
+		return fmt.Errorf("Service %s not found", args[0])
+	}
+
+	// validating ports
+	portMapping, err := parsePortMapping(service, targetPorts)
+	if err != nil {
+		return err
+	}
+
+	service.PublishNotReadyAddresses = publishNotReadyAddresses
+
+	err = cli.ServiceInterfaceBind(context.Background(), service, targetType, targetName, protocol, portMapping)
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	return nil
+}
+
+func (s *SkupperKube) ServiceBindArgs(cmd *cobra.Command, args []string) error {
+	return s.bindArgs(cmd, args)
+}
+
+func (s *SkupperKube) ServiceBindFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&publishNotReadyAddresses, "publish-not-ready-addresses", false, "If specified, skupper will not wait for pods to be ready")
+}
+
+func (s *SkupperKube) ServiceUnbind(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+
+	targetType, targetName := parseTargetTypeAndName(args[1:])
+
+	err := cli.ServiceInterfaceUnbind(context.Background(), targetType, targetName, args[0], false)
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+	return nil
+}

--- a/cmd/skupper/skupper_kube_site.go
+++ b/cmd/skupper/skupper_kube_site.go
@@ -59,6 +59,8 @@ func (s *SkupperKubeSite) Create(cmd *cobra.Command, args []string) error {
 	routerCreateOpts.Labels = asMap(initFlags.labels)
 	routerCreateOpts.IngressAnnotations = asMap(s.kubeInit.ingressAnnotations)
 	routerCreateOpts.Router.ServiceAnnotations = asMap(s.kubeInit.routerServiceAnnotations)
+	routerCreateOpts.Router.MaxFrameSize = types.RouterMaxFrameSizeDefault
+	routerCreateOpts.Router.MaxSessionFrames = types.RouterMaxSessionFramesDefault
 	routerCreateOpts.Controller.ServiceAnnotations = asMap(s.kubeInit.controllerServiceAnnotations)
 	if err := routerCreateOpts.CheckIngress(); err != nil {
 		return err

--- a/cmd/skupper/skupper_kube_site.go
+++ b/cmd/skupper/skupper_kube_site.go
@@ -126,6 +126,10 @@ func (s *SkupperKubeSite) Create(cmd *cobra.Command, args []string) error {
 
 	err = cli.RouterCreate(ctx, *siteConfig)
 	if err != nil {
+		err2 := cli.SiteConfigRemove(context.Background())
+		if err2 != nil {
+			fmt.Println("Failed to cleanup site: ", err2)
+		}
 		return err
 	}
 	fmt.Println("Skupper is now installed in namespace '" + ns + "'.  Use 'skupper status' to get more information.")

--- a/cmd/skupper/skupper_kube_site.go
+++ b/cmd/skupper/skupper_kube_site.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/client"
+	"github.com/skupperproject/skupper/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type SkupperKubeSite struct {
+	kube     *SkupperKube
+	kubeInit kubeInit
+}
+
+func (s *SkupperKubeSite) NewClient(cmd *cobra.Command, args []string) {
+	s.kube.NewClient(cmd, args)
+}
+
+func (s *SkupperKubeSite) Platform() types.Platform {
+	return s.kube.Platform()
+}
+
+func (s *SkupperKubeSite) Create(cmd *cobra.Command, args []string) error {
+	cli := s.kube.Cli
+
+	silenceCobra(cmd)
+	ns := cli.GetNamespace()
+
+	routerModeFlag := cmd.Flag("router-mode")
+	edgeFlag := cmd.Flag("edge")
+	if routerModeFlag.Changed && edgeFlag.Changed {
+		return fmt.Errorf("You can not use the deprecated --edge, and --router-mode together, use --router-mode")
+	}
+
+	if routerModeFlag.Changed {
+		options := []string{string(types.TransportModeInterior), string(types.TransportModeEdge)}
+		if !utils.StringSliceContains(options, initFlags.routerMode) {
+			return fmt.Errorf(`invalid "--router-mode=%v", it must be one of "%v"`, initFlags.routerMode, strings.Join(options, ", "))
+		}
+		routerCreateOpts.RouterMode = initFlags.routerMode
+	} else {
+		if s.kubeInit.isEdge {
+			routerCreateOpts.RouterMode = string(types.TransportModeEdge)
+		} else {
+			routerCreateOpts.RouterMode = string(types.TransportModeInterior)
+		}
+	}
+
+	routerIngressFlag := cmd.Flag("ingress")
+	routerClusterLocalFlag := cmd.Flag("cluster-local")
+	routerCreateOpts.Platform = s.kube.Platform()
+
+	if routerIngressFlag.Changed && routerClusterLocalFlag.Changed {
+		return fmt.Errorf(`You can not use the deprecated --cluster-local, and --ingress together, use "--ingress none" as equivalent of --cluster-local`)
+	} else if routerClusterLocalFlag.Changed {
+		if s.kubeInit.clusterLocal { // this is redundant, because "if changed" it must be true, but it is also correct
+			routerCreateOpts.Ingress = types.IngressNoneString
+		}
+	} else if !routerIngressFlag.Changed {
+		routerCreateOpts.Ingress = cli.GetIngressDefault()
+	}
+	if routerCreateOpts.Ingress == types.IngressNodePortString && routerCreateOpts.IngressHost == "" && routerCreateOpts.Router.IngressHost == "" {
+		return fmt.Errorf(`One of --ingress-host or --router-ingress-host option is required when using "--ingress nodeport"`)
+	}
+	if routerCreateOpts.Ingress == types.IngressContourHttpProxyString && routerCreateOpts.IngressHost == "" {
+		return fmt.Errorf(`--ingress-host option is required when using "--ingress contour-http-proxy"`)
+	}
+	routerCreateOpts.Annotations = asMap(s.kubeInit.annotations)
+	routerCreateOpts.Labels = asMap(initFlags.labels)
+	routerCreateOpts.IngressAnnotations = asMap(s.kubeInit.ingressAnnotations)
+	routerCreateOpts.Router.ServiceAnnotations = asMap(s.kubeInit.routerServiceAnnotations)
+	routerCreateOpts.Controller.ServiceAnnotations = asMap(s.kubeInit.controllerServiceAnnotations)
+	if err := routerCreateOpts.CheckIngress(); err != nil {
+		return err
+	}
+	if err := routerCreateOpts.CheckConsoleIngress(); err != nil {
+		return err
+	}
+
+	routerCreateOpts.SkupperNamespace = ns
+	siteConfig, err := cli.SiteConfigInspect(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	if routerLogging != "" {
+		logConfig, err := client.ParseRouterLogConfig(routerLogging)
+		if err != nil {
+			return fmt.Errorf("Bad value for --router-logging: %s", err)
+		}
+		routerCreateOpts.Router.Logging = logConfig
+	}
+	if routerCreateOpts.Router.DebugMode != "" {
+		if routerCreateOpts.Router.DebugMode != "asan" && routerCreateOpts.Router.DebugMode != "gdb" {
+			return fmt.Errorf("Bad value for --router-debug-mode: %s (use 'asan' or 'gdb')", routerCreateOpts.Router.DebugMode)
+		}
+	}
+
+	if LoadBalancerTimeout.Seconds() <= 0 {
+		return fmt.Errorf(`invalid timeout value`)
+	}
+
+	if siteConfig == nil {
+		siteConfig, err = cli.SiteConfigCreate(context.Background(), routerCreateOpts)
+		if err != nil {
+			return err
+		}
+	} else {
+		updated, err := cli.SiteConfigUpdate(context.Background(), routerCreateOpts)
+		if err != nil {
+			return fmt.Errorf("Error while trying to update router configuration: %s", err)
+		}
+		if len(updated) > 0 {
+			for _, i := range updated {
+				fmt.Println("Updated", i)
+			}
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), LoadBalancerTimeout)
+	defer cancel()
+
+	err = cli.RouterCreate(ctx, *siteConfig)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Skupper is now installed in namespace '" + ns + "'.  Use 'skupper status' to get more information.")
+
+	return nil
+}
+
+func (s *SkupperKubeSite) CreateFlags(cmd *cobra.Command) {
+	s.kubeInit = kubeInit{}
+	s.kubeInit.ingressAnnotations = []string{}
+	s.kubeInit.annotations = []string{}
+	s.kubeInit.routerServiceAnnotations = []string{}
+	s.kubeInit.controllerServiceAnnotations = []string{}
+	cmd.Flags().BoolVarP(&routerCreateOpts.EnableConsole, "enable-console", "", true, "Enable skupper console")
+	cmd.Flags().BoolVarP(&routerCreateOpts.CreateNetworkPolicy, "create-network-policy", "", false, "Create network policy to restrict access to skupper services exposed through this site to current pods in namespace")
+	cmd.Flags().StringVarP(&routerCreateOpts.AuthMode, "console-auth", "", "", "Authentication mode for console(s). One of: 'openshift', 'internal', 'unsecured'")
+	cmd.Flags().StringVarP(&routerCreateOpts.User, "console-user", "", "", "Skupper console user. Valid only when --console-auth=internal")
+	cmd.Flags().StringVarP(&routerCreateOpts.Password, "console-password", "", "", "Skupper console user. Valid only when --console-auth=internal")
+	cmd.Flags().StringVarP(&routerCreateOpts.ConsoleIngress, "console-ingress", "", "", "Determines if/how console is exposed outside cluster. If not specified uses value of --ingress. One of: ["+strings.Join(types.ValidIngressOptions(s.kube.Platform()), "|")+"].")
+	cmd.Flags().StringSliceVar(&s.kubeInit.ingressAnnotations, "ingress-annotations", []string{}, "Annotations to add to skupper ingress")
+	cmd.Flags().StringSliceVar(&s.kubeInit.annotations, "annotations", []string{}, "Annotations to add to skupper pods")
+	cmd.Flags().StringSliceVar(&s.kubeInit.routerServiceAnnotations, "router-service-annotations", []string{}, "Annotations to add to skupper router service")
+	cmd.Flags().StringSliceVar(&s.kubeInit.controllerServiceAnnotations, "controller-service-annotation", []string{}, "Annotations to add to skupper controller service")
+	cmd.Flags().BoolVarP(&routerCreateOpts.EnableServiceSync, "enable-service-sync", "", true, "Participate in cross-site service synchronization")
+
+	cmd.Flags().StringVar(&routerCreateOpts.Router.Cpu, "router-cpu", "", "CPU request for router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.Memory, "router-memory", "", "Memory request for router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.CpuLimit, "router-cpu-limit", "", "CPU limit for router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.MemoryLimit, "router-memory-limit", "", "Memory limit for router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.NodeSelector, "router-node-selector", "", "Node selector to control placement of router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.Affinity, "router-pod-affinity", "", "Pod affinity label matches to control placement of router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.AntiAffinity, "router-pod-antiaffinity", "", "Pod antiaffinity label matches to control placement of router pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.IngressHost, "router-ingress-host", "", "Host through which node is accessible when using nodeport as ingress.")
+	cmd.Flags().StringVar(&routerCreateOpts.Router.LoadBalancerIp, "router-load-balancer-ip", "", "Load balancer ip that will be used for router service, if supported by cloud provider")
+
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.Cpu, "controller-cpu", "", "CPU request for controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.Memory, "controller-memory", "", "Memory request for controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.CpuLimit, "controller-cpu-limit", "", "CPU limit for controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.MemoryLimit, "controller-memory-limit", "", "Memory limit for controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.NodeSelector, "controller-node-selector", "", "Node selector to control placement of controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.Affinity, "controller-pod-affinity", "", "Pod affinity label matches to control placement of controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.AntiAffinity, "controller-pod-antiaffinity", "", "Pod antiaffinity label matches to control placement of controller pods")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.IngressHost, "controller-ingress-host", "", "Host through which node is accessible when using nodeport as ingress.")
+	cmd.Flags().StringVar(&routerCreateOpts.Controller.LoadBalancerIp, "controller-load-balancer-ip", "", "Load balancer ip that will be used for controller service, if supported by cloud provider")
+
+	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.Cpu, "config-sync-cpu", "", "CPU request for config-sync pods")
+	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.Memory, "config-sync-memory", "", "Memory request for config-sync pods")
+	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.CpuLimit, "config-sync-cpu-limit", "", "CPU limit for config-sync pods")
+	cmd.Flags().StringVar(&routerCreateOpts.ConfigSync.MemoryLimit, "config-sync-memory-limit", "", "Memory limit for config-sync pods")
+
+	cmd.Flags().DurationVar(&LoadBalancerTimeout, "timeout", types.DefaultTimeoutDuration, "Configurable timeout for the ingress loadbalancer option.")
+
+	cmd.Flags().BoolVarP(&s.kubeInit.clusterLocal, "cluster-local", "", false, "Set up Skupper to only accept links from within the local cluster.")
+	f := cmd.Flag("cluster-local")
+	f.Deprecated = "This flag is deprecated, use --ingress [" + strings.Join(types.ValidIngressOptions(s.kube.Platform()), "|") + "]"
+	f.Hidden = true
+
+	cmd.Flags().BoolVarP(&s.kubeInit.isEdge, "edge", "", false, "Configure as an edge")
+	f = cmd.Flag("edge")
+	f.Deprecated = "This flag is deprecated, use --router-mode [interior|edge]"
+	f.Hidden = true
+}
+
+func (s *SkupperKubeSite) Delete(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+	cli := s.kube.Cli
+	gateways, err := cli.GatewayList(context.Background())
+	for _, gateway := range gateways {
+		cli.GatewayRemove(context.Background(), gateway.Name)
+	}
+	err = cli.SiteConfigRemove(context.Background())
+	if err != nil {
+		err = cli.RouterRemove(context.Background())
+	}
+	if err != nil {
+		return err
+	} else {
+		fmt.Println("Skupper is now removed from '" + cli.GetNamespace() + "'.")
+	}
+	return nil
+}
+
+func (s *SkupperKubeSite) DeleteFlags(cmd *cobra.Command) {}
+
+func (s *SkupperKubeSite) List(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+func (s *SkupperKubeSite) ListFlags(cmd *cobra.Command) {}
+
+func (s *SkupperKubeSite) Status(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+	cli := s.kube.Cli
+	vir, err := cli.RouterInspect(context.Background())
+	if err == nil {
+		ns := cli.GetNamespace()
+		var modedesc string = " in interior mode"
+		if vir.Status.Mode == string(types.TransportModeEdge) {
+			modedesc = " in edge mode"
+		}
+		sitename := ""
+		if vir.Status.SiteName != "" && vir.Status.SiteName != ns {
+			sitename = fmt.Sprintf(" with site name %q", vir.Status.SiteName)
+		}
+		policyStr := ""
+		if vanClient, ok := cli.(*client.VanClient); ok {
+			p := client.NewPolicyValidatorAPI(vanClient)
+			r, err := p.IncomingLink()
+			if err == nil && r.Enabled {
+				policyStr = " (with policies)"
+			}
+		}
+		fmt.Printf("Skupper is enabled for namespace %q%s%s%s.", ns, sitename, modedesc, policyStr)
+		if vir.Status.TransportReadyReplicas == 0 {
+			fmt.Printf(" Status pending...")
+		} else {
+			if len(vir.Status.ConnectedSites.Warnings) > 0 {
+				for _, w := range vir.Status.ConnectedSites.Warnings {
+					fmt.Printf("Warning: %s", w)
+					fmt.Println()
+				}
+			}
+			if vir.Status.ConnectedSites.Total == 0 {
+				fmt.Printf(" It is not connected to any other sites.")
+			} else if vir.Status.ConnectedSites.Total == 1 {
+				fmt.Printf(" It is connected to 1 other site.")
+			} else if vir.Status.ConnectedSites.Total == vir.Status.ConnectedSites.Direct {
+				fmt.Printf(" It is connected to %d other sites.", vir.Status.ConnectedSites.Total)
+			} else {
+				fmt.Printf(" It is connected to %d other sites (%d indirectly).", vir.Status.ConnectedSites.Total, vir.Status.ConnectedSites.Indirect)
+			}
+		}
+		if vir.ExposedServices == 0 {
+			fmt.Printf(" It has no exposed services.")
+		} else if vir.ExposedServices == 1 {
+			fmt.Printf(" It has 1 exposed service.")
+		} else {
+			fmt.Printf(" It has %d exposed services.", vir.ExposedServices)
+		}
+		fmt.Println()
+		if vir.ConsoleUrl != "" {
+			fmt.Println("The site console url is: ", vir.ConsoleUrl)
+			siteConfig, err := cli.SiteConfigInspect(context.Background(), nil)
+			if err != nil {
+				return err
+			}
+			if siteConfig.Spec.AuthMode == "internal" {
+				fmt.Println("The credentials for internal console-auth mode are held in secret: 'skupper-console-users'")
+			}
+		}
+	} else {
+		if vir == nil {
+			fmt.Printf("Skupper is not enabled in namespace '%s'\n", cli.GetNamespace())
+		} else {
+			return fmt.Errorf("Unable to retrieve skupper status: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *SkupperKubeSite) StatusFlags(cmd *cobra.Command) {}
+
+func (s *SkupperKubeSite) Update(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+	cli := s.kube.Cli
+
+	updated, err := cli.RouterUpdateVersion(context.Background(), forceHup)
+	if err != nil {
+		return err
+	}
+	if updated {
+		fmt.Println("Skupper is now updated in '" + cli.GetNamespace() + "'.")
+	} else {
+		fmt.Println("No update required in '" + cli.GetNamespace() + "'.")
+	}
+	return nil
+}
+
+func (s *SkupperKubeSite) UpdateFlags(cmd *cobra.Command) {}
+
+func (s *SkupperKubeSite) Version(cmd *cobra.Command, args []string) error {
+	cli := s.kube.Cli
+	if !IsZero(reflect.ValueOf(cli)) {
+		fmt.Printf("%-30s %s\n", "transport version", cli.GetVersion(types.TransportComponentName, types.TransportContainerName))
+		fmt.Printf("%-30s %s\n", "controller version", cli.GetVersion(types.ControllerComponentName, types.ControllerContainerName))
+		fmt.Printf("%-30s %s\n", "config-sync version", cli.GetVersion(types.TransportComponentName, types.ConfigSyncContainerName))
+	} else {
+		fmt.Printf("%-30s %s\n", "transport version", "not-found (no configuration has been provided)")
+		fmt.Printf("%-30s %s\n", "controller version", "not-found (no configuration has been provided)")
+	}
+	return nil
+}
+
+func (s *SkupperKubeSite) RevokeAccess(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+	err := s.kube.Cli.RevokeAccess(context.Background())
+	if err != nil {
+		return fmt.Errorf("Unable to revoke access: %w", err)
+	}
+	return nil
+}

--- a/cmd/skupper/skupper_kube_token.go
+++ b/cmd/skupper/skupper_kube_token.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type SkupperKubeToken struct {
+	kube *SkupperKube
+}
+
+func (s *SkupperKubeToken) NewClient(cmd *cobra.Command, args []string) {
+	s.kube.NewClient(cmd, args)
+}
+
+func (s *SkupperKubeToken) Platform() types.Platform {
+	return s.kube.Platform()
+}
+
+func (s *SkupperKubeToken) Create(cmd *cobra.Command, args []string) error {
+	silenceCobra(cmd)
+	cli := s.kube.Cli
+	switch tokenType {
+	case "cert":
+		err := cli.ConnectorTokenCreateFile(context.Background(), clientIdentity, args[0])
+		if err != nil {
+			return fmt.Errorf("Failed to create token: %w", err)
+		}
+		return nil
+	case "claim":
+		name := clientIdentity
+		if name == "skupper" {
+			name = ""
+		}
+		if password == "" {
+			password = utils.RandomId(24)
+		}
+		err := cli.TokenClaimCreateFile(context.Background(), name, []byte(password), expiry, uses, args[0])
+		if err != nil {
+			return fmt.Errorf("Failed to create token: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid token type. Specify cert or claim")
+	}
+}
+
+func (s *SkupperKubeToken) CreateFlags(cmd *cobra.Command) {}

--- a/cmd/skupper/skupper_link.go
+++ b/cmd/skupper/skupper_link.go
@@ -18,7 +18,7 @@ func NewCmdLink() *cobra.Command {
 
 var connectorCreateOpts types.ConnectorCreateOptions
 
-func NewCmdLinkCreate(skupperClient SkupperClient, flag string) *cobra.Command {
+func NewCmdLinkCreate(skupperClient SkupperLinkClient, flag string) *cobra.Command {
 
 	if flag == "" { // hack for backwards compatibility
 		flag = "name"
@@ -29,7 +29,7 @@ func NewCmdLinkCreate(skupperClient SkupperClient, flag string) *cobra.Command {
 		Short:  "Links this skupper site to the site that issued the token",
 		Args:   cobra.ExactArgs(1),
 		PreRun: skupperClient.NewClient,
-		RunE:   skupperClient.LinkCreate,
+		RunE:   skupperClient.Create,
 	}
 	cmd.Flags().StringVarP(&connectorCreateOpts.Name, flag, "", "", "Provide a specific name for the link (used when deleting it)")
 	cmd.Flags().Int32VarP(&connectorCreateOpts.Cost, "cost", "", 1, "Specify a cost for this link.")
@@ -39,13 +39,13 @@ func NewCmdLinkCreate(skupperClient SkupperClient, flag string) *cobra.Command {
 
 var connectorRemoveOpts types.ConnectorRemoveOptions
 
-func NewCmdLinkDelete(skupperClient SkupperClient) *cobra.Command {
+func NewCmdLinkDelete(skupperClient SkupperLinkClient) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "delete <name>",
 		Short:  "Remove specified link",
 		Args:   cobra.ExactArgs(1),
 		PreRun: skupperClient.NewClient,
-		RunE:   skupperClient.LinkDelete,
+		RunE:   skupperClient.Delete,
 	}
 
 	return cmd
@@ -62,13 +62,13 @@ func allConnected(links []types.LinkStatus) bool {
 	return true
 }
 
-func NewCmdLinkStatus(skupperClient SkupperClient) *cobra.Command {
+func NewCmdLinkStatus(skupperClient SkupperLinkClient) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "status [<link-name>]",
 		Short:  "Check whether a link to another Skupper site is active",
 		Args:   cobra.MaximumNArgs(1),
 		PreRun: skupperClient.NewClient,
-		RunE:   skupperClient.LinkStatus,
+		RunE:   skupperClient.Status,
 	}
 	cmd.Flags().IntVar(&waitFor, "wait", 0, "The number of seconds to wait for links to become active")
 

--- a/cmd/skupper/skupper_link.go
+++ b/cmd/skupper/skupper_link.go
@@ -1,13 +1,6 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"time"
-
-	"k8s.io/apimachinery/pkg/api/errors"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/spf13/cobra"
@@ -25,9 +18,9 @@ func NewCmdLink() *cobra.Command {
 
 var connectorCreateOpts types.ConnectorCreateOptions
 
-func NewCmdLinkCreate(newClient cobraFunc, flag string) *cobra.Command {
+func NewCmdLinkCreate(skupperClient SkupperClient, flag string) *cobra.Command {
 
-	if flag == "" { //hack for backwards compatibility
+	if flag == "" { // hack for backwards compatibility
 		flag = "name"
 	}
 
@@ -35,44 +28,8 @@ func NewCmdLinkCreate(newClient cobraFunc, flag string) *cobra.Command {
 		Use:    "create <input-token-file>",
 		Short:  "Links this skupper site to the site that issued the token",
 		Args:   cobra.ExactArgs(1),
-		PreRun: newClient,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			silenceCobra(cmd)
-			siteConfig, err := cli.SiteConfigInspect(context.Background(), nil)
-			if err != nil {
-				fmt.Println("Unable to retrieve site config: ", err.Error())
-				os.Exit(1)
-			}
-			connectorCreateOpts.SkupperNamespace = cli.GetNamespace()
-			yaml, err := ioutil.ReadFile(args[0])
-			if err != nil {
-				return fmt.Errorf("Could not read connection token: %s", err.Error())
-			}
-			secret, err := cli.ConnectorCreateSecretFromData(context.Background(), yaml, connectorCreateOpts)
-			if err != nil {
-				return fmt.Errorf("Failed to create link: %w", err)
-			} else {
-				if secret.ObjectMeta.Labels[types.SkupperTypeQualifier] == types.TypeToken {
-					if siteConfig.Spec.RouterMode == string(types.TransportModeEdge) {
-						fmt.Printf("Site configured to link to %s:%s (name=%s)\n",
-							secret.ObjectMeta.Annotations["edge-host"],
-							secret.ObjectMeta.Annotations["edge-port"],
-							secret.ObjectMeta.Name)
-					} else {
-						fmt.Printf("Site configured to link to %s:%s (name=%s)\n",
-							secret.ObjectMeta.Annotations["inter-router-host"],
-							secret.ObjectMeta.Annotations["inter-router-port"],
-							secret.ObjectMeta.Name)
-					}
-				} else {
-					fmt.Printf("Site configured to link to %s (name=%s)\n",
-						secret.ObjectMeta.Annotations[types.ClaimUrlAnnotationKey],
-						secret.ObjectMeta.Name)
-				}
-			}
-			fmt.Println("Check the status of the link using 'skupper link status'.")
-			return nil
-		},
+		PreRun: skupperClient.NewClient,
+		RunE:   skupperClient.LinkCreate,
 	}
 	cmd.Flags().StringVarP(&connectorCreateOpts.Name, flag, "", "", "Provide a specific name for the link (used when deleting it)")
 	cmd.Flags().Int32VarP(&connectorCreateOpts.Cost, "cost", "", 1, "Specify a cost for this link.")
@@ -82,25 +39,13 @@ func NewCmdLinkCreate(newClient cobraFunc, flag string) *cobra.Command {
 
 var connectorRemoveOpts types.ConnectorRemoveOptions
 
-func NewCmdLinkDelete(newClient cobraFunc) *cobra.Command {
+func NewCmdLinkDelete(skupperClient SkupperClient) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "delete <name>",
 		Short:  "Remove specified link",
 		Args:   cobra.ExactArgs(1),
-		PreRun: newClient,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			silenceCobra(cmd)
-			connectorRemoveOpts.Name = args[0]
-			connectorRemoveOpts.SkupperNamespace = cli.GetNamespace()
-			connectorRemoveOpts.ForceCurrent = false
-			err := cli.ConnectorRemove(context.Background(), connectorRemoveOpts)
-			if err == nil {
-				fmt.Println("Link '" + args[0] + "' has been removed")
-			} else {
-				return fmt.Errorf("Failed to remove link: %w", err)
-			}
-			return nil
-		},
+		PreRun: skupperClient.NewClient,
+		RunE:   skupperClient.LinkDelete,
 	}
 
 	return cmd
@@ -117,74 +62,13 @@ func allConnected(links []types.LinkStatus) bool {
 	return true
 }
 
-func NewCmdLinkStatus(newClient cobraFunc) *cobra.Command {
+func NewCmdLinkStatus(skupperClient SkupperClient) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "status [<link-name>]",
 		Short:  "Check whether a link to another Skupper site is active",
 		Args:   cobra.MaximumNArgs(1),
-		PreRun: newClient,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			silenceCobra(cmd)
-
-			if len(args) == 1 && args[0] != "all" {
-				for i := 0; ; i++ {
-					if i > 0 {
-						time.Sleep(time.Second)
-					}
-					link, err := cli.ConnectorInspect(context.Background(), args[0])
-					if errors.IsNotFound(err) {
-						fmt.Printf("No such link %q", args[0])
-						fmt.Println()
-						break
-					} else if err != nil {
-						fmt.Println(err)
-						break
-					} else if link.Connected {
-						fmt.Printf("Link %s is active", link.Name)
-						fmt.Println()
-						break
-					} else if i == waitFor {
-						if link.Description != "" {
-							fmt.Printf("Link %s not active (%s)", link.Name, link.Description)
-						} else {
-							fmt.Printf("Link %s not active", link.Name)
-						}
-						fmt.Println()
-						break
-					}
-				}
-			} else {
-				for i := 0; ; i++ {
-					if i > 0 {
-						time.Sleep(time.Second)
-					}
-					links, err := cli.ConnectorList(context.Background())
-					if err != nil {
-						fmt.Println(err)
-						break
-					} else if allConnected(links) || i == waitFor {
-						if len(links) == 0 {
-							fmt.Println("There are no links configured or active")
-						}
-						for _, link := range links {
-							if link.Connected {
-								fmt.Printf("Link %s is active", link.Name)
-								fmt.Println()
-							} else {
-								if link.Description != "" {
-									fmt.Printf("Link %s not active (%s)", link.Name, link.Description)
-								} else {
-									fmt.Printf("Link %s not active", link.Name)
-								}
-								fmt.Println()
-							}
-						}
-						break
-					}
-				}
-			}
-			return nil
-		},
+		PreRun: skupperClient.NewClient,
+		RunE:   skupperClient.LinkStatus,
 	}
 	cmd.Flags().IntVar(&waitFor, "wait", 0, "The number of seconds to wait for links to become active")
 

--- a/cmd/skupper/skupper_mock_test.go
+++ b/cmd/skupper/skupper_mock_test.go
@@ -299,12 +299,10 @@ func (v *vanClientMock) NetworkStatus() ([]*types.SiteInfo, error) {
 }
 
 func TestCmdUnexposeRun(t *testing.T) {
-	skupperClient := &SkupperTestClient{}
+	skupperClient := NewSkupperTestClient()
 	cmd := NewCmdUnexpose(skupperClient)
 	test := func(targetType, targetName, address string) {
-
-		cli := cli.(*vanClientMock)
-
+		cli := skupperClient.Cli.(*vanClientMock)
 		unexposeAddress = address
 
 		args := []string{targetType}
@@ -338,12 +336,12 @@ func TestCmdUnexposeRun(t *testing.T) {
 	}
 
 	testSuccess := func(targetType, targetName, address string) {
-		cli = &vanClientMock{}
+		skupperClient.Cli = &vanClientMock{}
 		test(targetType, targetName, address)
 	}
 
 	testError := func(targetType, targetName, address string, errorString string) {
-		cli = &vanClientMock{
+		skupperClient.Cli = &vanClientMock{
 			injectedReturns: vanClientMockInjectedReturnValues{
 				serviceInterfaceUnbind: fmt.Errorf("%s", errorString),
 			},
@@ -360,13 +358,13 @@ func TestCmdUnexposeRun(t *testing.T) {
 
 func TestCmdInit(t *testing.T) {
 	skupperCli := NewSkupperTestClient()
+	skupperCli.Cli = &vanClientMock{}
 	cmd := NewCmdInit(skupperCli)
-	var lcli (*vanClientMock)
+	var lcli *vanClientMock
 	args := []string{}
 	resetCli := func() {
-		cli = &vanClientMock{}
-		lcli = cli.(*vanClientMock)
-		skupperCli.Cli = cli
+		lcli = &vanClientMock{}
+		skupperCli.Cli = lcli
 	}
 
 	t.Run("SiteConfigInspectReturnsError",
@@ -592,8 +590,7 @@ func TestExpose_Binding(t *testing.T) {
 func TestCmdExposeRun(t *testing.T) {
 	skupperCli := NewSkupperTestClient()
 	cmd := NewCmdExpose(skupperCli)
-	cli = &vanClientMock{} // the global cli is used by the "RunE" func
-	cli := cli.(*vanClientMock)
+	cli := &vanClientMock{} // the global cli is used by the "RunE" func
 	skupperCli.Cli = cli
 
 	args := []string{"service", "name"}
@@ -612,13 +609,13 @@ func TestCmdExposeRun(t *testing.T) {
 
 func TestCmdBind(t *testing.T) {
 	skupperCli := NewSkupperTestClient()
-	cmd := NewCmdBind(skupperCli)
 	var lcli *vanClientMock
+
+	cmd := NewCmdBind(skupperCli)
 	args := []string{}
 	resetCli := func() {
-		cli = &vanClientMock{}
-		lcli = cli.(*vanClientMock)
-		skupperCli.Cli = cli
+		lcli = &vanClientMock{}
+		skupperCli.Cli = lcli
 	}
 
 	t.Run("invalidProtocol",

--- a/cmd/skupper/skupper_mock_test.go
+++ b/cmd/skupper/skupper_mock_test.go
@@ -299,7 +299,8 @@ func (v *vanClientMock) NetworkStatus() ([]*types.SiteInfo, error) {
 }
 
 func TestCmdUnexposeRun(t *testing.T) {
-	cmd := NewCmdUnexpose(nil)
+	skupperClient := &SkupperTestClient{}
+	cmd := NewCmdUnexpose(skupperClient)
 	test := func(targetType, targetName, address string) {
 
 		cli := cli.(*vanClientMock)
@@ -358,12 +359,14 @@ func TestCmdUnexposeRun(t *testing.T) {
 }
 
 func TestCmdInit(t *testing.T) {
-	cmd := NewCmdInit(nil)
+	skupperCli := NewSkupperTestClient()
+	cmd := NewCmdInit(skupperCli)
 	var lcli (*vanClientMock)
 	args := []string{}
 	resetCli := func() {
 		cli = &vanClientMock{}
 		lcli = cli.(*vanClientMock)
+		skupperCli.Cli = cli
 	}
 
 	t.Run("SiteConfigInspectReturnsError",
@@ -587,9 +590,11 @@ func TestExpose_Binding(t *testing.T) {
 }
 
 func TestCmdExposeRun(t *testing.T) {
-	cmd := NewCmdExpose(nil)
+	skupperCli := NewSkupperTestClient()
+	cmd := NewCmdExpose(skupperCli)
 	cli = &vanClientMock{} // the global cli is used by the "RunE" func
 	cli := cli.(*vanClientMock)
+	skupperCli.Cli = cli
 
 	args := []string{"service", "name"}
 	exposeOpts.Address = ""
@@ -606,12 +611,14 @@ func TestCmdExposeRun(t *testing.T) {
 }
 
 func TestCmdBind(t *testing.T) {
-	cmd := NewCmdBind(nil)
+	skupperCli := NewSkupperTestClient()
+	cmd := NewCmdBind(skupperCli)
 	var lcli *vanClientMock
 	args := []string{}
 	resetCli := func() {
 		cli = &vanClientMock{}
 		lcli = cli.(*vanClientMock)
+		skupperCli.Cli = cli
 	}
 
 	t.Run("invalidProtocol",

--- a/cmd/skupper/skupper_mock_test.go
+++ b/cmd/skupper/skupper_mock_test.go
@@ -300,7 +300,7 @@ func (v *vanClientMock) NetworkStatus() ([]*types.SiteInfo, error) {
 
 func TestCmdUnexposeRun(t *testing.T) {
 	skupperClient := NewSkupperTestClient()
-	cmd := NewCmdUnexpose(skupperClient)
+	cmd := NewCmdUnexpose(skupperClient.Service())
 	test := func(targetType, targetName, address string) {
 		cli := skupperClient.Cli.(*vanClientMock)
 		unexposeAddress = address
@@ -359,7 +359,7 @@ func TestCmdUnexposeRun(t *testing.T) {
 func TestCmdInit(t *testing.T) {
 	skupperCli := NewSkupperTestClient()
 	skupperCli.Cli = &vanClientMock{}
-	cmd := NewCmdInit(skupperCli)
+	cmd := NewCmdInit(skupperCli.Site())
 	var lcli *vanClientMock
 	args := []string{}
 	resetCli := func() {
@@ -589,7 +589,7 @@ func TestExpose_Binding(t *testing.T) {
 
 func TestCmdExposeRun(t *testing.T) {
 	skupperCli := NewSkupperTestClient()
-	cmd := NewCmdExpose(skupperCli)
+	cmd := NewCmdExpose(skupperCli.Service())
 	cli := &vanClientMock{} // the global cli is used by the "RunE" func
 	skupperCli.Cli = cli
 
@@ -611,7 +611,7 @@ func TestCmdBind(t *testing.T) {
 	skupperCli := NewSkupperTestClient()
 	var lcli *vanClientMock
 
-	cmd := NewCmdBind(skupperCli)
+	cmd := NewCmdBind(skupperCli.Service())
 	args := []string{}
 	resetCli := func() {
 		lcli = &vanClientMock{}

--- a/cmd/skupper/skupper_network.go
+++ b/cmd/skupper/skupper_network.go
@@ -1,15 +1,9 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"strings"
-	"time"
 
 	"github.com/skupperproject/skupper/api/types"
-	"github.com/skupperproject/skupper/client"
-	"github.com/skupperproject/skupper/pkg/utils"
-	"github.com/skupperproject/skupper/pkg/utils/formatter"
 	"github.com/spf13/cobra"
 )
 
@@ -23,138 +17,13 @@ func NewCmdNetwork() *cobra.Command {
 
 var selectedSite string
 
-func NewCmdNetworkStatus(newClient cobraFunc) *cobra.Command {
+func NewCmdNetworkStatus(skupperClient SkupperClient) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "status",
 		Short:  "Shows information about the current site, and connected sites.",
 		Args:   cobra.MaximumNArgs(1),
-		PreRun: newClient,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			silenceCobra(cmd)
-
-			var sites []*types.SiteInfo
-			var errStatus error
-			err := utils.RetryError(time.Second, 3, func() error {
-				sites, errStatus = cli.NetworkStatus()
-
-				if errStatus != nil {
-					return errStatus
-				}
-
-				return nil
-			})
-
-			loadOnlyLocalInformation := false
-
-			if err != nil {
-				fmt.Printf("Unable to retrieve network information: %s", err)
-				fmt.Println()
-				fmt.Println()
-				fmt.Println("Loading just local information:")
-				loadOnlyLocalInformation = true
-			}
-
-			vir, err := cli.RouterInspect(context.Background())
-			if err != nil || vir == nil {
-				fmt.Printf("The router configuration is not available: %s", err)
-				fmt.Println()
-				return nil
-			}
-
-			siteConfig, err := cli.SiteConfigInspect(nil, nil)
-			if err != nil || siteConfig == nil {
-				fmt.Printf("The site configuration is not available: %s", err)
-				fmt.Println()
-				return nil
-			}
-
-			currentSite := siteConfig.Reference.UID
-
-			if loadOnlyLocalInformation {
-				printLocalStatus(vir.Status.TransportReadyReplicas, vir.Status.ConnectedSites.Warnings, vir.Status.ConnectedSites.Total, vir.Status.ConnectedSites.Direct, vir.ExposedServices)
-
-				serviceInterfaces, err := cli.ServiceInterfaceList(context.Background())
-				if err != nil {
-					fmt.Printf("Service local configuration is not available: %s", err)
-					fmt.Println()
-					return nil
-				}
-
-				sites = getLocalSiteInfo(serviceInterfaces, currentSite, vir.Status.SiteName, cli.GetNamespace(), vir.TransportVersion)
-			}
-
-			if sites != nil && len(sites) > 0 {
-				siteList := formatter.NewList()
-				siteList.Item("Sites:")
-				for _, site := range sites {
-
-					if site.Name != selectedSite && selectedSite != "all" {
-						continue
-					}
-
-					location := "remote"
-					siteVersion := site.Version
-					detailsMap := map[string]string{"name": site.Name, "namespace": site.Namespace, "URL": site.Url, "version": siteVersion}
-
-					if len(site.MinimumVersion) > 0 {
-						siteVersion = fmt.Sprintf("%s (minimum version required %s)", site.Version, site.MinimumVersion)
-					}
-
-					if site.SiteId == currentSite {
-						location = "local"
-						detailsMap["mode"] = vir.Status.Mode
-					}
-
-					newItem := fmt.Sprintf("[%s] %s - %s ", location, site.SiteId[:7], site.Name)
-
-					newItem = newItem + fmt.Sprintln()
-
-					if len(site.Links) > 0 {
-						detailsMap["sites linked to"] = fmt.Sprint(strings.Join(site.Links, ", "))
-					}
-
-					serviceLevel := siteList.NewChildWithDetail(newItem, detailsMap)
-					if len(site.Services) > 0 {
-						services := serviceLevel.NewChild("Services:")
-						var addresses []string
-						svcAuth := map[string]bool{}
-						for _, svc := range site.Services {
-							addresses = append(addresses, svc.Name)
-							svcAuth[svc.Name] = true
-						}
-						if vc, ok := cli.(*client.VanClient); ok && site.Namespace == cli.GetNamespace() {
-							policy := client.NewPolicyValidatorAPI(vc)
-							res, _ := policy.Services(addresses...)
-							for addr, auth := range res {
-								svcAuth[addr] = auth.Allowed
-							}
-						}
-						for _, svc := range site.Services {
-							authSuffix := ""
-							if !svcAuth[svc.Name] {
-								authSuffix = " - not authorized"
-							}
-							svcItem := "name: " + svc.Name + authSuffix + fmt.Sprintln()
-							detailsSvc := map[string]string{"protocol": svc.Protocol, "address": svc.Address}
-							targetLevel := services.NewChildWithDetail(svcItem, detailsSvc)
-
-							if len(svc.Targets) > 0 {
-								targets := targetLevel.NewChild("Targets:")
-								for _, target := range svc.Targets {
-									targets.NewChild("name: " + target.Name)
-
-								}
-							}
-
-						}
-					}
-				}
-
-				siteList.Print()
-			}
-
-			return nil
-		},
+		PreRun: skupperClient.NewClient,
+		RunE:   skupperClient.NetworkStatus,
 	}
 
 	cmd.Flags().StringVarP(&selectedSite, "site", "s", "all", "Site identifier")

--- a/cmd/skupper/skupper_network.go
+++ b/cmd/skupper/skupper_network.go
@@ -17,13 +17,13 @@ func NewCmdNetwork() *cobra.Command {
 
 var selectedSite string
 
-func NewCmdNetworkStatus(skupperClient SkupperClient) *cobra.Command {
+func NewCmdNetworkStatus(skupperClient SkupperNetworkClient) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "status",
 		Short:  "Shows information about the current site, and connected sites.",
 		Args:   cobra.MaximumNArgs(1),
 		PreRun: skupperClient.NewClient,
-		RunE:   skupperClient.NetworkStatus,
+		RunE:   skupperClient.Status,
 	}
 
 	cmd.Flags().StringVarP(&selectedSite, "site", "s", "all", "Site identifier")

--- a/cmd/skupper/skupper_podman.go
+++ b/cmd/skupper/skupper_podman.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/spf13/cobra"
+)
+
+type SkupperPodman struct {
+}
+
+func (s *SkupperPodman) NewClient(cmd *cobra.Command, args []string) {
+	fmt.Println("Not implemented")
+	os.Exit(1)
+}
+
+func (s *SkupperPodman) Platform() types.Platform {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (s *SkupperPodman) SupportedCommands() []string {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (s *SkupperPodman) Options(cmd *cobra.Command) {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (s *SkupperPodman) Init(cmd *cobra.Command, args []string) error {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (s *SkupperPodman) InitFlags(cmd *cobra.Command) {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (s *SkupperPodman) DebugDump(cmd *cobra.Command, args []string) error {
+	// TODO implement me
+	panic("implement me")
+}

--- a/cmd/skupper/skupper_podman.go
+++ b/cmd/skupper/skupper_podman.go
@@ -8,40 +8,165 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var notImplementedErr = fmt.Errorf("Not implemented")
+
+var SkupperPodmanCommands = []string{
+	"switch",
+}
+
 type SkupperPodman struct {
 }
 
-func (s *SkupperPodman) NewClient(cmd *cobra.Command, args []string) {
+func (s *SkupperPodman) notImplementedExit() {
 	fmt.Println("Not implemented")
 	os.Exit(1)
 }
 
+func (s *SkupperPodman) NewClient(cmd *cobra.Command, args []string) {
+	s.notImplementedExit()
+}
+
 func (s *SkupperPodman) Platform() types.Platform {
-	// TODO implement me
-	panic("implement me")
+	return types.PlatformPodman
+}
+
+func (s *SkupperPodman) Delete(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) Update(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) Status(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) Expose(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) ExposeArgs(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) ExposeFlags(cmd *cobra.Command) {
+}
+
+func (s *SkupperPodman) Unexpose(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) ServiceCreate(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) ServiceDelete(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) ServiceStatus(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) ServiceLabel(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) ServiceBind(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) ServiceBindArgs(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) ServiceBindFlags(cmd *cobra.Command) {
+}
+
+func (s *SkupperPodman) ServiceUnbind(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) Version(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) DebugEvents(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) DebugService(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) ListConnectors(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) LinkCreate(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) LinkDelete(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) LinkStatus(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) TokenCreate(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) RevokeAccess(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
+}
+
+func (s *SkupperPodman) NetworkStatus(cmd *cobra.Command, args []string) error {
+	s.notImplementedExit()
+	return notImplementedErr
 }
 
 func (s *SkupperPodman) SupportedCommands() []string {
-	// TODO implement me
-	panic("implement me")
+	return SkupperPodmanCommands
 }
 
 func (s *SkupperPodman) Options(cmd *cobra.Command) {
-	// TODO implement me
-	panic("implement me")
 }
 
 func (s *SkupperPodman) Init(cmd *cobra.Command, args []string) error {
-	// TODO implement me
-	panic("implement me")
+	s.notImplementedExit()
+	return notImplementedErr
 }
 
 func (s *SkupperPodman) InitFlags(cmd *cobra.Command) {
-	// TODO implement me
-	panic("implement me")
 }
 
 func (s *SkupperPodman) DebugDump(cmd *cobra.Command, args []string) error {
-	// TODO implement me
-	panic("implement me")
+	s.notImplementedExit()
+	return notImplementedErr
 }

--- a/cmd/skupper/skupper_podman.go
+++ b/cmd/skupper/skupper_podman.go
@@ -18,167 +18,40 @@ type SkupperPodman struct {
 }
 
 func (s *SkupperPodman) Site() SkupperSiteClient {
-	// TODO implement me
-	panic("implement me")
+	return &SkupperPodmanSite{}
 }
 
 func (s *SkupperPodman) Service() SkupperServiceClient {
-	// TODO implement me
-	panic("implement me")
+	return &SkupperPodmanService{}
 }
 
 func (s *SkupperPodman) Debug() SkupperDebugClient {
-	// TODO implement me
-	panic("implement me")
+	return &SkupperPodmanDebug{}
 }
 
 func (s *SkupperPodman) Link() SkupperLinkClient {
-	// TODO implement me
-	panic("implement me")
+	return &SkupperPodmanLink{}
 }
 
 func (s *SkupperPodman) Token() SkupperTokenClient {
-	// TODO implement me
-	panic("implement me")
+	return &SkupperPodmanToken{}
 }
 
 func (s *SkupperPodman) Network() SkupperNetworkClient {
-	// TODO implement me
-	panic("implement me")
+	return &SkupperPodmanNetwork{}
 }
 
-func (s *SkupperPodman) notImplementedExit() {
+func notImplementedExit() {
 	fmt.Println("Not implemented")
 	os.Exit(1)
 }
 
 func (s *SkupperPodman) NewClient(cmd *cobra.Command, args []string) {
-	s.notImplementedExit()
+	notImplementedExit()
 }
 
 func (s *SkupperPodman) Platform() types.Platform {
 	return types.PlatformPodman
-}
-
-func (s *SkupperPodman) Delete(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) Update(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) Status(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) Expose(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) ExposeArgs(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) ExposeFlags(cmd *cobra.Command) {
-}
-
-func (s *SkupperPodman) Unexpose(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) ServiceCreate(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) ServiceDelete(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) ServiceStatus(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) ServiceLabel(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) ServiceBind(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) ServiceBindArgs(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) ServiceBindFlags(cmd *cobra.Command) {
-}
-
-func (s *SkupperPodman) ServiceUnbind(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) Version(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) DebugEvents(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) DebugService(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) ListConnectors(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) LinkCreate(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) LinkDelete(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) LinkStatus(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) TokenCreate(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) RevokeAccess(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) NetworkStatus(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
 }
 
 func (s *SkupperPodman) SupportedCommands() []string {
@@ -186,17 +59,4 @@ func (s *SkupperPodman) SupportedCommands() []string {
 }
 
 func (s *SkupperPodman) Options(cmd *cobra.Command) {
-}
-
-func (s *SkupperPodman) Init(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
-}
-
-func (s *SkupperPodman) InitFlags(cmd *cobra.Command) {
-}
-
-func (s *SkupperPodman) DebugDump(cmd *cobra.Command, args []string) error {
-	s.notImplementedExit()
-	return notImplementedErr
 }

--- a/cmd/skupper/skupper_podman.go
+++ b/cmd/skupper/skupper_podman.go
@@ -17,6 +17,36 @@ var SkupperPodmanCommands = []string{
 type SkupperPodman struct {
 }
 
+func (s *SkupperPodman) Site() SkupperSiteClient {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (s *SkupperPodman) Service() SkupperServiceClient {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (s *SkupperPodman) Debug() SkupperDebugClient {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (s *SkupperPodman) Link() SkupperLinkClient {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (s *SkupperPodman) Token() SkupperTokenClient {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (s *SkupperPodman) Network() SkupperNetworkClient {
+	// TODO implement me
+	panic("implement me")
+}
+
 func (s *SkupperPodman) notImplementedExit() {
 	fmt.Println("Not implemented")
 	os.Exit(1)

--- a/cmd/skupper/skupper_podman_debug.go
+++ b/cmd/skupper/skupper_podman_debug.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/spf13/cobra"
+)
+
+type SkupperPodmanDebug struct {
+}
+
+func (s *SkupperPodmanDebug) Dump(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanDebug) Events(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanDebug) Service(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanDebug) NewClient(cmd *cobra.Command, args []string) {}
+
+func (s *SkupperPodmanDebug) Platform() types.Platform {
+	return types.PlatformPodman
+}

--- a/cmd/skupper/skupper_podman_link.go
+++ b/cmd/skupper/skupper_podman_link.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/spf13/cobra"
+)
+
+type SkupperPodmanLink struct {
+}
+
+func (s *SkupperPodmanLink) Create(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanLink) CreateFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanLink) Delete(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanLink) DeleteFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanLink) List(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanLink) ListFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanLink) Status(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanLink) StatusFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanLink) NewClient(cmd *cobra.Command, args []string) {}
+
+func (s *SkupperPodmanLink) Platform() types.Platform {
+	return types.PlatformPodman
+}

--- a/cmd/skupper/skupper_podman_network.go
+++ b/cmd/skupper/skupper_podman_network.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/spf13/cobra"
+)
+
+type SkupperPodmanNetwork struct {
+}
+
+func (s *SkupperPodmanNetwork) Status(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanNetwork) StatusFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanNetwork) NewClient(cmd *cobra.Command, args []string) {}
+
+func (s *SkupperPodmanNetwork) Platform() types.Platform {
+	return types.PlatformPodman
+}

--- a/cmd/skupper/skupper_podman_service.go
+++ b/cmd/skupper/skupper_podman_service.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/spf13/cobra"
+)
+
+type SkupperPodmanService struct {
+}
+
+func (s *SkupperPodmanService) Create(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanService) CreateFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanService) Delete(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanService) DeleteFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanService) List(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanService) ListFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanService) Status(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanService) StatusFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanService) NewClient(cmd *cobra.Command, args []string) {}
+
+func (s *SkupperPodmanService) Platform() types.Platform {
+	return types.PlatformPodman
+}
+
+func (s *SkupperPodmanService) Label(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanService) Bind(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanService) BindArgs(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanService) BindFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanService) Unbind(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanService) Expose(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanService) ExposeArgs(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanService) ExposeFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanService) Unexpose(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}

--- a/cmd/skupper/skupper_podman_site.go
+++ b/cmd/skupper/skupper_podman_site.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/spf13/cobra"
+)
+
+type SkupperPodmanSite struct{}
+
+func (s *SkupperPodmanSite) Create(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanSite) CreateFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanSite) Delete(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanSite) DeleteFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanSite) List(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanSite) ListFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanSite) Status(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanSite) StatusFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanSite) NewClient(cmd *cobra.Command, args []string) {}
+
+func (s *SkupperPodmanSite) Platform() types.Platform {
+	return types.PlatformPodman
+}
+
+func (s *SkupperPodmanSite) Update(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanSite) UpdateFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanSite) Version(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanSite) RevokeAccess(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}

--- a/cmd/skupper/skupper_podman_token.go
+++ b/cmd/skupper/skupper_podman_token.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/spf13/cobra"
+)
+
+type SkupperPodmanToken struct {
+}
+
+func (s *SkupperPodmanToken) Create(cmd *cobra.Command, args []string) error {
+	return notImplementedErr
+}
+
+func (s *SkupperPodmanToken) CreateFlags(cmd *cobra.Command) {}
+
+func (s *SkupperPodmanToken) NewClient(cmd *cobra.Command, args []string) {}
+
+func (s *SkupperPodmanToken) Platform() types.Platform {
+	return types.PlatformPodman
+}

--- a/cmd/skupper/skupper_switch.go
+++ b/cmd/skupper/skupper_switch.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/pkg/config"
+	"github.com/skupperproject/skupper/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdSwitch() *cobra.Command {
+	validPlatforms := []string{"kubernetes", "podman", "-"}
+	cmd := &cobra.Command{
+		Use:       "switch <platform>",
+		Short:     fmt.Sprintf("Select the platform to manage (valid platforms: %s)", strings.Join(validPlatforms, ", ")),
+		ValidArgs: validPlatforms,
+		Args:      cobra.OnlyValidArgs,
+		Example: `
+	# Display selected platform
+	skupper switch
+
+	# Switch to kubernetes
+	skupper switch kubernetes
+
+	# Switch to podman
+	skupper switch podman
+
+	# Switch back to the previous platform
+	skupper switch -`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+			currentPlatform := config.GetPlatform()
+			if len(args) == 0 {
+				fmt.Printf("%s\n", currentPlatform)
+				return nil
+			}
+			selectedPlatform := args[0]
+			p := &config.PlatformInfo{}
+			if err := p.Load(); err != nil {
+				return err
+			}
+			if selectedPlatform == "-" {
+				selectedPlatform = utils.DefaultStr(string(p.Previous), string(currentPlatform))
+				fmt.Printf("Switched to: %s\n", selectedPlatform)
+			}
+			return p.Update(types.Platform(selectedPlatform))
+		},
+	}
+
+	return cmd
+}

--- a/cmd/skupper/skupper_test.go
+++ b/cmd/skupper/skupper_test.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"flag"
-	"github.com/skupperproject/skupper/api/types"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/skupperproject/skupper/api/types"
 
 	"gotest.tools/assert"
 )
@@ -21,7 +22,7 @@ func TestParseTargetTypeAndName(t *testing.T) {
 }
 
 func TestBindArgs(t *testing.T) {
-	s := &SkupperKube{}
+	s := &SkupperKubeService{}
 	genericError := "Service name, target type and target name must all be specified (e.g. 'skupper bind <service-name> <target-type> <target-name>')"
 	b := func(args []string) error {
 		return s.bindArgs(nil, args)
@@ -68,7 +69,7 @@ func TestCreateServiceArgs(t *testing.T) {
 }
 
 func TestCreateServiceParseArgs(t *testing.T) {
-	cmd := NewCmdCreateService(NewSkupperTestClient())
+	cmd := NewCmdCreateService(NewSkupperTestClient().Service())
 
 	assert.Assert(t, cmd.ParseFlags([]string{}))
 	assert.Equal(t, serviceToCreate.EnableTls, false)
@@ -93,7 +94,7 @@ func TestCreateServiceParseArgs(t *testing.T) {
 }
 
 func TestExposeTargetArgs(t *testing.T) {
-	s := &SkupperKube{}
+	s := &SkupperKubeService{}
 	genericError := "expose target and name must be specified (e.g. 'skupper expose deployment <name>'"
 	targetError := "target type must be one of: [deployment, statefulset, pods, service]"
 
@@ -125,7 +126,7 @@ func TestExposeTargetArgs(t *testing.T) {
 
 func TestExposeParseArgs(t *testing.T) {
 	cmd_args := []string{"deployment/name", "--address", "theAddress"}
-	cmd := NewCmdExpose(NewSkupperTestClient())
+	cmd := NewCmdExpose(NewSkupperTestClient().Service())
 
 	assert.Assert(t, cmd.ParseFlags([]string{}))
 	assert.Equal(t, exposeOpts.Address, "")
@@ -143,13 +144,13 @@ func TestExposeParseArgs(t *testing.T) {
 
 func TestExposePublishNotReadyAddressesParseArgs(t *testing.T) {
 	cmdArgs := []string{"deployment/name", "--publish-not-ready-addresses"}
-	cmd := NewCmdExpose(NewSkupperTestClient())
+	cmd := NewCmdExpose(NewSkupperTestClient().Service())
 
 	assert.Assert(t, cmd.ParseFlags(cmdArgs))
 	assert.Equal(t, exposeOpts.PublishNotReadyAddresses, true)
 
 	cmdArgs2 := []string{"statefulset/web", "--headless", "--publish-not-ready-addresses"}
-	cmd2 := NewCmdExpose(NewSkupperTestClient())
+	cmd2 := NewCmdExpose(NewSkupperTestClient().Service())
 	assert.Assert(t, cmd2.ParseFlags(cmdArgs2))
 	assert.Equal(t, exposeOpts.Headless, true)
 	assert.Equal(t, exposeOpts.PublishNotReadyAddresses, true)
@@ -210,7 +211,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestSkupperInitConfigSyncParseArgs(t *testing.T) {
-	cmd := NewCmdInit(NewSkupperTestClient())
+	cmd := NewCmdInit(NewSkupperTestClient().Site())
 
 	assert.Assert(t, cmd.ParseFlags([]string{}))
 	assert.Equal(t, routerCreateOpts.ConfigSync.Cpu, "")
@@ -235,7 +236,7 @@ func TestSkupperInitConfigSyncParseArgs(t *testing.T) {
 }
 
 func TestSkupperInitControllerParseArgs(t *testing.T) {
-	cmd := NewCmdInit(NewSkupperTestClient())
+	cmd := NewCmdInit(NewSkupperTestClient().Site())
 
 	assert.Assert(t, cmd.ParseFlags([]string{}))
 	assert.Equal(t, routerCreateOpts.Controller.Cpu, "")
@@ -268,7 +269,7 @@ func TestSkupperInitControllerParseArgs(t *testing.T) {
 }
 
 func TestSkupperInitTimeoutParseArgs(t *testing.T) {
-	cmd := NewCmdInit(nil)
+	cmd := NewCmdInit(NewSkupperTestClient().Site())
 
 	assert.Assert(t, cmd.ParseFlags([]string{}))
 	assert.Equal(t, LoadBalancerTimeout, types.DefaultTimeoutDuration)

--- a/cmd/skupper/skupper_token.go
+++ b/cmd/skupper/skupper_token.go
@@ -23,7 +23,7 @@ var password string
 var expiry time.Duration
 var uses int
 
-func NewCmdTokenCreate(skupperClient SkupperClient, flag string) *cobra.Command {
+func NewCmdTokenCreate(skupperClient SkupperTokenClient, flag string) *cobra.Command {
 	subflag := ""
 	if flag == "client-identity" {
 		subflag = "i"
@@ -37,7 +37,7 @@ func NewCmdTokenCreate(skupperClient SkupperClient, flag string) *cobra.Command 
 		Short:  "Create a token.  The 'link create' command uses the token to establish a link from a remote Skupper site.",
 		Args:   cobra.ExactArgs(1),
 		PreRun: skupperClient.NewClient,
-		RunE:   skupperClient.TokenCreate,
+		RunE:   skupperClient.Create,
 	}
 	cmd.Flags().StringVarP(&clientIdentity, flag, subflag, types.DefaultVanName, "Provide a specific identity as which connecting skupper installation will be authenticated")
 	cmd.Flags().StringVarP(&tokenType, "token-type", "t", "claim", "Type of token to create. Valid options are 'claim' or 'cert'")

--- a/pkg/config/local.go
+++ b/pkg/config/local.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -50,7 +51,7 @@ func (p *PlatformInfo) Load() error {
 	}
 	if data != nil {
 		decoder := yaml.NewDecoder(bytes.NewReader(data))
-		if err = decoder.Decode(p); err != nil {
+		if err = decoder.Decode(p); err != nil && err != io.EOF {
 			return fmt.Errorf("error decoding %s: %v", PlatformConfigFile, err)
 		}
 	}

--- a/pkg/config/local.go
+++ b/pkg/config/local.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/pkg/utils"
+	yaml "gopkg.in/yaml.v3"
+)
+
+var (
+	PlatformConfigFile = path.Join(GetDataHome(), "platform.yaml")
+)
+
+type PlatformInfo struct {
+	Current  types.Platform `yaml:"current"`
+	Previous types.Platform `yaml:"previous"`
+}
+
+func (p *PlatformInfo) Update(platform types.Platform) error {
+	_ = p.Load()
+	if p.Current == "" {
+		p.Current = types.PlatformKubernetes
+	}
+	p.Previous = p.Current
+	p.Current = platform
+
+	f, err := os.Create(PlatformConfigFile)
+	if err != nil {
+		return fmt.Errorf("error creating file %s: %v", PlatformConfigFile, err)
+	}
+	defer f.Close()
+	e := yaml.NewEncoder(f)
+	if err = e.Encode(p); err != nil {
+		return fmt.Errorf("error saving file: %s: %v", PlatformConfigFile, err)
+	}
+	return nil
+}
+
+func (p *PlatformInfo) Load() error {
+	data, err := ioutil.ReadFile(PlatformConfigFile)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("error loading %s: %v", PlatformConfigFile, err)
+	}
+	if data != nil {
+		decoder := yaml.NewDecoder(bytes.NewReader(data))
+		if err = decoder.Decode(p); err != nil {
+			return fmt.Errorf("error decoding %s: %v", PlatformConfigFile, err)
+		}
+	}
+	return nil
+}
+
+var (
+	Platform string
+)
+
+func GetPlatform() types.Platform {
+	p := &PlatformInfo{}
+	_ = p.Load()
+	return types.Platform(utils.DefaultStr(Platform,
+		os.Getenv(types.ENV_PLATFORM),
+		string(p.Current),
+		string(types.PlatformKubernetes)))
+}
+
+func GetDataHome() string {
+	dataHome, ok := os.LookupEnv("XDG_DATA_HOME")
+	if !ok {
+		homeDir, _ := os.UserHomeDir()
+		dataHome = homeDir + "/.local/share"
+	}
+	return path.Join(dataHome, "skupper")
+}
+
+func GetConfigHome() string {
+	configHome, ok := os.LookupEnv("XDG_CONFIG_HOME")
+	if !ok {
+		homeDir, _ := os.UserHomeDir()
+		return homeDir + "/.config"
+	} else {
+		return configHome
+	}
+}

--- a/pkg/config/local.go
+++ b/pkg/config/local.go
@@ -22,9 +22,11 @@ type PlatformInfo struct {
 }
 
 func (p *PlatformInfo) Update(platform types.Platform) error {
-	_ = p.Load()
+	if err := p.Load(); err != nil {
+		return err
+	}
 	if p.Current == "" {
-		p.Current = types.PlatformKubernetes
+		p.Current = platform
 	}
 	p.Previous = p.Current
 	p.Current = platform

--- a/pkg/config/local_test.go
+++ b/pkg/config/local_test.go
@@ -1,0 +1,376 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/skupperproject/skupper/api/types"
+	"gopkg.in/yaml.v3"
+	"gotest.tools/assert"
+)
+
+func TestGetConfigHome(t *testing.T) {
+	const XDG_CONFIG_HOME = "XDG_CONFIG_HOME"
+	const HOME = "HOME"
+
+	tests := []struct {
+		name          string
+		want          string
+		homeDir       string
+		xdgConfigHome string
+	}{
+		{
+			name:          "xdg-config-home-unset",
+			want:          "/home/skupper/.config",
+			homeDir:       "/home/skupper",
+			xdgConfigHome: "",
+		},
+		{
+			name:          "xdg-config-home-set",
+			want:          "/home/skupper/.custom",
+			homeDir:       "/home/skupper",
+			xdgConfigHome: "/home/skupper/.custom",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var xdgConfigHomeOrig = os.Getenv(XDG_CONFIG_HOME)
+			var homeOrig = os.Getenv(HOME)
+
+			if tt.xdgConfigHome != "" {
+				_ = os.Setenv(XDG_CONFIG_HOME, tt.xdgConfigHome)
+			}
+			if tt.homeDir != "" {
+				_ = os.Setenv(HOME, tt.homeDir)
+			}
+			got := GetConfigHome()
+			_ = os.Setenv(XDG_CONFIG_HOME, xdgConfigHomeOrig)
+			_ = os.Setenv(HOME, homeOrig)
+			if got != tt.want {
+				t.Errorf("GetConfigHome() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetDataHome(t *testing.T) {
+	const XDG_DATA_HOME = "XDG_DATA_HOME"
+	const HOME = "HOME"
+
+	tests := []struct {
+		name        string
+		want        string
+		homeDir     string
+		xdgDataHome string
+	}{
+		{
+			name:        "xdg-data-home-unset",
+			want:        "/home/skupper/.local/share/skupper",
+			homeDir:     "/home/skupper",
+			xdgDataHome: "",
+		},
+		{
+			name:        "xdg-data-home-set",
+			want:        "/home/skupper/.custom/skupper",
+			homeDir:     "/home/skupper",
+			xdgDataHome: "/home/skupper/.custom",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var xdgDataHomeOrig = os.Getenv(XDG_DATA_HOME)
+			var homeOrig = os.Getenv(HOME)
+
+			if tt.xdgDataHome != "" {
+				_ = os.Setenv(XDG_DATA_HOME, tt.xdgDataHome)
+			}
+			if tt.homeDir != "" {
+				_ = os.Setenv(HOME, tt.homeDir)
+			}
+			got := GetDataHome()
+			_ = os.Setenv(XDG_DATA_HOME, xdgDataHomeOrig)
+			_ = os.Setenv(HOME, homeOrig)
+			if got != tt.want {
+				t.Errorf("GetDataHome() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPlatform(t *testing.T) {
+	tests := []struct {
+		name   string
+		want   types.Platform
+		cliVar string
+		envVar string
+		cfgVal types.Platform
+	}{
+		{
+			name:   "default-as-nothing-set",
+			want:   "kubernetes",
+			cliVar: "",
+			envVar: "",
+			cfgVal: "",
+		},
+		{
+			name:   "podman-as-cli-flag-set",
+			want:   "podman",
+			cliVar: "podman",
+			envVar: "",
+			cfgVal: "",
+		},
+		{
+			name:   "podman-as-cli-flag-set-highest-precedence",
+			want:   "podman",
+			cliVar: "podman",
+			envVar: "kubernetes",
+			cfgVal: types.PlatformKubernetes,
+		},
+		{
+			name:   "podman-as-envvar-set",
+			want:   "podman",
+			cliVar: "",
+			envVar: "podman",
+			cfgVal: "",
+		},
+		{
+			name:   "podman-as-envvar-set-over-config",
+			want:   "podman",
+			cliVar: "",
+			envVar: "podman",
+			cfgVal: types.PlatformKubernetes,
+		},
+		{
+			name:   "podman-as-config-set",
+			want:   "podman",
+			cliVar: "",
+			envVar: "",
+			cfgVal: types.PlatformPodman,
+		},
+	}
+	// Saving original values
+	cliOrig := Platform
+	envOrig := os.Getenv(types.ENV_PLATFORM)
+	cfgFileOrig := PlatformConfigFile
+	// Restore original values
+	defer func() {
+		Platform = cliOrig
+		_ = os.Setenv(types.ENV_PLATFORM, envOrig)
+		PlatformConfigFile = cfgFileOrig
+	}()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Platform = tt.cliVar
+			_ = os.Setenv(types.ENV_PLATFORM, tt.envVar)
+
+			// creating a temporary platform file
+			f, err := os.CreateTemp(os.TempDir(), "platform-*.yaml")
+			_ = f.Close()
+			assert.Assert(t, err, "unable to create temporary platform file")
+			PlatformConfigFile = f.Name()
+			if tt.cfgVal == "" {
+				_ = os.Remove(f.Name())
+			} else {
+				info := &PlatformInfo{}
+				assert.Assert(t, info.Update(tt.cfgVal), "error setting platform in %s", f.Name())
+			}
+
+			got := GetPlatform()
+
+			// removing temporary file
+			if tt.cfgVal != "" {
+				_ = os.Remove(f.Name())
+			}
+			if got != tt.want {
+				t.Errorf("GetPlatform() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlatformInfo_Load(t *testing.T) {
+	tests := []struct {
+		name          string
+		existing      *PlatformInfo
+		want          *PlatformInfo
+		wantReadErr   bool
+		wantDecodeErr bool
+	}{
+		{
+			name:     "default-no-config-file",
+			existing: nil,
+			want:     &PlatformInfo{},
+		},
+		{
+			name:        "error-no-permission",
+			existing:    nil,
+			want:        &PlatformInfo{},
+			wantReadErr: true,
+		},
+		{
+			name:          "error-invalid-content",
+			existing:      &PlatformInfo{},
+			want:          &PlatformInfo{},
+			wantDecodeErr: true,
+		},
+		{
+			name: "valid-config-file",
+			existing: &PlatformInfo{
+				Current:  types.PlatformPodman,
+				Previous: types.PlatformKubernetes,
+			},
+			want: &PlatformInfo{
+				Current:  types.PlatformPodman,
+				Previous: types.PlatformKubernetes,
+			},
+		},
+	}
+	// Saving original values
+	cfgFileOrig := PlatformConfigFile
+	// Restore original values
+	defer func() {
+		PlatformConfigFile = cfgFileOrig
+	}()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := os.CreateTemp(os.TempDir(), "platform-*.yaml")
+			tempFile := f.Name()
+			assert.Assert(t, err, "error creating temporary platform config file")
+			tempFile = f.Name()
+			defer func(name string) {
+				_ = os.Remove(name)
+			}(tempFile)
+			PlatformConfigFile = tempFile
+			if !tt.wantReadErr {
+				_ = os.Remove(tempFile)
+			} else {
+				_ = os.Chmod(tempFile, 0)
+			}
+			if tt.existing == nil {
+				tt.existing = &PlatformInfo{}
+			} else if !tt.wantReadErr {
+				// populating temp file
+				info := tt.existing
+				var data string
+				if !tt.wantDecodeErr {
+					data = fmt.Sprintf("current: %s\nprevious: %s\n", info.Current, info.Previous)
+				} else {
+					data = `invalid content`
+				}
+				assert.Assert(t, os.WriteFile(tempFile, []byte(data), 0644), "error writing to temporary file")
+			}
+			wantErr := tt.wantReadErr || tt.wantDecodeErr
+			if err := tt.existing.Load(); (err != nil) != wantErr {
+				t.Errorf("Load() error = %v, wantReadErr %v", err, tt.wantReadErr)
+			}
+			assert.Assert(t, reflect.DeepEqual(tt.existing, tt.want), "want = %v, got = %v", tt.want, tt.existing)
+		})
+	}
+}
+
+func TestPlatformInfo_Update(t *testing.T) {
+	tests := []struct {
+		name         string
+		existing     *PlatformInfo
+		platform     types.Platform
+		want         *PlatformInfo
+		wantWriteErr bool
+		wantReadErr  bool
+	}{
+		{
+			name:     "new-config-file",
+			existing: nil,
+			platform: types.PlatformPodman,
+			want: &PlatformInfo{
+				Current:  types.PlatformPodman,
+				Previous: types.PlatformPodman,
+			},
+		},
+		{
+			name: "config-file-changed",
+			existing: &PlatformInfo{
+				Current:  types.PlatformKubernetes,
+				Previous: types.PlatformKubernetes,
+			},
+			platform: types.PlatformPodman,
+			want: &PlatformInfo{
+				Current:  types.PlatformPodman,
+				Previous: types.PlatformKubernetes,
+			},
+		},
+		{
+			name: "error-no-write-permission",
+			existing: &PlatformInfo{
+				Current:  types.PlatformKubernetes,
+				Previous: types.PlatformKubernetes,
+			},
+			platform: types.PlatformPodman,
+			want: &PlatformInfo{
+				Current:  types.PlatformKubernetes,
+				Previous: types.PlatformKubernetes,
+			},
+			wantWriteErr: true,
+		},
+		{
+			name: "error-no-read-permission",
+			existing: &PlatformInfo{
+				Current:  types.PlatformKubernetes,
+				Previous: types.PlatformKubernetes,
+			},
+			platform:    types.PlatformPodman,
+			want:        &PlatformInfo{},
+			wantReadErr: true,
+		},
+	}
+	// Saving original values
+	cfgFileOrig := PlatformConfigFile
+	// Restore original values
+	defer func() {
+		PlatformConfigFile = cfgFileOrig
+	}()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := os.TempDir()
+			f, err := os.CreateTemp(tempDir, "platform-*.yaml")
+			assert.Assert(t, err, "error creating temporary platform config file")
+			_ = f.Close()
+			tempFile := f.Name()
+			defer func(name string) {
+				_ = os.Remove(name)
+			}(tempFile)
+			PlatformConfigFile = tempFile
+			if tt.existing == nil {
+				_ = os.Remove(tempFile)
+				tt.existing = &PlatformInfo{}
+			} else {
+				data := fmt.Sprintf("current: %s\nprevious: %s\n", tt.existing.Current, tt.existing.Previous)
+				assert.Assert(t, os.WriteFile(tempFile, []byte(data), 0644), "error preparing platform config file")
+			}
+
+			if tt.wantWriteErr {
+				_ = os.Chmod(tempFile, 0444)
+			} else if tt.wantReadErr {
+				_ = os.Chmod(tempFile, 0)
+			}
+
+			wantErr := tt.wantWriteErr || tt.wantReadErr
+			if err := tt.existing.Update(tt.platform); (err != nil) != wantErr {
+				t.Errorf("Update() error = %v, wantErr %v", err, wantErr)
+			}
+
+			// loading file
+			if tt.want != nil {
+				data, _ := ioutil.ReadFile(tempFile)
+				decoder := yaml.NewDecoder(bytes.NewReader(data))
+				current := &PlatformInfo{}
+				_ = decoder.Decode(current)
+				assert.Assert(t, reflect.DeepEqual(tt.want, current), "want = %v, got = %v", tt.want, current)
+			}
+		})
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -127,3 +127,14 @@ func StringSlicesEqual(a, b []string) bool {
 	}
 	return true
 }
+
+// DefaultStr returns the first non-empty string
+func DefaultStr(values ...string) string {
+	if len(values) == 1 {
+		return values[0]
+	}
+	if values[0] != "" {
+		return values[0]
+	}
+	return DefaultStr(values[1:]...)
+}

--- a/test/integration/acceptance/gateway_test.go
+++ b/test/integration/acceptance/gateway_test.go
@@ -40,7 +40,6 @@ func TestGateway(t *testing.T) {
 	t.Run("local-gateway-service", testLocalGatewayService)
 	t.Run("local-gateway-docker", testLocalGatewayDocker)
 	t.Run("local-gateway-podman", testLocalGatewayPodman)
-
 }
 
 //

--- a/test/utils/skupper/cli/gateway/init.go
+++ b/test/utils/skupper/cli/gateway/init.go
@@ -128,6 +128,33 @@ func (i *InitTester) Run(cluster *base.ClusterContext) (stdout string, stderr st
 		return
 	}
 
+	expectAvailable := true
+	if i.isService() {
+		// Validating systemd user service created
+		available := SystemdUnitAvailable(gatewayName)
+		if available != expectAvailable {
+			err = fmt.Errorf("systemd unit %s.service availability issue - available: %v - expected: %v", gatewayName, available, expectAvailable)
+			return
+		}
+
+		// Validating systemd user service enabled
+		enabled := SystemdUnitEnabled(gatewayName)
+		if enabled != expectAvailable {
+			err = fmt.Errorf("systemd unit %s.service availability issue - enabled: %v - expected: %v", gatewayName, enabled, expectAvailable)
+			return
+		}
+	} else if i.Type == "docker" {
+		available, _ := IsDockerContainerRunning(gatewayName)
+		if available != expectAvailable {
+			err = fmt.Errorf("docker container %s availability issue - enabled: %v - expected: %v", gatewayName, available, expectAvailable)
+		}
+	} else if i.Type == "podman" {
+		available, _ := IsPodmanContainerRunning(gatewayName)
+		if available != expectAvailable {
+			err = fmt.Errorf("podman container %s availability issue - enabled: %v - expected: %v", gatewayName, available, expectAvailable)
+		}
+	}
+
 	// Setting Generated Name
 	if i.GeneratedName != nil {
 		*i.GeneratedName = gatewayName


### PR DESCRIPTION
This PR introduces a new `switch` command that will be used to control the target
platform to be manipulated by the `skupper` CLI.

Along with the `switch` command, it also introduces a new environment variable
named `SKUPPER_PLATFORM` and a new CLI option `--platform` that can be
used to override the currently defined platform.

At this point, both the `switch` command and the `--platform` option have been
marked as hidden.

In order to support different platforms through the CLI, it also introduces the
`SkupperClient` interface, which must be implemented by each supported
platform so that the supported commands can be executed properly.

The interface is now used by the existing command functions. The reason for
this choice was that the existing functions can be reused as well as the common
command definitions, flags and eventual generic behavior can be preserved, while
platform specific flags and implementation details can be customized as needed.