### PR TITLE
Improve output link status

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -333,6 +333,6 @@ type VanClientInterface interface {
 	GetVersion(component string, name string) string
 	GetIngressDefault() string
 	RevokeAccess(ctx context.Context) error
-	NetworkStatus() ([]*SiteInfo, error)
+	NetworkStatus(ctx context.Context) ([]*SiteInfo, error)
 	GetRemoteLinks(ctx context.Context, siteConfig *SiteConfig) ([]*RemoteLinkInfo, error)
 }

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -278,6 +278,12 @@ type TargetInfo struct {
 	SiteId string `json:"site_id,omitempty"`
 }
 
+type RemoteLinkInfo struct {
+	SiteName  string `json:"site_name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	SiteId    string `json:"site_id,omitempty"`
+}
+
 type VanClientInterface interface {
 	RouterCreate(ctx context.Context, options SiteConfig) error
 	RouterInspect(ctx context.Context) (*RouterInspectResponse, error)
@@ -328,4 +334,5 @@ type VanClientInterface interface {
 	GetIngressDefault() string
 	RevokeAccess(ctx context.Context) error
 	NetworkStatus() ([]*SiteInfo, error)
+	GetRemoteLinks(ctx context.Context, siteConfig *SiteConfig) ([]*RemoteLinkInfo, error)
 }

--- a/client/connector_list.go
+++ b/client/connector_list.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -33,6 +34,8 @@ func getLinkStatus(s *corev1.Secret, edge bool, connections []qdr.Connection) ty
 		link.Configured = true
 		if connection := kubeqdr.GetInterRouterOrEdgeConnection(link.Url, connections); connection != nil && connection.Active {
 			link.Connected = true
+			link.Cost, _ = strconv.Atoi(s.ObjectMeta.Annotations[types.TokenCost])
+			link.Created = s.ObjectMeta.CreationTimestamp.String()
 		}
 		if s.ObjectMeta.Labels[types.SkupperDisabledQualifier] == "true" {
 			link.Description = "Destination host is not allowed"

--- a/client/network_status.go
+++ b/client/network_status.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (cli *VanClient) NetworkStatus() ([]*types.SiteInfo, error) {
+func (cli *VanClient) NetworkStatus(ctx context.Context) ([]*types.SiteInfo, error) {
 
 	//Checking if the router has been deployed
 	_, err := cli.KubeClient.AppsV1().Deployments(cli.Namespace).Get(types.TransportDeploymentName, metav1.GetOptions{})
@@ -17,7 +17,7 @@ func (cli *VanClient) NetworkStatus() ([]*types.SiteInfo, error) {
 		return nil, fmt.Errorf("skupper is not installed: %s", err)
 	}
 
-	sites, err := server.GetSiteInfo(cli.Namespace, cli.KubeClient, cli.RestConfig)
+	sites, err := server.GetSiteInfo(ctx, cli.Namespace, cli.KubeClient, cli.RestConfig)
 
 	if err != nil {
 		return nil, err
@@ -173,7 +173,7 @@ func (cli *VanClient) GetRemoteLinks(ctx context.Context, siteConfig *types.Site
 
 	currentSiteId := siteConfig.Reference.UID
 
-	sites, err := server.GetSiteInfo(cli.Namespace, cli.KubeClient, cli.RestConfig)
+	sites, err := server.GetSiteInfo(ctx, cli.Namespace, cli.KubeClient, cli.RestConfig)
 
 	if err != nil {
 		return nil, err

--- a/client/network_status.go
+++ b/client/network_status.go
@@ -14,7 +14,7 @@ func (cli *VanClient) NetworkStatus(ctx context.Context) ([]*types.SiteInfo, err
 	//Checking if the router has been deployed
 	_, err := cli.KubeClient.AppsV1().Deployments(cli.Namespace).Get(types.TransportDeploymentName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("skupper is not installed: %s", err)
+		return nil, fmt.Errorf("Skupper is not installed: %s", err)
 	}
 
 	sites, err := server.GetSiteInfo(ctx, cli.Namespace, cli.KubeClient, cli.RestConfig)

--- a/client/utils.go
+++ b/client/utils.go
@@ -50,7 +50,7 @@ func PrintKeyValueMap(entries map[string]string) error {
 	}
 	sort.Strings(keys)
 
-	_, err := fmt.Fprint(writer, "\n ---\n")
+	_, err := fmt.Fprint(writer, "")
 	if err != nil {
 		return err
 	}
@@ -60,10 +60,6 @@ func PrintKeyValueMap(entries map[string]string) error {
 		if err != nil {
 			return err
 		}
-	}
-	_, err = fmt.Fprint(writer, "\n ---\n")
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/client/utils.go
+++ b/client/utils.go
@@ -1,6 +1,12 @@
 package client
 
-import "strings"
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+)
 
 func splitWithEscaping(s string, separator, escape byte) []string {
 	var token []byte
@@ -31,4 +37,34 @@ func asMap(entries []string) map[string]string {
 		}
 	}
 	return result
+}
+
+func PrintKeyValueMap(entries map[string]string) error {
+	writer := new(tabwriter.Writer)
+	writer.Init(os.Stdout, 8, 8, 0, '\t', 0)
+	defer writer.Flush()
+
+	keys := make([]string, 0, len(entries))
+	for k := range entries {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	_, err := fmt.Fprint(writer, "\n ---\n")
+	if err != nil {
+		return err
+	}
+
+	for _, key := range keys {
+		_, err := fmt.Fprintf(writer, "\n %s\t%s\t", key, entries[key])
+		if err != nil {
+			return err
+		}
+	}
+	_, err = fmt.Fprint(writer, "\n ---\n")
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/skupper/skupper_cluster_test.go
+++ b/cmd/skupper/skupper_cluster_test.go
@@ -1651,6 +1651,12 @@ func TestLinkStatus(t *testing.T) {
 		},
 	}
 
+	if !*clusterRun {
+		lightRed := "\033[1;31m"
+		resetColor := "\033[0m"
+		t.Skip(fmt.Sprintf("%sSkipping: This test only works in real clusters.%s", string(lightRed), string(resetColor)))
+	}
+
 	namespace := "cmd-link-cluster-test-" + strings.ToLower(utils.RandomId(4))
 	testClient = &SkupperTestClient{
 		SkupperKube: &SkupperKube{

--- a/cmd/skupper/skupper_cluster_test.go
+++ b/cmd/skupper/skupper_cluster_test.go
@@ -1620,6 +1620,16 @@ func TestLinkStatus(t *testing.T) {
 			createConn:      false,
 		},
 		{
+			doc:             "Should display link details of an existing link",
+			args:            []string{"link1", "--verbose"},
+			expectedCapture: "",
+			expectedOutput:  "",
+			expectedError:   "",
+			outputRegExp:    "^\\n\\sCost:.*\\n\\sCreated:.*\\n\\sName:.*\\n\\sNamespace:.*\\n\\sSite:.*\\n\\sStatus:.*\\n\\sURL:.*\\n",
+			realCluster:     true,
+			createConn:      true,
+		},
+		{
 			doc:             "Should display local links",
 			args:            []string{},
 			expectedCapture: "Links initiated from this site",
@@ -1651,6 +1661,8 @@ func TestLinkStatus(t *testing.T) {
 		t.Skip(fmt.Sprintf("%sSkipping: This test only works in real clusters.%s", string(lightRed), string(resetColor)))
 	}
 
+	cli = NewClient(namespace, kubeContext, kubeConfigPath)
+
 	if c, ok := cli.(*client.VanClient); ok {
 		_, err := kube.NewNamespace(namespace, c.KubeClient)
 		assert.Check(t, err)
@@ -1659,9 +1671,6 @@ func TestLinkStatus(t *testing.T) {
 	skupperInit(t, []string{}...)
 
 	for _, tc := range testcases {
-		if tc.realCluster && !*clusterRun {
-			continue
-		}
 
 		// create a connection to list
 		if tc.createConn {

--- a/cmd/skupper/skupper_cluster_test.go
+++ b/cmd/skupper/skupper_cluster_test.go
@@ -1625,7 +1625,7 @@ func TestLinkStatus(t *testing.T) {
 			expectedCapture: "",
 			expectedOutput:  "",
 			expectedError:   "",
-			outputRegExp:    "^\\n\\sCost:.*\\n\\sCreated:.*\\n\\sName:.*\\n\\sNamespace:.*\\n\\sSite:.*\\n\\sStatus:.*\\n\\sURL:.*\\n",
+			outputRegExp:    "^\\n\\sCost:.*\\n\\sCreated:.*\\n\\sName:.*\\n\\sNamespace:.*\\n\\sSite:.*\\n\\sStatus:.*\\n",
 			realCluster:     true,
 			createConn:      true,
 		},

--- a/cmd/skupper/skupper_cluster_test.go
+++ b/cmd/skupper/skupper_cluster_test.go
@@ -1645,10 +1645,10 @@ func TestLinkStatus(t *testing.T) {
 	kubeContext = ""
 	kubeConfigPath = ""
 
-	if *clusterRun {
-		cli = NewClient(namespace, kubeContext, kubeConfigPath)
-	} else {
-		cli = newMockClient(namespace)
+	if !*clusterRun {
+		lightRed := "\033[1;31m"
+		resetColor := "\033[0m"
+		t.Skip(fmt.Sprintf("%sSkipping: This test only works in real clusters.%s", string(lightRed), string(resetColor)))
 	}
 
 	if c, ok := cli.(*client.VanClient); ok {

--- a/cmd/skupper/skupper_cluster_test.go
+++ b/cmd/skupper/skupper_cluster_test.go
@@ -711,7 +711,7 @@ func TestCheckConnectionWithCluster(t *testing.T) {
 		},
 		{
 			doc:             "check-connection-test2",
-			args:            []string{"all", "--timeout", "1s"},
+			args:            []string{"all", "--timeout", "1s"}, //added timeout to not wait for remote links which are not relevant for this testq
 			expectedCapture: "There are no links configured or active",
 			expectedOutput:  "",
 			expectedError:   "",

--- a/cmd/skupper/skupper_kube_link.go
+++ b/cmd/skupper/skupper_kube_link.go
@@ -120,7 +120,7 @@ func (s *SkupperKubeLink) Status(cmd *cobra.Command, args []string) error {
 	}
 
 	if verbose && (len(args) == 0 || args[0] == "all") {
-		fmt.Println("In order to provide detailed information about the link, please specify the name")
+		fmt.Println("In order to provide detailed information about the link, specify the link name")
 		return nil
 	}
 
@@ -176,7 +176,7 @@ func (s *SkupperKubeLink) Status(cmd *cobra.Command, args []string) error {
 				fmt.Println(err)
 				break
 			} else if allConnected(links) || i == waitFor {
-				fmt.Println("\nLinks initiated from this site:")
+				fmt.Println("\nLinks created from this site:")
 				fmt.Println("-------------------------------")
 
 				if len(links) == 0 {
@@ -248,7 +248,6 @@ func createLinkDetailMap(link *types.LinkStatus, siteConfig *types.SiteConfig) m
 		"Status:":    status,
 		"Namespace:": siteConfig.Spec.SkupperNamespace,
 		"Site:":      siteConfig.Spec.SkupperName + "-" + siteConfig.Reference.UID,
-		"URL:":       link.Url,
 		"Cost:":      strconv.Itoa(link.Cost),
 		"Created:":   link.Created,
 	}

--- a/cmd/skupper/skupper_link.go
+++ b/cmd/skupper/skupper_link.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"time"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/spf13/cobra"
@@ -52,6 +53,8 @@ func NewCmdLinkDelete(skupperClient SkupperLinkClient) *cobra.Command {
 }
 
 var waitFor int
+var remoteInfoTimeout time.Duration
+var verbose bool
 
 func allConnected(links []types.LinkStatus) bool {
 	for _, l := range links {
@@ -71,6 +74,8 @@ func NewCmdLinkStatus(skupperClient SkupperLinkClient) *cobra.Command {
 		RunE:   skupperClient.Status,
 	}
 	cmd.Flags().IntVar(&waitFor, "wait", 0, "The number of seconds to wait for links to become active")
+	cmd.Flags().DurationVar(&remoteInfoTimeout, "timeout", time.Second*120, "Configurable timeout for retrieving information about remote links")
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "Show detailed information about the links")
 
 	return cmd
 

--- a/cmd/skupper/skupper_link.go
+++ b/cmd/skupper/skupper_link.go
@@ -80,3 +80,15 @@ func NewCmdLinkStatus(skupperClient SkupperLinkClient) *cobra.Command {
 	return cmd
 
 }
+
+func createLinkDetailMap(link *types.LinkStatus, siteConfig *types.SiteConfig) map[string]string {
+	return map[string]string{
+		"Name:":      link.Name,
+		"Status:":    "Active",
+		"Namespace:": siteConfig.Spec.SkupperNamespace,
+		"Site:":      siteConfig.Spec.SkupperName + "-" + siteConfig.Reference.UID,
+		"URL:":       link.Url,
+		"Cost:":      strconv.Itoa(link.Cost),
+		"Created:":   link.Created,
+	}
+}

--- a/cmd/skupper/skupper_link.go
+++ b/cmd/skupper/skupper_link.go
@@ -75,7 +75,7 @@ func NewCmdLinkStatus(skupperClient SkupperLinkClient) *cobra.Command {
 	}
 	cmd.Flags().IntVar(&waitFor, "wait", 0, "The number of seconds to wait for links to become active")
 	cmd.Flags().DurationVar(&remoteInfoTimeout, "timeout", time.Second*120, "Configurable timeout for retrieving information about remote links")
-	cmd.Flags().BoolVar(&verbose, "verbose", false, "Show detailed information about the links")
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "Show detailed information about a link")
 
 	return cmd
 

--- a/cmd/skupper/skupper_link.go
+++ b/cmd/skupper/skupper_link.go
@@ -82,9 +82,20 @@ func NewCmdLinkStatus(skupperClient SkupperLinkClient) *cobra.Command {
 }
 
 func createLinkDetailMap(link *types.LinkStatus, siteConfig *types.SiteConfig) map[string]string {
+
+	status := "Active"
+
+	if !link.Connected {
+		status = "Not active"
+
+		if len(link.Description) > 0 {
+			status = fmt.Sprintf("%s (%s)", status, link.Description)
+		}
+	}
+
 	return map[string]string{
 		"Name:":      link.Name,
-		"Status:":    "Active",
+		"Status:":    status,
 		"Namespace:": siteConfig.Spec.SkupperNamespace,
 		"Site:":      siteConfig.Spec.SkupperName + "-" + siteConfig.Reference.UID,
 		"URL:":       link.Url,

--- a/cmd/skupper/skupper_link.go
+++ b/cmd/skupper/skupper_link.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"time"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -54,7 +54,7 @@ func NewCmdLinkDelete(skupperClient SkupperLinkClient) *cobra.Command {
 
 var waitFor int
 var remoteInfoTimeout time.Duration
-var verbose bool
+var verboseLinkStatus bool
 
 func allConnected(links []types.LinkStatus) bool {
 	for _, l := range links {
@@ -75,31 +75,8 @@ func NewCmdLinkStatus(skupperClient SkupperLinkClient) *cobra.Command {
 	}
 	cmd.Flags().IntVar(&waitFor, "wait", 0, "The number of seconds to wait for links to become active")
 	cmd.Flags().DurationVar(&remoteInfoTimeout, "timeout", types.DefaultTimeoutDuration, "Configurable timeout for retrieving information about remote links")
-	cmd.Flags().BoolVar(&verbose, "verbose", false, "Show detailed information about a link")
+	cmd.Flags().BoolVar(&verboseLinkStatus, "verbose", false, "Show detailed information about a link")
 
 	return cmd
 
-}
-
-func createLinkDetailMap(link *types.LinkStatus, siteConfig *types.SiteConfig) map[string]string {
-
-	status := "Active"
-
-	if !link.Connected {
-		status = "Not active"
-
-		if len(link.Description) > 0 {
-			status = fmt.Sprintf("%s (%s)", status, link.Description)
-		}
-	}
-
-	return map[string]string{
-		"Name:":      link.Name,
-		"Status:":    status,
-		"Namespace:": siteConfig.Spec.SkupperNamespace,
-		"Site:":      siteConfig.Spec.SkupperName + "-" + siteConfig.Reference.UID,
-		"URL:":       link.Url,
-		"Cost:":      strconv.Itoa(link.Cost),
-		"Created:":   link.Created,
-	}
 }

--- a/cmd/skupper/skupper_link.go
+++ b/cmd/skupper/skupper_link.go
@@ -74,7 +74,7 @@ func NewCmdLinkStatus(skupperClient SkupperLinkClient) *cobra.Command {
 		RunE:   skupperClient.Status,
 	}
 	cmd.Flags().IntVar(&waitFor, "wait", 0, "The number of seconds to wait for links to become active")
-	cmd.Flags().DurationVar(&remoteInfoTimeout, "timeout", time.Second*120, "Configurable timeout for retrieving information about remote links")
+	cmd.Flags().DurationVar(&remoteInfoTimeout, "timeout", types.DefaultTimeoutDuration, "Configurable timeout for retrieving information about remote links")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Show detailed information about a link")
 
 	return cmd

--- a/cmd/skupper/skupper_mock_test.go
+++ b/cmd/skupper/skupper_mock_test.go
@@ -298,6 +298,10 @@ func (v *vanClientMock) NetworkStatus() ([]*types.SiteInfo, error) {
 	return nil, nil
 }
 
+func (v *vanClientMock) GetRemoteLinks(ctx context.Context, siteConfig *types.SiteConfig) ([]*types.RemoteLinkInfo, error) {
+	return nil, nil
+}
+
 func TestCmdUnexposeRun(t *testing.T) {
 	skupperClient := NewSkupperTestClient()
 	cmd := NewCmdUnexpose(skupperClient.Service())

--- a/cmd/skupper/skupper_mock_test.go
+++ b/cmd/skupper/skupper_mock_test.go
@@ -294,7 +294,7 @@ func (v *vanClientMock) RevokeAccess(ctx context.Context) error {
 	return nil
 }
 
-func (v *vanClientMock) NetworkStatus() ([]*types.SiteInfo, error) {
+func (v *vanClientMock) NetworkStatus(ctx context.Context) ([]*types.SiteInfo, error) {
 	return nil, nil
 }
 

--- a/cmd/skupper/skupper_network.go
+++ b/cmd/skupper/skupper_network.go
@@ -28,7 +28,7 @@ func NewCmdNetworkStatus(skupperClient SkupperNetworkClient) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&selectedSite, "site", "s", "all", "Site identifier")
-	cmd.Flags().DurationVar(&networkStatusTimeout, "timeout", time.Second*120, "Configurable timeout for retrieving remote information")
+	cmd.Flags().DurationVar(&networkStatusTimeout, "timeout", types.DefaultTimeoutDuration, "Configurable timeout for retrieving remote information")
 
 	return cmd
 

--- a/cmd/skupper/skupper_network.go
+++ b/cmd/skupper/skupper_network.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-    "time"
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/spf13/cobra"
+	"time"
 )
 
 func NewCmdNetwork() *cobra.Command {

--- a/cmd/skupper/skupper_network.go
+++ b/cmd/skupper/skupper_network.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-
+    "time"
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/spf13/cobra"
 )
@@ -16,6 +16,7 @@ func NewCmdNetwork() *cobra.Command {
 }
 
 var selectedSite string
+var networkStatusTimeout time.Duration
 
 func NewCmdNetworkStatus(skupperClient SkupperNetworkClient) *cobra.Command {
 	cmd := &cobra.Command{
@@ -27,6 +28,7 @@ func NewCmdNetworkStatus(skupperClient SkupperNetworkClient) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&selectedSite, "site", "s", "all", "Site identifier")
+	cmd.Flags().DurationVar(&networkStatusTimeout, "timeout", time.Second*120, "Configurable timeout for retrieving remote information")
 
 	return cmd
 

--- a/pkg/server/server_mgmt.go
+++ b/pkg/server/server_mgmt.go
@@ -21,7 +21,7 @@ func GetSiteInfo(ctx context.Context, namespace string, clientset kubernetes.Int
 	if ok {
 		timeout = time.Until(deadline)
 	} else {
-		timeout = 120 * time.Second
+		timeout = types.DefaultTimeoutDuration
 	}
 
 	command := getQueryServiceController("sites")

--- a/pkg/utils/retry.go
+++ b/pkg/utils/retry.go
@@ -120,3 +120,22 @@ func RetryWithContext(ctx context.Context, interval time.Duration, f ConditionFu
 		}
 	}
 }
+
+// RetryErrorWithContext will retry as long the checked function is returning an error and the context does not time out
+func RetryErrorWithContext(ctx context.Context, interval time.Duration, f CheckedFunc) error {
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return context.DeadlineExceeded
+
+		case <-tick.C:
+			err := f()
+			if err == nil {
+				return nil
+			}
+		}
+	}
+}


### PR DESCRIPTION
Solves #878 

### Command Line changes:
#### New flags:
```
      --timeout duration   Configurable timeout for retrieving information about remote links (default 2m0s)
      --verbose            Show detailed information about a link
```
#### New output by default:
example 1)
```
$ skupper link status

Links initiated from this site:
-------------------------------
There are no links configured or active

Currently active links from other sites:
----------------------------------------
A link from the namespace public2 on site public2(ccd891d1-b79a-41e8-aafc-fd88f4fe475c) is active 
A link from the namespace private1 on site private1(981164ef-f16a-4a07-8370-dd4750bc1bc9) is active 
```
example 2)
```
$ skupper link status

Links initiated from this site:
-------------------------------
Link link1 is active

Currently active links from other sites:
----------------------------------------
A link from the namespace private1 on site private1(981164ef-f16a-4a07-8370-dd4750bc1bc9) is active 

```
example 3)
```
Links initiated from this site:
-------------------------------
Link link1 is active
Link link2 is active

Currently active links from other sites:
----------------------------------------
There are no active links

```
### New detailed information about the link:
```
skupper link status link2 --verbose

 Cost:		1						
 Created:	2022-09-19 13:43:53 +0200 CEST			
 Name:		link2						
 Namespace:	private1					
 Site:		private1-981164ef-f16a-4a07-8370-dd4750bc1bc9	
 Status:	Active						
 URL:		10.107.185.200:55671

```

EDIT:
Fixing the propagation of the context for remote links, it was also updated the command `network status` to use a timeout flag during its execution:
```
$ skupper network status --help
Shows information about the current site, and connected sites.

Usage:
  skupper network status [flags]

Flags:
  -h, --help               help for status
  -s, --site string        Site identifier (default "all")
      --timeout duration   Configurable timeout for retrieving remote information (default 2m0s)
```
