### PR TITLE
Expose router feature dataConnectionCount with flag on link create co…

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -17,6 +17,7 @@ type ConnectorCreateOptions struct {
 	SkupperNamespace string
 	Name             string
 	Cost             int32
+        Dcc              int
 }
 
 type ConnectorRemoveOptions struct {
@@ -29,6 +30,7 @@ type LinkStatus struct {
 	Name        string
 	Url         string
 	Cost        int
+	Dcc         int
 	Connected   bool
 	Configured  bool
 	Description string

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -168,6 +168,7 @@ const (
 	TokenGeneratedBy            string = BaseQualifier + "/generated-by"
 	SiteVersion                 string = BaseQualifier + "/site-version"
 	TokenCost                   string = BaseQualifier + "/cost"
+	TokenDcc                    string = BaseQualifier + "/dcc"
 	UpdatedAnnotation           string = InternalQualifier + "/updated"
 	AnnotationExcludes          string = BaseQualifier + "/exclude-annotations"
 	LabelExcludes               string = BaseQualifier + "/exclude-labels"
@@ -431,6 +432,7 @@ type Connector struct {
 	VerifyHostname bool   `json:"verifyHostname,omitempty"`
 	SslProfile     string `json:"sslProfile,omitempty"`
 	LinkCapacity   int32  `json:"linkCapacity,omitempty"`
+	Dcc            int    `json:"dataConnectionCount"`
 }
 
 type Credential struct {

--- a/client/connector_create.go
+++ b/client/connector_create.go
@@ -167,6 +167,12 @@ func (cli *VanClient) ConnectorCreateSecretFromData(ctx context.Context, secretD
 				}
 				secret.ObjectMeta.Annotations[types.TokenCost] = strconv.Itoa(int(options.Cost))
 			}
+			if options.Dcc != 0 {
+				if secret.ObjectMeta.Annotations == nil {
+					secret.ObjectMeta.Annotations = map[string]string{}
+				}
+				secret.ObjectMeta.Annotations[types.TokenDcc] = strconv.Itoa(int(options.Dcc))
+			}
 			_, err = cli.KubeClient.CoreV1().Secrets(options.SkupperNamespace).Create(&secret)
 			if err == nil {
 				return &secret, nil
@@ -268,6 +274,7 @@ func (cli *VanClient) ConnectorCreate(ctx context.Context, secret *corev1.Secret
 			Name:       options.Name,
 			Cost:       options.Cost,
 			SslProfile: profileName,
+                        Dcc:        options.Dcc,
 		}
 		connector.SetMaxFrameSize(siteConfig.Spec.Router.MaxFrameSize)
 		connector.SetMaxSessionFrames(siteConfig.Spec.Router.MaxSessionFrames)

--- a/client/connector_list.go
+++ b/client/connector_list.go
@@ -35,6 +35,7 @@ func getLinkStatus(s *corev1.Secret, edge bool, connections []qdr.Connection) ty
 		if connection := kubeqdr.GetInterRouterOrEdgeConnection(link.Url, connections); connection != nil && connection.Active {
 			link.Connected = true
 			link.Cost, _ = strconv.Atoi(s.ObjectMeta.Annotations[types.TokenCost])
+			link.Dcc,  _ = strconv.Atoi(s.ObjectMeta.Annotations[types.TokenDcc])
 			link.Created = s.ObjectMeta.CreationTimestamp.String()
 		}
 		if s.ObjectMeta.Labels[types.SkupperDisabledQualifier] == "true" {

--- a/cmd/service-controller/links.go
+++ b/cmd/service-controller/links.go
@@ -94,6 +94,12 @@ func getLinkFromClaim(s *corev1.Secret) *types.LinkStatus {
 				link.Cost = cost
 			}
 		}
+		if value, ok := s.ObjectMeta.Annotations[types.TokenDcc]; ok {
+			dcc, err := strconv.Atoi(value)
+			if err == nil {
+				link.Dcc = dcc
+			}
+		}
 	}
 	return &link
 }

--- a/cmd/service-controller/token_handler_test.go
+++ b/cmd/service-controller/token_handler_test.go
@@ -156,6 +156,53 @@ func TestTokenHandler(t *testing.T) {
 			},
 			expectedConnector: nil,
 		},
+		{  // Set dataConnectionCount to 3
+			name: "six",
+			annotations: map[string]string{
+				types.TokenDcc:      "3",
+				"inter-router-host": "myrouter.com",
+				"inter-router-port": "55671",
+			},
+			expectedConnector: &qdr.Connector{
+				Name:       "six",
+				Host:       "myrouter.com",
+				Port:       "55671",
+				Cost:       0,
+				SslProfile: "six-profile",
+                                Dcc:        3,
+			},
+		},
+		{  // Do not set dataConnectionCount
+			name: "seven",
+			annotations: map[string]string{
+				"inter-router-host": "myrouter.com",
+				"inter-router-port": "55671",
+			},
+			expectedConnector: &qdr.Connector{
+				Name:       "seven",
+				Host:       "myrouter.com",
+				Port:       "55671",
+				Cost:       0,
+				SslProfile: "seven-profile",
+                                Dcc:        0,
+			},
+		},
+		{  // Set dataConnectionCount to a bad value
+			name: "eight",
+			annotations: map[string]string{
+				"inter-router-host": "myrouter.com",
+				"inter-router-port": "55671",
+				types.TokenDcc:      "foo",
+			},
+			expectedConnector: &qdr.Connector{
+				Name:       "eight",
+				Host:       "myrouter.com",
+				Port:       "55671",
+				Cost:       0,
+				SslProfile: "eight-profile",
+                                Dcc:        0,
+			},
+		},
 	}
 	for _, test := range tests {
 		token := createToken(test.name, test.annotations)
@@ -182,6 +229,7 @@ func TestTokenHandler(t *testing.T) {
 			assert.Equal(t, connector.Host, test.expectedConnector.Host, test.name)
 			assert.Equal(t, connector.Port, test.expectedConnector.Port, test.name)
 			assert.Equal(t, connector.Cost, test.expectedConnector.Cost, test.name)
+			assert.Equal(t, connector.Dcc,  test.expectedConnector.Dcc,  test.name)
 			assert.Equal(t, connector.SslProfile, test.expectedConnector.SslProfile, test.name)
 
 			//now disconnect:

--- a/cmd/site-controller/controller.go
+++ b/cmd/site-controller/controller.go
@@ -287,6 +287,21 @@ func getTokenCost(token *corev1.Secret) (int32, bool) {
 	return 0, false
 }
 
+func getTokenDcc(token *corev1.Secret) (int, bool) {
+	if token.ObjectMeta.Annotations == nil {
+		return 0, false
+	}
+	if dccString, ok := token.ObjectMeta.Annotations[types.TokenDcc]; ok {
+		dcc, err := strconv.Atoi(dccString)
+		if err != nil {
+			log.Printf("Ignoring invalid dcc annotation %q", dccString)
+			return 0, false
+		}
+		return int(dcc), true
+	}
+	return 0, false
+}
+
 func (c *SiteController) connect(token *corev1.Secret, namespace string) error {
 	log.Printf("Connecting site in %s using token %s", namespace, token.ObjectMeta.Name)
 	var options types.ConnectorCreateOptions
@@ -294,6 +309,9 @@ func (c *SiteController) connect(token *corev1.Secret, namespace string) error {
 	options.SkupperNamespace = namespace
 	if cost, ok := getTokenCost(token); ok {
 		options.Cost = cost
+	}
+	if dcc, ok := getTokenDcc(token); ok {
+		options.Dcc = dcc
 	}
 	return c.vanClient.ConnectorCreate(context.Background(), token, options)
 }

--- a/cmd/site-controller/controller_cluster_test.go
+++ b/cmd/site-controller/controller_cluster_test.go
@@ -261,6 +261,7 @@ func TestSiteControlleWithCluster(t *testing.T) {
 		Data: currentToken.Data,
 	}
 	connectSecret.ObjectMeta.Annotations[types.TokenCost] = "5"
+	connectSecret.ObjectMeta.Annotations[types.TokenDcc]  = "2"
 
 	os.Setenv("WATCH_NAMESPACE", privateNamespace)
 	privateController, err := NewSiteController(privateCli)

--- a/cmd/skupper/skupper_kube_link.go
+++ b/cmd/skupper/skupper_kube_link.go
@@ -36,6 +36,7 @@ func (s *SkupperKubeLink) Create(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 	connectorCreateOpts.SkupperNamespace = cli.GetNamespace()
+	connectorCreateOpts.Dcc, _ = cmd.Flags().GetInt("dataConnectionCount")
 	yaml, err := ioutil.ReadFile(args[0])
 	if err != nil {
 		return fmt.Errorf("Could not read connection token: %s", err.Error())

--- a/cmd/skupper/skupper_link.go
+++ b/cmd/skupper/skupper_link.go
@@ -34,6 +34,7 @@ func NewCmdLinkCreate(skupperClient SkupperLinkClient, flag string) *cobra.Comma
 	}
 	cmd.Flags().StringVarP(&connectorCreateOpts.Name, flag, "", "", "Provide a specific name for the link (used when deleting it)")
 	cmd.Flags().Int32VarP(&connectorCreateOpts.Cost, "cost", "", 1, "Specify a cost for this link.")
+	cmd.Flags().IntVarP(&connectorCreateOpts.Dcc, "dataConnectionCount", "", 1, "How many inter-router data connections")
 
 	return cmd
 }

--- a/pkg/qdr/amqp_mgmt.go
+++ b/pkg/qdr/amqp_mgmt.go
@@ -1165,6 +1165,7 @@ type ConnectorStatus struct {
 	Port        string
 	Role        string
 	Cost        int
+        Dcc         int
 	Status      string
 	Description string
 }
@@ -1176,6 +1177,7 @@ func asConnectorStatus(record Record) ConnectorStatus {
 		Port:        record.AsString("port"),
 		Role:        record.AsString("role"),
 		Cost:        record.AsInt("cost"),
+		Dcc:         record.AsInt("dataConnectionCount"),
 		Status:      record.AsString("connectionStatus"),
 		Description: record.AsString("connectionMsg"),
 	}
@@ -1186,6 +1188,7 @@ func asConnector(record Record) Connector {
 		Name:           record.AsString("name"),
 		Host:           record.AsString("host"),
 		Port:           record.AsString("port"),
+		Dcc:            record.AsInt("dataConnectionCount"),
 		RouteContainer: record.AsBool("routeContainer"),
 		VerifyHostname: record.AsBool("verifyHostname"),
 		SslProfile:     record.AsString("sslProfile"),
@@ -1202,7 +1205,6 @@ func asSslProfile(record Record) SslProfile {
 }
 
 func asRecord(connector Connector) Record {
-
 	record := map[string]interface{}{}
 	record["name"] = connector.Name
 	record["role"] = string(connector.Role)
@@ -1220,6 +1222,9 @@ func asRecord(connector Connector) Record {
 	if connector.MaxSessionFrames > 0 {
 		record["maxSessionFrames"] = connector.MaxSessionFrames
 	}
+	if connector.Dcc > 0 {
+		record["dataConnectionCount"] = connector.Dcc
+        }
 
 	return record
 }

--- a/pkg/qdr/qdr.go
+++ b/pkg/qdr/qdr.go
@@ -404,6 +404,7 @@ type Connector struct {
 	VerifyHostname   bool   `json:"verifyHostname,omitempty"`
 	SslProfile       string `json:"sslProfile,omitempty"`
 	LinkCapacity     int32  `json:"linkCapacity,omitempty"`
+	Dcc              int    `json:"dataConnectionCount,omitempty"`
 	MaxFrameSize     int    `json:"maxFrameSize,omitempty"`
 	MaxSessionFrames int    `json:"maxSessionFrames,omitempty"`
 }

--- a/pkg/utils/configs/config.go
+++ b/pkg/utils/configs/config.go
@@ -38,6 +38,7 @@ connector {
     name: {{.Name}}-connector
     host: {{.Host}}
     port: {{.Port}}
+    dataConnectionCount: {{.Dcc}}
     role: {{.Role}}
     cost: {{.Cost}}
     sslProfile: {{.Name}}-profile

--- a/test/integration/acceptance/custom/edge_connectivity/edge_connectivity.go
+++ b/test/integration/acceptance/custom/edge_connectivity/edge_connectivity.go
@@ -14,8 +14,6 @@ import (
 	"gotest.tools/assert"
 )
 
-var fp = fmt.Fprintf
-
 type TestCase struct {
 	name               string
 	diagram            []string


### PR DESCRIPTION
…mmand

This allows user to control data connection count  (number of parallel data links) on inter-router connections between skupper sites. -- using a flag on the link create command.

This is my first Skupper PR, somebody please let me know what I missed...
