### PR TITLE
Fix: skupper network status failure when formatting the links

### DIFF
--- a/client/connector_list.go
+++ b/client/connector_list.go
@@ -76,7 +76,7 @@ func (cli *VanClient) ConnectorList(ctx context.Context) ([]types.LinkStatus, er
 	return links, nil
 }
 
-func (cli *VanClient) getLocalLinkStatus(namespace string, siteNameMap map[string]string) (map[string]*types.LinkStatus, error) {
+func GetLocalLinkStatus(cli *VanClient, namespace string, siteNameMap map[string]string) (map[string]*types.LinkStatus, error) {
 	mapLinks := make(map[string]*types.LinkStatus)
 	secrets, err := cli.KubeClient.CoreV1().Secrets(namespace).List(metav1.ListOptions{LabelSelector: "skupper.io/type in (connection-token, token-claim)"})
 	if err != nil {

--- a/client/network_status_test.go
+++ b/client/network_status_test.go
@@ -1,0 +1,149 @@
+package client
+
+import (
+	"fmt"
+	"github.com/skupperproject/skupper/api/types"
+	"gotest.tools/assert"
+	"testing"
+)
+
+type testCase struct {
+	doc            string
+	site           types.SiteInfo
+	siteNameMap    map[string]string
+	isLocalSite    bool
+	expectedError  string
+	expectedResult []string
+}
+
+func TestGetFormattedLinks(t *testing.T) {
+
+	testcases := []testCase{
+		{
+			doc: "map-is-not-initialized",
+			site: types.SiteInfo{
+				Name:      "",
+				Namespace: "test1",
+				SiteId:    "",
+			},
+			isLocalSite:   false,
+			expectedError: "the site name map used to format the links has no values or it is not initialized",
+		},
+		{
+			doc: "map-is-empty",
+			site: types.SiteInfo{
+				Name:      "",
+				Namespace: "test2",
+				SiteId:    "",
+				Links:     []string{"link1"},
+			},
+			isLocalSite:   false,
+			siteNameMap:   map[string]string{},
+			expectedError: "the site name map used to format the links has no values or it is not initialized",
+		},
+		{
+			doc: "map-does-not-contain-the-value",
+			site: types.SiteInfo{
+				Name:      "",
+				Namespace: "test3",
+				SiteId:    "",
+				Links:     []string{"link1"},
+			},
+			isLocalSite:    false,
+			siteNameMap:    asMap([]string{"link2=site2"}),
+			expectedResult: []string{"link1-"},
+		},
+		{
+			doc: "returns-results-formatted",
+			site: types.SiteInfo{
+				Name:      "",
+				Namespace: "test4",
+				SiteId:    "",
+				Links:     []string{"link2"},
+			},
+			isLocalSite:    false,
+			siteNameMap:    asMap([]string{"link2=site2"}),
+			expectedResult: []string{"link2-site2"},
+		},
+		{
+			doc: "returns-results-formatted-with-link-id-trimmed",
+			site: types.SiteInfo{
+				Name:      "",
+				Namespace: "test5",
+				SiteId:    "",
+				Links:     []string{"link123456"},
+			},
+			isLocalSite:    false,
+			siteNameMap:    asMap([]string{"link123456=site1"}),
+			expectedResult: []string{"link123-site1"},
+		},
+		{
+			doc: "returns-error-after-checking-link-local-status",
+			site: types.SiteInfo{
+				Name:      "",
+				Namespace: "test6",
+				SiteId:    "",
+				Links:     []string{"link1"},
+			},
+			isLocalSite:   true,
+			siteNameMap:   asMap([]string{"link1=site1"}),
+			expectedError: "error getting local link status",
+		},
+		{
+			doc: "returns-results-formatted-with-local-data-in-red",
+			site: types.SiteInfo{
+				Name:      "",
+				Namespace: "test7",
+				SiteId:    "",
+				Links:     []string{"link1"},
+			},
+			isLocalSite:    true,
+			siteNameMap:    asMap([]string{"link1=site1"}),
+			expectedResult: []string{"\u001B[1;31mlink1-site1 (link not active)\u001B[0m"},
+		},
+		{
+			doc: "returns-results-formatted-with-local-data",
+			site: types.SiteInfo{
+				Name:      "",
+				Namespace: "test8",
+				SiteId:    "",
+				Links:     []string{"link1"},
+			},
+			isLocalSite:    true,
+			siteNameMap:    asMap([]string{"link1=site1"}),
+			expectedResult: []string{"link1-site1"},
+		},
+	}
+
+	for _, tc := range testcases {
+
+		cli, _ := newMockClient(tc.doc, "", "")
+
+		links, err := GetFormattedLinks(MockGetLocalLink, cli, tc.site, tc.siteNameMap, tc.isLocalSite)
+
+		if err != nil {
+			assert.Assert(t, err.Error() == tc.expectedError, "expected: '%s', but found: '%s'", tc.expectedError, err.Error())
+		} else {
+			assert.DeepEqual(t, links, tc.expectedResult)
+		}
+
+	}
+}
+
+func MockGetLocalLink(cli *VanClient, namespace string, siteNameMap map[string]string) (map[string]*types.LinkStatus, error) {
+	if namespace == "test6" {
+		return nil, fmt.Errorf("error getting local link status")
+	} else if namespace == "test7" {
+		mapLinks := make(map[string]*types.LinkStatus)
+		mapLinks["link1-site1"] = &types.LinkStatus{
+			Connected: false,
+		}
+		return mapLinks, nil
+	} else {
+		mapLinks := make(map[string]*types.LinkStatus)
+		mapLinks["link1-site1"] = &types.LinkStatus{
+			Connected: true,
+		}
+		return mapLinks, nil
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
-	github.com/aws/aws-sdk-go v1.34.28 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 // indirect


### PR DESCRIPTION
- Fixes #928.
- Updates dependencies: aws-sdk-go@v1.34.28 not available
