### PR TITLE
Removing GDB config hardcoded from tests

### DIFF
--- a/test/integration/acceptance/custom/hello_policy/init_test.go
+++ b/test/integration/acceptance/custom/hello_policy/init_test.go
@@ -52,7 +52,6 @@ func skupperInitEdgeTestScenario(ctx *base.ClusterContext, prefix string, withPo
 					ConsoleUser:           "admin",
 					ConsolePassword:       "admin",
 					Ingress:               "none",
-					RouterDebugMode:       "gdb",
 					RouterLogging:         "trace",
 					RouterMode:            "edge",
 					SiteName:              "private",

--- a/test/integration/examples/custom/helloworld/helloworld_test.go
+++ b/test/integration/examples/custom/helloworld/helloworld_test.go
@@ -113,7 +113,6 @@ func TestHelloWorldCLI(t *testing.T) {
 						ConsoleUser:           "admin",
 						ConsolePassword:       "admin",
 						Ingress:               "none",
-						RouterDebugMode:       "gdb",
 						RouterLogging:         "trace",
 						RouterMode:            "edge",
 						SiteName:              "private",

--- a/test/utils/base/env.go
+++ b/test/utils/base/env.go
@@ -56,6 +56,9 @@ const (
 	// skipped on the normal runs.  Setting this variable will include
 	// those on the runs
 	ENV_RUN_ISSUE_TESTS = "SKUPPER_TEST_RUN_ISSUE_TESTS"
+
+	// If populated, skupper integration tests will not run in debug mode
+	ENV_SKIP_DEBUG = "SKUPPER_TEST_SKIP_DEBUG"
 )
 
 // ** POLICY **

--- a/test/utils/constants/constants.go
+++ b/test/utils/constants/constants.go
@@ -1,9 +1,11 @@
 package constants
 
 import (
+	"os"
 	"time"
 
 	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/test/utils/base"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -29,7 +31,9 @@ func DefaultRouterOptions(spec *types.RouterOptions) types.RouterOptions {
 		spec = &types.RouterOptions{}
 	}
 
-	spec.DebugMode = "gdb"
+	if os.Getenv(base.ENV_SKIP_DEBUG) == "" {
+		spec.DebugMode = "gdb"
+	}
 	if spec.Logging == nil {
 		spec.Logging = []types.RouterLogConfig{}
 	}

--- a/test/utils/constants/constants.go
+++ b/test/utils/constants/constants.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/skupperproject/skupper/api/types"
-	"github.com/skupperproject/skupper/test/utils/base"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -31,7 +30,7 @@ func DefaultRouterOptions(spec *types.RouterOptions) types.RouterOptions {
 		spec = &types.RouterOptions{}
 	}
 
-	if os.Getenv(base.ENV_SKIP_DEBUG) == "" {
+	if os.Getenv("SKUPPER_TEST_SKIP_DEBUG") == "" {
 		spec.DebugMode = "gdb"
 	}
 	if spec.Logging == nil {

--- a/test/utils/skupper/cli/init.go
+++ b/test/utils/skupper/cli/init.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/skupperproject/skupper/api/types"
@@ -63,7 +64,7 @@ func (s *InitTester) Command(cluster *base.ClusterContext) []string {
 	if s.ConsoleIngress != "" {
 		args = append(args, "--console-ingress", s.ConsoleIngress)
 	}
-	if s.RouterDebugMode == "" {
+	if s.RouterDebugMode == "" && os.Getenv(base.ENV_SKIP_DEBUG) == "" {
 		s.RouterDebugMode = "gdb"
 	}
 	args = append(args, "--router-debug-mode", s.RouterDebugMode)


### PR DESCRIPTION
Signed-off-by: Rafael Zago <rzago@redhat.com>

Cherrypick for Removing GDB config hardcoded from tests.