### PR TITLE
Mongo replicaset fix (#859); cherry-pick into 1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ executors:
   local_cluster_test_executor:
     machine:
       image: ubuntu-2004:current
+    resource_class: large
 
 commands:
   minikube-install:
@@ -33,7 +34,7 @@ commands:
       - run:
           command: >-
             curl -Lo minikube
-            https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && 
+            https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 &&
             chmod +x minikube && sudo
             mv minikube /usr/local/bin/
           name: Install Minikube Executable
@@ -43,7 +44,7 @@ commands:
     steps:
       - run:
           command: >-
-            minikube start --vm-driver=docker --cpus 2 --memory 2048
+            minikube start --vm-driver=docker --cpus 4 --memory 6144
           name: Start Minikube Cluster
 
   minikube-start-load-balancer:

--- a/test/integration/examples/mongodb/mongo.go
+++ b/test/integration/examples/mongodb/mongo.go
@@ -2,10 +2,16 @@ package mongodb
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/skupperproject/skupper/api/types"
 	vanClient "github.com/skupperproject/skupper/client"
+	"github.com/skupperproject/skupper/pkg/kube"
+	"github.com/skupperproject/skupper/pkg/utils"
 	"github.com/skupperproject/skupper/test/utils/base"
 	"github.com/skupperproject/skupper/test/utils/constants"
 	"github.com/skupperproject/skupper/test/utils/k8s"
@@ -21,15 +27,60 @@ func RunTests(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) 
 	prvCluster1, err := r.GetPrivateContext(1)
 	assert.Assert(t, err)
 
+	jobName := "mongo"
+
+	defer func() {
+		log.Print("Replicaset status at the end of the test")
+		prvCluster1.KubectlExec(`exec deploy/mongo-a -- mongo --host 127.0.0.1:27017 --eval 'rs.status()'`)
+	}()
+
 	_, err = k8s.WaitForSkupperServiceToBeCreatedAndReadyToUse(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, "mongo-a")
 	assert.Assert(t, err)
 	_, err = k8s.WaitForSkupperServiceToBeCreatedAndReadyToUse(prvCluster1.Namespace, prvCluster1.VanClient.KubeClient, "mongo-b")
 	assert.Assert(t, err)
-
-	_, err = prvCluster1.KubectlExec(`exec deploy/mongo-a -- mongo --host 127.0.0.1:27017 --eval 'rs.initiate({ _id : "rs0", members: [ { _id: 0, host: "mongo-a:27017" }, { _id: 1, host: "mongo-b:27017" }]})'`)
+	_, err = k8s.WaitForSkupperServiceToBeCreatedAndReadyToUse(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, "mongo-c")
 	assert.Assert(t, err)
 
-	jobName := "mongo"
+	// Make sure you have a minimum of three members on the replicaset
+	// https://www.mongodb.com/docs/manual/tutorial/deploy-replica-set/
+	// https://www.mongodb.com/docs/manual/core/replica-set-architecture-three-members/
+	_, err = prvCluster1.KubectlExec(
+		`exec deploy/mongo-a -- mongo --host 127.0.0.1:27017 --eval '
+		var resp = rs.initiate(
+			{
+				_id : "rs0",
+				members: [
+					{ _id: 0, host: "mongo-a:27017", priority: 3 },
+					{ _id: 1, host: "mongo-b:27017", priority: 2 },
+					{ _id: 2, host: "mongo-c:27017", priority: 1 }
+				]
+			}
+		);
+		printjson (resp);
+		if (resp.ok != 1) {
+			quit(1);
+		}'
+	`)
+	if err != nil {
+		r.DumpTestInfo(jobName)
+	}
+	assert.Assert(t, err)
+
+	// Let's wait until the election is settled, for a maximum of 5 min
+	log.Print("Waiting for the Mongo replicaset primary member election to be settled")
+	err = utils.RetryError(5*time.Second, 12*5, func() error {
+		out, err := prvCluster1.KubectlExec(`exec deploy/mongo-a -- mongo --host 127.0.0.1:27017 --eval 'db.hello().primary' --quiet`)
+		if err != nil {
+			return err
+		}
+		if string(out) == "" {
+			return fmt.Errorf("No primary elected for the Mongo replicaset")
+		}
+		log.Printf("Mongo primary election settled: %v.  Proceeding", strings.TrimSpace(string(out)))
+		return nil
+	})
+	assert.Assert(t, err)
+
 	jobCmd := []string{"/app/mongo_test", "-test.run", "Job"}
 
 	_, err = k8s.CreateTestJob(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, jobName, jobCmd)
@@ -59,6 +110,16 @@ func Setup(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) {
 	_, err = pub1Cluster.KubectlExec("apply -f https://raw.githubusercontent.com/skupperproject/skupper-example-mongodb-replica-set/master/deployment-mongo-b.yaml")
 	assert.Assert(t, err)
 
+	_, err = pub1Cluster.KubectlExec("apply -f https://raw.githubusercontent.com/skupperproject/skupper-example-mongodb-replica-set/master/deployment-mongo-c.yaml")
+
+	// wait deployments ready
+	_, err = kube.WaitDeploymentReadyReplicas("mongo-a", prv1Cluster.Namespace, 1, prv1Cluster.VanClient.KubeClient, time.Minute, time.Second)
+	assert.Assert(t, err)
+	_, err = kube.WaitDeploymentReadyReplicas("mongo-b", pub1Cluster.Namespace, 1, pub1Cluster.VanClient.KubeClient, time.Minute, time.Second)
+	assert.Assert(t, err)
+	_, err = kube.WaitDeploymentReadyReplicas("mongo-c", pub1Cluster.Namespace, 1, pub1Cluster.VanClient.KubeClient, time.Minute, time.Second)
+	assert.Assert(t, err)
+
 	expose := func(name string, cli *vanClient.VanClient) {
 		t.Helper()
 		service := types.ServiceInterface{
@@ -76,7 +137,8 @@ func Setup(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) {
 	}
 	expose("mongo-a", prv1Cluster.VanClient)
 	expose("mongo-b", pub1Cluster.VanClient)
-	// Just need to do load orr rs inittiate, the easiest one.
+	expose("mongo-c", pub1Cluster.VanClient)
+	// Just need to do load orr rs initiate, the easiest one.
 
 }
 


### PR DESCRIPTION
Mongo tests were failing because replicaset leader election was not complete by the time the test runs.

The best practice is to ensure that the number of voting members on a replicaset is odd; we had two members.

- Add third mongodb replica to the replicaset
- Give each member a different priority on elections
- Wait for elections to be settled before starting actual tests
- Add logging to help relating failures to items in tcpdump, and to inspect Mongo status
- Properly fail test if replicaset creation fails straight off
- Fixed MongoDB integration test with container not found (fgiorgetti)

The new member on the replicaset mirrors what's done on https://github.com/skupperproject/skupper-example-mongodb-replica-set (and it actually uses a YAML from that repo).

Signed-off-by: Danilo Gonzalez Hashimoto <dhashimo@redhat.com>
Co-authored-by: Fernando Giorgetti <fgiorget@redhat.com>
(cherry picked from commit 62aa69d44dc152226a5e470ee47fabb9baadb76a)