### PR TITLE
Adding HTTP API for revoke-access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build-get:
 	go build -ldflags="${LDFLAGS}"  -o get ./cmd/get
 
 build-service-controller:
-	go build -ldflags="${LDFLAGS}"  -o service-controller cmd/service-controller/main.go cmd/service-controller/controller.go cmd/service-controller/ports.go cmd/service-controller/definition_monitor.go cmd/service-controller/console_server.go cmd/service-controller/site_query.go cmd/service-controller/ip_lookup.go cmd/service-controller/claim_verifier.go cmd/service-controller/token_handler.go cmd/service-controller/secret_controller.go cmd/service-controller/claim_handler.go cmd/service-controller/tokens.go cmd/service-controller/links.go cmd/service-controller/services.go cmd/service-controller/policies.go cmd/service-controller/policy_controller.go
+	go build -ldflags="${LDFLAGS}"  -o service-controller cmd/service-controller/main.go cmd/service-controller/controller.go cmd/service-controller/ports.go cmd/service-controller/definition_monitor.go cmd/service-controller/console_server.go cmd/service-controller/site_query.go cmd/service-controller/ip_lookup.go cmd/service-controller/claim_verifier.go cmd/service-controller/token_handler.go cmd/service-controller/secret_controller.go cmd/service-controller/claim_handler.go cmd/service-controller/tokens.go cmd/service-controller/links.go cmd/service-controller/services.go cmd/service-controller/policies.go cmd/service-controller/policy_controller.go cmd/service-controller/sites.go
 
 build-site-controller:
 	go build -ldflags="${LDFLAGS}"  -o site-controller cmd/site-controller/main.go cmd/site-controller/controller.go

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build-get:
 	go build -ldflags="${LDFLAGS}"  -o get ./cmd/get
 
 build-service-controller:
-	go build -ldflags="${LDFLAGS}"  -o service-controller cmd/service-controller/main.go cmd/service-controller/controller.go cmd/service-controller/ports.go cmd/service-controller/definition_monitor.go cmd/service-controller/console_server.go cmd/service-controller/site_query.go cmd/service-controller/ip_lookup.go cmd/service-controller/claim_verifier.go cmd/service-controller/token_handler.go cmd/service-controller/secret_controller.go cmd/service-controller/claim_handler.go cmd/service-controller/tokens.go cmd/service-controller/links.go cmd/service-controller/services.go cmd/service-controller/policies.go cmd/service-controller/policy_controller.go cmd/service-controller/sites.go
+	go build -ldflags="${LDFLAGS}"  -o service-controller cmd/service-controller/main.go cmd/service-controller/controller.go cmd/service-controller/ports.go cmd/service-controller/definition_monitor.go cmd/service-controller/console_server.go cmd/service-controller/site_query.go cmd/service-controller/ip_lookup.go cmd/service-controller/claim_verifier.go cmd/service-controller/token_handler.go cmd/service-controller/secret_controller.go cmd/service-controller/claim_handler.go cmd/service-controller/tokens.go cmd/service-controller/links.go cmd/service-controller/services.go cmd/service-controller/policies.go cmd/service-controller/policy_controller.go cmd/service-controller/revoke_access.go
 
 build-site-controller:
 	go build -ldflags="${LDFLAGS}"  -o site-controller cmd/site-controller/main.go cmd/site-controller/controller.go

--- a/cmd/service-controller/console_server.go
+++ b/cmd/service-controller/console_server.go
@@ -35,6 +35,7 @@ type ConsoleServer struct {
 	links     *LinkManager
 	services  *ServiceManager
 	policies  *PolicyManager
+	sites     *SiteManager
 }
 
 func newConsoleServer(cli *client.VanClient, config *tls.Config) *ConsoleServer {
@@ -45,6 +46,7 @@ func newConsoleServer(cli *client.VanClient, config *tls.Config) *ConsoleServer 
 		links:     newLinkManager(cli, pool),
 		services:  newServiceManager(cli),
 		policies:  newPolicyManager(cli),
+		sites:     newSiteManager(cli),
 	}
 }
 
@@ -402,6 +404,7 @@ func (server *ConsoleServer) listen() {
 	r.Handle("/links", authenticated(serveLinks(server.links)))
 	r.Handle("/links/", authenticated(serveLinks(server.links)))
 	r.Handle("/links/{name}", authenticated(serveLinks(server.links)))
+	r.Handle("/revokeaccess", authenticated(serveSites(server.sites)))
 	r.Handle("/services", authenticated(serveServices(server.services)))
 	r.Handle("/services/", authenticated(serveServices(server.services)))
 	r.Handle("/services/{name}", authenticated(serveServices(server.services)))

--- a/cmd/service-controller/revoke_access.go
+++ b/cmd/service-controller/revoke_access.go
@@ -7,21 +7,17 @@ import (
 	"github.com/skupperproject/skupper/client"
 )
 
-const (
-	SiteManagement string = "SiteManagement"
-)
-
-type SiteManager struct {
+type AccessRevoker struct {
 	cli *client.VanClient
 }
 
-func newSiteManager(cli *client.VanClient) *SiteManager {
-	return &SiteManager{
+func newAccessRevoker(cli *client.VanClient) *AccessRevoker {
+	return &AccessRevoker{
 		cli: cli,
 	}
 }
 
-func (m *SiteManager) revokeAccess() error {
+func (m *AccessRevoker) revokeAccess() error {
 	err := m.cli.RevokeAccess(context.Background())
 	if err != nil {
 		return err
@@ -29,9 +25,9 @@ func (m *SiteManager) revokeAccess() error {
 	return nil
 }
 
-func serveSites(m *SiteManager) http.Handler {
+func serveAccessRevoker(m *AccessRevoker) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodDelete {
+		if r.Method == http.MethodPost {
 			err := m.revokeAccess()
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/cmd/service-controller/sites.go
+++ b/cmd/service-controller/sites.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/skupperproject/skupper/client"
+)
+
+const (
+	SiteManagement string = "SiteManagement"
+)
+
+type SiteManager struct {
+	cli *client.VanClient
+}
+
+func newSiteManager(cli *client.VanClient) *SiteManager {
+	return &SiteManager{
+		cli: cli,
+	}
+}
+
+func (m *SiteManager) revokeAccess() error {
+	err := m.cli.RevokeAccess(context.Background())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func serveSites(m *SiteManager) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			err := m.revokeAccess()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		} else if r.Method != http.MethodOptions {
+			http.Error(w, "Invalid method", http.StatusMethodNotAllowed)
+		}
+	})
+}


### PR DESCRIPTION
Resolves https://github.com/skupperproject/skupper/issues/849

`revoke-access` is only (currently) available via the Skupper CLI. This change will make it available via the HTTP API also, for example, in response to the following request:

`curl --location --request POST 'https://skupper-host/revokeaccess'`

### DATA response before hitting revokeaccess endpoint
<img width="554" alt="image" src="https://user-images.githubusercontent.com/65195049/184327874-53ea116e-7cc6-4187-8f8b-18b040230eff.png">

### revokeaccess request
<img width="437" alt="image" src="https://user-images.githubusercontent.com/65195049/184336232-2c8fe96c-fcf5-4fb8-980e-6dd0f5192f16.png">

### DATA response after hitting revokeaccess endpoint
<img width="566" alt="image" src="https://user-images.githubusercontent.com/65195049/184328916-8a29923b-50b7-4081-b8f9-fb92e465fe4c.png">

