### PR TITLE
Increase timeout for -use-cluster tests to 20 min

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
       - run:
           command: >-
             curl -Lo minikube
-            https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && 
+            https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 &&
             chmod +x minikube && sudo
             mv minikube /usr/local/bin/
           name: Install Minikube Executable
@@ -171,7 +171,7 @@ commands:
             go test -tags=integration -timeout=60m -v ./test/integration/...
       - run:
           name: Run client tests in real cluster
-          command: go test -v -count=1 ./client -use-cluster
+          command: go test -v -count=1 -timeout=20m ./client -use-cluster
       - run:
           name: Run skupper cli tests in real cluster
           command: go test -v -count=1 ./cmd/skupper -use-cluster


### PR DESCRIPTION
CircleCI does not allow for an easy way to check the time it takes for each step on various runs.  I checked the last three successful CI runs for the master branch, and they're taking between 9 and 10 minutes, which makes it fairly possible that the test will fail with the default 10 min timeout from `go test`.

That actually happened on [this run](https://app.circleci.com/pipelines/github/skupperproject/skupper/2038/workflows/59705de2-d743-4e1c-8538-fccadb139ff0/jobs/10547) at 10m2s, while [this one](https://app.circleci.com/pipelines/github/skupperproject/skupper/2013/workflows/1b299352-611a-41b8-9005-d459c83ccc4e/jobs/10363) passed in 10m1s.