### PR TITLE
fix: updated bridge config for tcp listeners

### DIFF
--- a/cmd/config-sync/config_sync_test.go
+++ b/cmd/config-sync/config_sync_test.go
@@ -118,6 +118,44 @@ func TestSyncSecretsWithTlsEnabled(t *testing.T) {
 			sslProfileToSync: "skupper-tls-adservice",
 			expected:         "./tmp/skupper-router/tls/skupper-tls-adservice",
 		},
+		{
+			doc:    "adding-tcp-connector-with-tls",
+			before: &qdr.BridgeConfigDifference{},
+			after: &qdr.BridgeConfigDifference{
+				TcpConnectors: qdr.TcpEndpointDifference{
+					Added: []qdr.TcpEndpoint{
+						{
+							Name:       "adservice",
+							SslProfile: "skupper-service-client",
+						},
+					},
+				},
+				AddedSslProfiles: []string{
+					"skupper-service-client",
+				},
+			},
+			sslProfileToSync: "skupper-service-client",
+			expected:         "./tmp/skupper-router/tls/skupper-service-client",
+		},
+		{
+			doc:    "adding-tcp-listener-with-tls",
+			before: &qdr.BridgeConfigDifference{},
+			after: &qdr.BridgeConfigDifference{
+				TcpListeners: qdr.TcpEndpointDifference{
+					Added: []qdr.TcpEndpoint{
+						{
+							Name:       "adservice",
+							SslProfile: "skupper-tls-adservice",
+						},
+					},
+				},
+				AddedSslProfiles: []string{
+					"skupper-tls-adservice",
+				},
+			},
+			sslProfileToSync: "skupper-tls-adservice",
+			expected:         "./tmp/skupper-router/tls/skupper-tls-adservice",
+		},
 	}
 
 	for _, s := range scenarios {

--- a/pkg/qdr/amqp_mgmt.go
+++ b/pkg/qdr/amqp_mgmt.go
@@ -110,11 +110,12 @@ func (r Record) AsRecord(field string) Record {
 
 func asTcpEndpoint(record Record) TcpEndpoint {
 	return TcpEndpoint{
-		Name:    record.AsString("name"),
-		Host:    record.AsString("host"),
-		Port:    record.AsString("port"),
-		Address: record.AsString("address"),
-		SiteId:  record.AsString("siteId"),
+		Name:       record.AsString("name"),
+		Host:       record.AsString("host"),
+		Port:       record.AsString("port"),
+		Address:    record.AsString("address"),
+		SiteId:     record.AsString("siteId"),
+		SslProfile: record.AsString("sslProfile"),
 	}
 }
 

--- a/pkg/qdr/qdr.go
+++ b/pkg/qdr/qdr.go
@@ -864,11 +864,25 @@ func getSslProfilesDifference(before *BridgeConfig, desired *BridgeConfig) (Adde
 		originalSslConfig[httpListener.SslProfile] = httpListener.SslProfile
 	}
 
+	for _, tcpConnector := range before.TcpConnectors {
+		originalSslConfig[tcpConnector.SslProfile] = tcpConnector.SslProfile
+	}
+	for _, tcpListener := range before.TcpListeners {
+		originalSslConfig[tcpListener.SslProfile] = tcpListener.SslProfile
+	}
+
 	for _, httpConnector := range desired.HttpConnectors {
 		newSslConfig[httpConnector.SslProfile] = httpConnector.SslProfile
 	}
 	for _, httpListener := range desired.HttpListeners {
 		newSslConfig[httpListener.SslProfile] = httpListener.SslProfile
+	}
+
+	for _, tcpConnector := range desired.TcpConnectors {
+		newSslConfig[tcpConnector.SslProfile] = tcpConnector.SslProfile
+	}
+	for _, tcpListener := range desired.TcpListeners {
+		newSslConfig[tcpListener.SslProfile] = tcpListener.SslProfile
 	}
 
 	for key, name := range originalSslConfig {

--- a/pkg/qdr/qdr_test.go
+++ b/pkg/qdr/qdr_test.go
@@ -528,11 +528,31 @@ func TestGetSslProfilesDifference(t *testing.T) {
 				SslProfile:      types.SkupperServiceCertPrefix + "another-new-listener",
 			},
 		},
+		TcpConnectors: map[string]TcpEndpoint{
+			"newConnector": {
+				Name:       "newTcpConnector",
+				Address:    "new-tcp-connector",
+				Host:       "abc.io",
+				Port:       "4321",
+				SiteId:     "abc",
+				SslProfile: types.ServiceClientSecret,
+			},
+		},
+		TcpListeners: map[string]TcpEndpoint{
+			"newListener": {
+				Name:       "newTCPListener",
+				Address:    "new-tcp-listener",
+				Host:       "localhost",
+				Port:       "8765",
+				SiteId:     "def",
+				SslProfile: types.SkupperServiceCertPrefix + "the-database",
+			},
+		},
 	}
 
 	addedSslProfiles, deletedSslProfiles := getSslProfilesDifference(&before, &after)
 
-	expectedAddedSslProfiles := []string{types.SkupperServiceCertPrefix + "new-listener", types.SkupperServiceCertPrefix + "another-new-listener"}
+	expectedAddedSslProfiles := []string{types.SkupperServiceCertPrefix + "new-listener", types.SkupperServiceCertPrefix + "another-new-listener", types.SkupperServiceCertPrefix + "the-database"}
 	expectedDeletedSslProfiles := []string{types.SkupperServiceCertPrefix + "blue"}
 	assert.Assert(t, utils.StringSlicesEqual(addedSslProfiles, expectedAddedSslProfiles), "Expected %v but got %v", expectedAddedSslProfiles, addedSslProfiles)
 	assert.Assert(t, utils.StringSlicesEqual(deletedSslProfiles, expectedDeletedSslProfiles), "Expected %v but got %v", expectedDeletedSslProfiles, deletedSslProfiles)


### PR DESCRIPTION
When a service is exposed over TLS using the TCP protocol, the sslProfile is not created in the router before creating the tcpListener, so the router can not create the tcpListener because the sslProfile does not exist in it (even thought the sslProfile is already included in the skupper-internal configmap, creating it in the router explicitly is necessary because the router will not be restarted).