### PR TITLE
Mongo replicaset fix

### DIFF
--- a/test/integration/examples/mongodb/job/mongojob_test.go
+++ b/test/integration/examples/mongodb/job/mongojob_test.go
@@ -27,6 +27,10 @@ var DB_NAME = "my_database"
 var COLLECTION_NAME = "posts"
 
 func TestMongoJob(t *testing.T) {
+	log.Print("Starting test job")
+	defer func() {
+		log.Print("Test job finished")
+	}()
 	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 
@@ -42,30 +46,40 @@ func TestMongoJob(t *testing.T) {
 	// we want to connect directly to each instance, so we make changes in one and
 	// see the results in the other, confirming the connectivity between them,
 	// through Skupper.
+	log.Print("connecting client a")
 	client_a := getClient("mongodb://mongo-a:27017")
-	client_b := getClient("mongodb://mongo-b:27017")
-	client_c := getClient("mongodb://mongo-c:27017")
 	defer client_a.Disconnect(ctx)
+	log.Print("connecting client b")
+	client_b := getClient("mongodb://mongo-b:27017")
 	defer client_b.Disconnect(ctx)
+	log.Print("connecting client c")
+	client_c := getClient("mongodb://mongo-c:27017")
 	defer client_c.Disconnect(ctx)
 
 	// needed in case of a retry
+	log.Print("Dropping posts")
 	err := DropAllPosts(client_a, ctx)
 	assert.Assert(t, err)
 
+	log.Print("Inserting posts")
 	err = InsertAllPosts(client_a, ctx)
 	assert.Assert(t, err)
 
+	log.Print("Counting documents on client b")
 	err = CountDocuments(client_b, TOTAL_DB_DOCUMENTS, ctx)
 	assert.Assert(t, err)
+	log.Print("Counting documents on client c")
 	err = CountDocuments(client_c, TOTAL_DB_DOCUMENTS, ctx)
 	assert.Assert(t, err)
 
+	log.Print("Popping posts")
 	err = PopAllExpectedPosts(client_a, ctx)
 	assert.Assert(t, err)
 
+	log.Print("Counting again on b, expecting zero")
 	err = CountDocuments(client_b, 0, ctx)
 	assert.Assert(t, err)
+	log.Print("Counting again on c, expecting zero")
 	err = CountDocuments(client_c, 0, ctx)
 	assert.Assert(t, err)
 }

--- a/test/integration/examples/mongodb/mongo.go
+++ b/test/integration/examples/mongodb/mongo.go
@@ -2,10 +2,15 @@ package mongodb
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/skupperproject/skupper/api/types"
 	vanClient "github.com/skupperproject/skupper/client"
+	"github.com/skupperproject/skupper/pkg/utils"
 	"github.com/skupperproject/skupper/test/utils/base"
 	"github.com/skupperproject/skupper/test/utils/constants"
 	"github.com/skupperproject/skupper/test/utils/k8s"
@@ -21,12 +26,53 @@ func RunTests(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) 
 	prvCluster1, err := r.GetPrivateContext(1)
 	assert.Assert(t, err)
 
+	defer func() {
+		log.Print("Replicaset status at the end of the test")
+		prvCluster1.KubectlExec(`exec deploy/mongo-a -- mongo --host 127.0.0.1:27017 --eval 'rs.status()'`)
+	}()
+
 	_, err = k8s.WaitForSkupperServiceToBeCreatedAndReadyToUse(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, "mongo-a")
 	assert.Assert(t, err)
 	_, err = k8s.WaitForSkupperServiceToBeCreatedAndReadyToUse(prvCluster1.Namespace, prvCluster1.VanClient.KubeClient, "mongo-b")
 	assert.Assert(t, err)
+	_, err = k8s.WaitForSkupperServiceToBeCreatedAndReadyToUse(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, "mongo-c")
+	assert.Assert(t, err)
 
-	_, err = prvCluster1.KubectlExec(`exec deploy/mongo-a -- mongo --host 127.0.0.1:27017 --eval 'rs.initiate({ _id : "rs0", members: [ { _id: 0, host: "mongo-a:27017" }, { _id: 1, host: "mongo-b:27017" }]})'`)
+	// Make sure you have a minimum of three members on the replicaset
+	// https://www.mongodb.com/docs/manual/tutorial/deploy-replica-set/
+	// https://www.mongodb.com/docs/manual/core/replica-set-architecture-three-members/
+	_, err = prvCluster1.KubectlExec(
+		`exec deploy/mongo-a -- mongo --host 127.0.0.1:27017 --eval '
+		var resp = rs.initiate(
+			{ 
+				_id : "rs0", 
+				members: [ 
+					{ _id: 0, host: "mongo-a:27017", priority: 3 }, 
+					{ _id: 1, host: "mongo-b:27017", priority: 2 },
+					{ _id: 2, host: "mongo-c:27017", priority: 1 }
+				]
+			}
+		); 
+		printjson (resp);
+		if (resp.ok != 1) {
+			quit(1);
+		}'
+	`)
+	assert.Assert(t, err)
+
+	// Let's wait until the election is settled, for a maximum of 5 min
+	log.Print("Waiting for the Mongo replicaset primary member election to be settled")
+	err = utils.RetryError(5*time.Second, 12*5, func() error {
+		out, err := prvCluster1.KubectlExec(`exec deploy/mongo-a -- mongo --host 127.0.0.1:27017 --eval 'db.hello().primary' --quiet`)
+		if err != nil {
+			return err
+		}
+		if string(out) == "" {
+			return fmt.Errorf("No primary elected for the Mongo replicaset")
+		}
+		log.Printf("Mongo primary election settled: %v.  Proceeding", strings.TrimSpace(string(out)))
+		return nil
+	})
 	assert.Assert(t, err)
 
 	jobName := "mongo"
@@ -59,6 +105,9 @@ func Setup(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) {
 	_, err = pub1Cluster.KubectlExec("apply -f https://raw.githubusercontent.com/skupperproject/skupper-example-mongodb-replica-set/master/deployment-mongo-b.yaml")
 	assert.Assert(t, err)
 
+	_, err = pub1Cluster.KubectlExec("apply -f https://raw.githubusercontent.com/skupperproject/skupper-example-mongodb-replica-set/master/deployment-mongo-c.yaml")
+	assert.Assert(t, err)
+
 	expose := func(name string, cli *vanClient.VanClient) {
 		t.Helper()
 		service := types.ServiceInterface{
@@ -76,7 +125,8 @@ func Setup(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) {
 	}
 	expose("mongo-a", prv1Cluster.VanClient)
 	expose("mongo-b", pub1Cluster.VanClient)
-	// Just need to do load orr rs inittiate, the easiest one.
+	expose("mongo-c", pub1Cluster.VanClient)
+	// Just need to do load orr rs initiate, the easiest one.
 
 }
 

--- a/test/integration/examples/mongodb/mongo.go
+++ b/test/integration/examples/mongodb/mongo.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/skupperproject/skupper/api/types"
 	vanClient "github.com/skupperproject/skupper/client"
+	"github.com/skupperproject/skupper/pkg/kube"
 	"github.com/skupperproject/skupper/pkg/utils"
 	"github.com/skupperproject/skupper/test/utils/base"
 	"github.com/skupperproject/skupper/test/utils/constants"
@@ -110,6 +111,13 @@ func Setup(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) {
 	assert.Assert(t, err)
 
 	_, err = pub1Cluster.KubectlExec("apply -f https://raw.githubusercontent.com/skupperproject/skupper-example-mongodb-replica-set/master/deployment-mongo-c.yaml")
+
+	// wait deployments ready
+	_, err = kube.WaitDeploymentReadyReplicas("mongo-a", prv1Cluster.Namespace, 1, prv1Cluster.VanClient.KubeClient, time.Minute, time.Second)
+	assert.Assert(t, err)
+	_, err = kube.WaitDeploymentReadyReplicas("mongo-b", pub1Cluster.Namespace, 1, pub1Cluster.VanClient.KubeClient, time.Minute, time.Second)
+	assert.Assert(t, err)
+	_, err = kube.WaitDeploymentReadyReplicas("mongo-c", pub1Cluster.Namespace, 1, pub1Cluster.VanClient.KubeClient, time.Minute, time.Second)
 	assert.Assert(t, err)
 
 	expose := func(name string, cli *vanClient.VanClient) {

--- a/test/integration/examples/mongodb/mongo.go
+++ b/test/integration/examples/mongodb/mongo.go
@@ -26,6 +26,8 @@ func RunTests(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) 
 	prvCluster1, err := r.GetPrivateContext(1)
 	assert.Assert(t, err)
 
+	jobName := "mongo"
+
 	defer func() {
 		log.Print("Replicaset status at the end of the test")
 		prvCluster1.KubectlExec(`exec deploy/mongo-a -- mongo --host 127.0.0.1:27017 --eval 'rs.status()'`)
@@ -44,20 +46,23 @@ func RunTests(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) 
 	_, err = prvCluster1.KubectlExec(
 		`exec deploy/mongo-a -- mongo --host 127.0.0.1:27017 --eval '
 		var resp = rs.initiate(
-			{ 
-				_id : "rs0", 
-				members: [ 
-					{ _id: 0, host: "mongo-a:27017", priority: 3 }, 
+			{
+				_id : "rs0",
+				members: [
+					{ _id: 0, host: "mongo-a:27017", priority: 3 },
 					{ _id: 1, host: "mongo-b:27017", priority: 2 },
 					{ _id: 2, host: "mongo-c:27017", priority: 1 }
 				]
 			}
-		); 
+		);
 		printjson (resp);
 		if (resp.ok != 1) {
 			quit(1);
 		}'
 	`)
+	if err != nil {
+		r.DumpTestInfo(jobName)
+	}
 	assert.Assert(t, err)
 
 	// Let's wait until the election is settled, for a maximum of 5 min
@@ -75,7 +80,6 @@ func RunTests(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) 
 	})
 	assert.Assert(t, err)
 
-	jobName := "mongo"
 	jobCmd := []string{"/app/mongo_test", "-test.run", "Job"}
 
 	_, err = k8s.CreateTestJob(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, jobName, jobCmd)


### PR DESCRIPTION
Mongo tests were failing because replicaset leader election was not complete by the time the test runs.

The best practice is to ensure that the number of voting members on a replicaset is odd; we had two members.

- Add third mongodb replica to the replicaset
- Give each member a different priority on elections
- Wait for elections to be settled before starting actual tests
- Add logging to help relating failures to items in tcpdump, and to inspect Mongo status

The new member on the replicaset mirrors what's done on https://github.com/skupperproject/skupper-example-mongodb-replica-set (and it actually uses a YAML from that repo).