### PR TITLE
Enable tls for http1 and tcp protocols

### DIFF
--- a/client/serviceinterface_update.go
+++ b/client/serviceinterface_update.go
@@ -125,8 +125,6 @@ func validateServiceInterface(service *types.ServiceInterface) error {
 		return fmt.Errorf("The aggregate option is currently only valid for http")
 	} else if service.EventChannel && service.Protocol != "http" {
 		return fmt.Errorf("The event-channel option is currently only valid for http")
-	} else if service.EnableTls && service.Protocol != "http2" {
-		return fmt.Errorf("The TLS support is only available for http2")
 	} else {
 		return nil
 	}

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -157,8 +157,6 @@ func expose(cli types.VanClientInterface, ctx context.Context, targetType string
 		return "", fmt.Errorf("Service already exposed, cannot reconfigure as headless")
 	} else if options.Protocol != "" && service.Protocol != options.Protocol {
 		return "", fmt.Errorf("Invalid protocol %s for service with mapping %s", options.Protocol, service.Protocol)
-	} else if options.EnableTls && options.Protocol != "http2" {
-		return "", fmt.Errorf("TLS can not be enabled for service with mapping %s (only available for http2)", service.Protocol)
 	} else if options.EnableTls && !service.EnableTls {
 		return "", fmt.Errorf("Service already exposed without TLS support")
 	} else if !options.EnableTls && service.EnableTls {
@@ -785,7 +783,7 @@ func NewCmdExpose(newClient cobraFunc) *cobra.Command {
 	cmd.Flags().StringVar(&exposeOpts.ProxyTuning.NodeSelector, "proxy-node-selector", "", "Node selector to control placement of router pods")
 	cmd.Flags().StringVar(&exposeOpts.ProxyTuning.Affinity, "proxy-pod-affinity", "", "Pod affinity label matches to control placement of router pods")
 	cmd.Flags().StringVar(&exposeOpts.ProxyTuning.AntiAffinity, "proxy-pod-antiaffinity", "", "Pod antiaffinity label matches to control placement of router pods")
-	cmd.Flags().BoolVar(&exposeOpts.EnableTls, "enable-tls", false, "If specified, the service will be exposed over TLS (valid only for http2 protocol)")
+	cmd.Flags().BoolVar(&exposeOpts.EnableTls, "enable-tls", false, "If specified, the service will be exposed over TLS")
 	cmd.Flags().BoolVar(&exposeOpts.PublishNotReadyAddresses, "publish-not-ready-addresses", false, "If specified, skupper will not wait for pods to be ready")
 
 	return cmd

--- a/pkg/qdr/qdr.go
+++ b/pkg/qdr/qdr.go
@@ -430,11 +430,13 @@ type Address struct {
 }
 
 type TcpEndpoint struct {
-	Name    string `json:"name,omitempty"`
-	Host    string `json:"host,omitempty"`
-	Port    string `json:"port,omitempty"`
-	Address string `json:"address,omitempty"`
-	SiteId  string `json:"siteId,omitempty"`
+	Name           string `json:"name,omitempty"`
+	Host           string `json:"host,omitempty"`
+	Port           string `json:"port,omitempty"`
+	Address        string `json:"address,omitempty"`
+	SiteId         string `json:"siteId,omitempty"`
+	SslProfile     string `json:"sslProfile,omitempty"`
+	VerifyHostname *bool  `json:"verifyHostname,omitempty"`
 }
 
 type HttpEndpoint struct {

--- a/pkg/service/bindings.go
+++ b/pkg/service/bindings.go
@@ -391,6 +391,14 @@ func addEgressBridge(protocol string, host string, port map[int]int, address str
 			if hostOverride != "" {
 				b.HostOverride = hostOverride
 			}
+
+			if len(tlsCredentials) > 0 {
+				verifyHostName := new(bool)
+				*verifyHostName = false
+				b.SslProfile = types.ServiceClientSecret
+				b.VerifyHostname = verifyHostName
+			}
+
 			bridges.AddHttpConnector(b)
 		case ProtocolHTTP2:
 			httpConnector := qdr.HttpEndpoint{
@@ -410,13 +418,21 @@ func addEgressBridge(protocol string, host string, port map[int]int, address str
 			}
 			bridges.AddHttpConnector(httpConnector)
 		case ProtocolTCP:
-			bridges.AddTcpConnector(qdr.TcpEndpoint{
+			tcpConnector := qdr.TcpEndpoint{
 				Name:    endpointName,
 				Host:    host,
 				Port:    strconv.Itoa(tPort),
 				Address: endpointAddr,
 				SiteId:  siteId,
-			})
+			}
+
+			if len(tlsCredentials) > 0 {
+				verifyHostName := new(bool)
+				*verifyHostName = false
+				tcpConnector.SslProfile = types.ServiceClientSecret
+				tcpConnector.VerifyHostname = verifyHostName
+			}
+			bridges.AddTcpConnector(tcpConnector)
 		default:
 			return false, fmt.Errorf("Unrecognised protocol for service %s: %s", address, protocol)
 		}
@@ -436,14 +452,21 @@ func addIngressBridge(sb *ServiceBindings, siteId string, bridges *qdr.BridgeCon
 			if sb.aggregation != "" || sb.eventChannel {
 				endpointAddr = "mc/" + endpointAddr
 			}
-			bridges.AddHttpListener(qdr.HttpEndpoint{
+
+			http1Listener := qdr.HttpEndpoint{
 				Name:         endpointName,
 				Port:         strconv.Itoa(iPort),
 				Address:      endpointAddr,
 				SiteId:       siteId,
 				Aggregation:  sb.aggregation,
 				EventChannel: sb.eventChannel,
-			})
+			}
+
+			if len(sb.tlsCredentials) > 0 {
+				http1Listener.SslProfile = sb.tlsCredentials
+			}
+
+			bridges.AddHttpListener(http1Listener)
 
 		case ProtocolHTTP2:
 			httpListener := qdr.HttpEndpoint{
@@ -462,12 +485,18 @@ func addIngressBridge(sb *ServiceBindings, siteId string, bridges *qdr.BridgeCon
 
 			bridges.AddHttpListener(httpListener)
 		case ProtocolTCP:
-			bridges.AddTcpListener(qdr.TcpEndpoint{
+			tcpListener := qdr.TcpEndpoint{
 				Name:    endpointName,
 				Port:    strconv.Itoa(iPort),
 				Address: endpointAddr,
 				SiteId:  siteId,
-			})
+			}
+
+			if len(sb.tlsCredentials) > 0 {
+				tcpListener.SslProfile = sb.tlsCredentials
+			}
+
+			bridges.AddTcpListener(tcpListener)
 		default:
 			return false, fmt.Errorf("Unrecognised protocol for service %s: %s", sb.Address, sb.protocol)
 		}


### PR DESCRIPTION
pending to be able to create tcpConnectors/tcpListeners with sslProfiles in the router.