### PR TITLE
Support for deploymentconfigs in OpenShift

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -118,6 +118,11 @@ var ControllerPolicyRule = []rbacv1.PolicyRule{
 	},
 	{
 		Verbs:     []string{"get", "list", "watch"},
+		APIGroups: []string{"apps.openshift.io"},
+		Resources: []string{"deploymentconfigs"},
+	},
+	{
+		Verbs:     []string{"get", "list", "watch"},
 		APIGroups: []string{"networking.k8s.io"},
 		Resources: []string{"ingresses"},
 	},

--- a/client/client.go
+++ b/client/client.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/openshift/client-go/apps/clientset/versioned"
+	openshiftapps "github.com/openshift/client-go/apps/clientset/versioned"
 	"time"
 
 	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
@@ -33,7 +33,7 @@ type VanClient struct {
 	Namespace       string
 	KubeClient      kubernetes.Interface
 	RouteClient     *routev1client.RouteV1Client
-	OCAppsClient    versioned.Interface
+	OCAppsClient    openshiftapps.Interface
 	RestConfig      *restclient.Config
 	DynamicClient   dynamic.Interface
 	DiscoveryClient *discovery.DiscoveryClient
@@ -98,7 +98,7 @@ func NewClient(namespace string, context string, kubeConfigPath string) (*VanCli
 	}
 	resources, err = dc.ServerResourcesForGroupVersion("apps.openshift.io/v1")
 	if err == nil && len(resources.APIResources) > 0 {
-		c.OCAppsClient, err = versioned.NewForConfig(restconfig)
+		c.OCAppsClient, err = openshiftapps.NewForConfig(restconfig)
 		if err != nil {
 			return c, err
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	appsv1client "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
 	"time"
 
 	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
@@ -32,6 +33,7 @@ type VanClient struct {
 	Namespace       string
 	KubeClient      kubernetes.Interface
 	RouteClient     *routev1client.RouteV1Client
+	AppsClient      *appsv1client.AppsV1Client
 	RestConfig      *restclient.Config
 	DynamicClient   dynamic.Interface
 	DiscoveryClient *discovery.DiscoveryClient
@@ -94,6 +96,14 @@ func NewClient(namespace string, context string, kubeConfigPath string) (*VanCli
 			return c, err
 		}
 	}
+	resources, err = dc.ServerResourcesForGroupVersion("apps.openshift.io/v1")
+	if err == nil && len(resources.APIResources) > 0 {
+		c.AppsClient, err = appsv1client.NewForConfig(restconfig)
+		if err != nil {
+			return c, err
+		}
+	}
+
 	c.DiscoveryClient = dc
 
 	if namespace == "" {

--- a/client/client.go
+++ b/client/client.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	appsv1client "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
+	"github.com/openshift/client-go/apps/clientset/versioned"
 	"time"
 
 	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
@@ -33,7 +33,7 @@ type VanClient struct {
 	Namespace       string
 	KubeClient      kubernetes.Interface
 	RouteClient     *routev1client.RouteV1Client
-	AppsClient      *appsv1client.AppsV1Client
+	OCAppsClient    versioned.Interface
 	RestConfig      *restclient.Config
 	DynamicClient   dynamic.Interface
 	DiscoveryClient *discovery.DiscoveryClient
@@ -98,7 +98,7 @@ func NewClient(namespace string, context string, kubeConfigPath string) (*VanCli
 	}
 	resources, err = dc.ServerResourcesForGroupVersion("apps.openshift.io/v1")
 	if err == nil && len(resources.APIResources) > 0 {
-		c.AppsClient, err = appsv1client.NewForConfig(restconfig)
+		c.OCAppsClient, err = versioned.NewForConfig(restconfig)
 		if err != nil {
 			return c, err
 		}

--- a/client/router_create.go
+++ b/client/router_create.go
@@ -89,10 +89,12 @@ func (cli *VanClient) getControllerRules() []rbacv1.PolicyRule {
 	// remove rule for routes or DeploymentConfigs if they are not defined
 	var rules []rbacv1.PolicyRule
 	for _, rule := range types.ControllerPolicyRule {
-		shouldAvoidRoutesRule := cli.RouteClient == nil && len(rule.APIGroups) > 0 && rule.APIGroups[0] == "route.openshift.io"
-		shouldAvoidDepConfigRule := cli.OCAppsClient == nil && len(rule.APIGroups) > 0 && rule.APIGroups[0] == "apps.openshift.io"
 
-		if shouldAvoidRoutesRule || shouldAvoidDepConfigRule {
+		if cli.RouteClient == nil && len(rule.APIGroups) > 0 && rule.APIGroups[0] == "route.openshift.io" {
+			continue
+		}
+
+		if cli.OCAppsClient == nil && len(rule.APIGroups) > 0 && rule.APIGroups[0] == "apps.openshift.io" {
 			continue
 		}
 

--- a/client/router_create.go
+++ b/client/router_create.go
@@ -86,17 +86,19 @@ func EdgeListener(options types.SiteConfigSpec) qdr.Listener {
 }
 
 func (cli *VanClient) getControllerRules() []rbacv1.PolicyRule {
-	if cli.RouteClient == nil {
-		// remove rule for routes if routes not defined
-		rules := []rbacv1.PolicyRule{}
-		for _, rule := range types.ControllerPolicyRule {
-			if len(rule.APIGroups) > 0 && rule.APIGroups[0] != "route.openshift.io" {
-				rules = append(rules, rule)
-			}
+	// remove rule for routes or DeploymentConfigs if they are not defined
+	var rules []rbacv1.PolicyRule
+	for _, rule := range types.ControllerPolicyRule {
+		shouldAvoidRoutesRule := cli.RouteClient == nil && len(rule.APIGroups) > 0 && rule.APIGroups[0] == "route.openshift.io"
+		shouldAvoidDepConfigRule := cli.OCAppsClient == nil && len(rule.APIGroups) > 0 && rule.APIGroups[0] == "apps.openshift.io"
+
+		if shouldAvoidRoutesRule || shouldAvoidDepConfigRule {
+			continue
 		}
-		return rules
+
+		rules = append(rules, rule)
 	}
-	return types.ControllerPolicyRule
+	return rules
 }
 
 func (cli *VanClient) GetVanControllerSpec(options types.SiteConfigSpec, van *types.RouterSpec, transport *appsv1.Deployment, siteId string) {

--- a/client/serviceinterface_update.go
+++ b/client/serviceinterface_update.go
@@ -171,7 +171,7 @@ func (cli *VanClient) ServiceInterfaceBind(ctx context.Context, service *types.S
 			return fmt.Errorf("Invalid protocol %s for service with mapping %s", protocol, service.Protocol)
 		}
 		deducePorts := len(service.Ports) == 0 && len(targetPorts) == 0
-		target, err := kube.GetServiceInterfaceTarget(targetType, targetName, deducePorts, cli.Namespace, cli.KubeClient, cli.AppsClient)
+		target, err := kube.GetServiceInterfaceTarget(targetType, targetName, deducePorts, cli.Namespace, cli.KubeClient, cli.OCAppsClient)
 		if err != nil {
 			return err
 		}
@@ -310,7 +310,7 @@ func removeServiceInterfaceTarget(serviceName string, targetName string, deleteI
 }
 
 func (cli *VanClient) ServiceInterfaceUnbind(ctx context.Context, targetType string, targetName string, address string, deleteIfNoTargets bool) error {
-	if targetType == "deployment" || targetType == "statefulset" || targetType == "service" {
+	if targetType == "deployment" || targetType == "statefulset" || targetType == "service" || targetType == "deploymentconfig" {
 		if address == "" {
 			err := removeServiceInterfaceTarget(targetName, targetName, deleteIfNoTargets, cli)
 			return err

--- a/client/serviceinterface_update.go
+++ b/client/serviceinterface_update.go
@@ -171,7 +171,7 @@ func (cli *VanClient) ServiceInterfaceBind(ctx context.Context, service *types.S
 			return fmt.Errorf("Invalid protocol %s for service with mapping %s", protocol, service.Protocol)
 		}
 		deducePorts := len(service.Ports) == 0 && len(targetPorts) == 0
-		target, err := kube.GetServiceInterfaceTarget(targetType, targetName, deducePorts, cli.Namespace, cli.KubeClient)
+		target, err := kube.GetServiceInterfaceTarget(targetType, targetName, deducePorts, cli.Namespace, cli.KubeClient, cli.AppsClient)
 		if err != nil {
 			return err
 		}

--- a/cmd/service-controller/definition_monitor.go
+++ b/cmd/service-controller/definition_monitor.go
@@ -125,7 +125,11 @@ func (m *DefinitionMonitor) start(stopCh <-chan struct{}) error {
 	go m.statefulSetInformer.Run(stopCh)
 	go m.daemonSetInformer.Run(stopCh)
 	go m.deploymentInformer.Run(stopCh)
-	go m.deploymentConfigInformer.Run(stopCh)
+
+	if m.deploymentConfigInformer != nil {
+		go m.deploymentConfigInformer.Run(stopCh)
+	}
+
 	if ok := cache.WaitForCacheSync(stopCh, m.statefulSetInformer.HasSynced, m.daemonSetInformer.HasSynced, m.deploymentInformer.HasSynced); !ok {
 		return fmt.Errorf("Failed to wait for caches to sync")
 	}

--- a/cmd/service-controller/definition_monitor.go
+++ b/cmd/service-controller/definition_monitor.go
@@ -326,7 +326,7 @@ func (m *DefinitionMonitor) getServiceDefinitionFromAnnotatedDeploymentConfig(de
 		svc.Origin = "annotation"
 
 		if policyRes := m.policy.ValidateExpose("deploymentconfig", deploymentConfig.Name); !policyRes.Allowed() {
-			event.Recordf(DefinitionMonitorIgnored, "Policy validation error: deployment/%s cannot be exposed", deploymentConfig.ObjectMeta.Name)
+			event.Recordf(DefinitionMonitorIgnored, "Policy validation error: deploymentconfig/%s cannot be exposed", deploymentConfig.ObjectMeta.Name)
 			return types.ServiceInterface{}, false
 		}
 		if policyRes := m.policy.ValidateImportService(svc.Address); !policyRes.Allowed() {
@@ -919,7 +919,7 @@ func (m *DefinitionMonitor) processNextEvent() bool {
 				} else if exists {
 					deploymentConfig, ok := obj.(*appv1.DeploymentConfig)
 					if !ok {
-						return fmt.Errorf("Expected Deployment for %s but got %#v", name, obj)
+						return fmt.Errorf("Expected DeploymentConfig for %s but got %#v", name, obj)
 					}
 
 					desired, ok := m.getServiceDefinitionFromAnnotatedDeploymentConfig(deploymentConfig)
@@ -934,7 +934,7 @@ func (m *DefinitionMonitor) processNextEvent() bool {
 							deleted := []string{}
 							err = kube.UpdateSkupperServices(changed, deleted, "annotation", m.vanClient.Namespace, m.vanClient.KubeClient)
 							if err != nil {
-								return fmt.Errorf("failed to update service definition for annotated deployment %s: %s", name, err)
+								return fmt.Errorf("failed to update service definition for annotated deploymentconfig %s: %s", name, err)
 							}
 							m.annotated[desired.Address] = desired
 						}

--- a/cmd/service-controller/policy_controller.go
+++ b/cmd/service-controller/policy_controller.go
@@ -401,7 +401,7 @@ func (c *PolicyController) inferTargetType(target types.ServiceInterfaceTarget) 
 	}
 	getBySelector := func(targetTypes ...string) string {
 		for _, targetType := range targetTypes {
-			retTarget, err := kube.GetServiceInterfaceTarget(targetType, target.Name, true, c.cli.Namespace, c.cli.KubeClient)
+			retTarget, err := kube.GetServiceInterfaceTarget(targetType, target.Name, true, c.cli.Namespace, c.cli.KubeClient, c.cli.AppsClient)
 			if err == nil {
 				if retTarget.Selector == target.Selector {
 					return targetType

--- a/cmd/service-controller/policy_controller.go
+++ b/cmd/service-controller/policy_controller.go
@@ -411,7 +411,7 @@ func (c *PolicyController) inferTargetType(target types.ServiceInterfaceTarget) 
 		return ""
 	}
 
-	return getBySelector("deployment", "statefulset", "deploymentconfig")
+	return getBySelector(DeploymentObjectType, StatefulSetObjectType, DeploymentConfigObjectType)
 }
 
 func NewPolicyController(cli *client.VanClient) *PolicyController {

--- a/cmd/service-controller/policy_controller.go
+++ b/cmd/service-controller/policy_controller.go
@@ -411,7 +411,7 @@ func (c *PolicyController) inferTargetType(target types.ServiceInterfaceTarget) 
 		return ""
 	}
 
-	return getBySelector("deployment", "statefulset")
+	return getBySelector("deployment", "statefulset", "deploymentconfig")
 }
 
 func NewPolicyController(cli *client.VanClient) *PolicyController {

--- a/cmd/service-controller/policy_controller.go
+++ b/cmd/service-controller/policy_controller.go
@@ -401,7 +401,7 @@ func (c *PolicyController) inferTargetType(target types.ServiceInterfaceTarget) 
 	}
 	getBySelector := func(targetTypes ...string) string {
 		for _, targetType := range targetTypes {
-			retTarget, err := kube.GetServiceInterfaceTarget(targetType, target.Name, true, c.cli.Namespace, c.cli.KubeClient, c.cli.AppsClient)
+			retTarget, err := kube.GetServiceInterfaceTarget(targetType, target.Name, true, c.cli.Namespace, c.cli.KubeClient, c.cli.OCAppsClient)
 			if err == nil {
 				if retTarget.Selector == target.Selector {
 					return targetType

--- a/cmd/service-controller/services.go
+++ b/cmd/service-controller/services.go
@@ -129,7 +129,7 @@ func (m *ServiceManager) createService(options *ServiceOptions) error {
 		Ports:    options.GetPorts(),
 	}
 	deducePort := options.DeducePort()
-	target, err := kube.GetServiceInterfaceTarget(options.GetTargetType(), options.GetTargetName(), deducePort, m.cli.Namespace, m.cli.KubeClient, m.cli.AppsClient)
+	target, err := kube.GetServiceInterfaceTarget(options.GetTargetType(), options.GetTargetName(), deducePort, m.cli.Namespace, m.cli.KubeClient, m.cli.OCAppsClient)
 	if err != nil {
 		return err
 	}

--- a/cmd/service-controller/services.go
+++ b/cmd/service-controller/services.go
@@ -129,7 +129,7 @@ func (m *ServiceManager) createService(options *ServiceOptions) error {
 		Ports:    options.GetPorts(),
 	}
 	deducePort := options.DeducePort()
-	target, err := kube.GetServiceInterfaceTarget(options.GetTargetType(), options.GetTargetName(), deducePort, m.cli.Namespace, m.cli.KubeClient)
+	target, err := kube.GetServiceInterfaceTarget(options.GetTargetType(), options.GetTargetName(), deducePort, m.cli.Namespace, m.cli.KubeClient, m.cli.AppsClient)
 	if err != nil {
 		return err
 	}

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -459,7 +459,7 @@ var exposeOpts ExposeOptions
 
 func NewCmdExpose(skupperCli SkupperServiceClient) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "expose [deployment <name>|pods <selector>|statefulset <statefulsetname>|service <name>]",
+		Use:    "expose [deployment <name>|pods <selector>|statefulset <statefulsetname>|service <name>|deploymentconfig <name>]",
 		Short:  "Expose a set of pods through a Skupper address",
 		Args:   skupperCli.ExposeArgs,
 		PreRun: skupperCli.NewClient,

--- a/cmd/skupper/skupper_cluster_test.go
+++ b/cmd/skupper/skupper_cluster_test.go
@@ -871,7 +871,7 @@ func TestExposeWithCluster(t *testing.T) {
 			args:            []string{"deployent", "tcp-not-deployed"},
 			expectedCapture: "",
 			expectedOutput:  "",
-			expectedError:   "target type must be one of: [deployment, statefulset, pods, service]",
+			expectedError:   "target type must be one of: [deployment, statefulset, pods, service, deploymentconfig]",
 			realCluster:     false,
 		},
 		{
@@ -1054,7 +1054,7 @@ func TestUnexposeWithCluster(t *testing.T) {
 			args:            []string{"deployent", "tcp-not-deployed"},
 			expectedCapture: "",
 			expectedOutput:  "",
-			expectedError:   "target type must be one of: [deployment, statefulset, pods, service]",
+			expectedError:   "target type must be one of: [deployment, statefulset, pods, service, deploymentconfig]",
 			realCluster:     false,
 		},
 		{

--- a/cmd/skupper/skupper_kube_expose.go
+++ b/cmd/skupper/skupper_kube_expose.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var validExposeTargetsKube = []string{"deployment", "statefulset", "pods", "service"}
+var validExposeTargetsKube = []string{"deployment", "statefulset", "pods", "service", "deploymentconfig"}
 
 func (s *SkupperKubeService) verifyTargetTypeFromArgs(args []string) error {
 	targetType, _ := parseTargetTypeAndName(args)

--- a/cmd/skupper/skupper_test.go
+++ b/cmd/skupper/skupper_test.go
@@ -36,7 +36,7 @@ func TestBindArgs(t *testing.T) {
 	// must this fail?
 	// assert.Error(t, b([]string{"one/two", "resource/name"}), genericError)
 
-	assert.Error(t, b([]string{"one", "resource/name"}), "target type must be one of: [deployment, statefulset, pods, service]")
+	assert.Error(t, b([]string{"one", "resource/name"}), "target type must be one of: [deployment, statefulset, pods, service, deploymentconfig]")
 
 	assert.Assert(t, b([]string{"one", "pods/name"}))
 	assert.Assert(t, b([]string{"one", "pods", "name"}))
@@ -96,7 +96,7 @@ func TestCreateServiceParseArgs(t *testing.T) {
 func TestExposeTargetArgs(t *testing.T) {
 	s := &SkupperKubeService{}
 	genericError := "expose target and name must be specified (e.g. 'skupper expose deployment <name>'"
-	targetError := "target type must be one of: [deployment, statefulset, pods, service]"
+	targetError := "target type must be one of: [deployment, statefulset, pods, service, deploymentconfig]"
 
 	e := func(args []string) error {
 		return s.ExposeArgs(nil, args)

--- a/pkg/kube/deploymentconfigs.go
+++ b/pkg/kube/deploymentconfigs.go
@@ -1,0 +1,1 @@
+package kube

--- a/pkg/kube/deploymentconfigs.go
+++ b/pkg/kube/deploymentconfigs.go
@@ -2,11 +2,11 @@ package kube
 
 import (
 	appv1 "github.com/openshift/api/apps/v1"
-	appsv1client "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
+	"github.com/openshift/client-go/apps/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func GetDeploymentConfig(name string, namespace string, appsClient *appsv1client.AppsV1Client) (*appv1.DeploymentConfig, error) {
-	depConfig, err := appsClient.DeploymentConfigs(namespace).Get(name, metav1.GetOptions{})
+func GetDeploymentConfig(name string, namespace string, appsClient versioned.Interface) (*appv1.DeploymentConfig, error) {
+	depConfig, err := appsClient.AppsV1().DeploymentConfigs(namespace).Get(name, metav1.GetOptions{})
 	return depConfig, err
 }

--- a/pkg/kube/deploymentconfigs.go
+++ b/pkg/kube/deploymentconfigs.go
@@ -1,1 +1,12 @@
 package kube
+
+import (
+	appv1 "github.com/openshift/api/apps/v1"
+	appsv1client "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetDeploymentConfig(name string, namespace string, appsClient *appsv1client.AppsV1Client) (*appv1.DeploymentConfig, error) {
+	depConfig, err := appsClient.DeploymentConfigs(namespace).Get(name, metav1.GetOptions{})
+	return depConfig, err
+}

--- a/pkg/kube/deploymentconfigs.go
+++ b/pkg/kube/deploymentconfigs.go
@@ -10,3 +10,11 @@ func GetDeploymentConfig(name string, namespace string, appsClient versioned.Int
 	depConfig, err := appsClient.AppsV1().DeploymentConfigs(namespace).Get(name, metav1.GetOptions{})
 	return depConfig, err
 }
+
+func GetContainerPortForDeploymentConfig(deploymentConfig *appv1.DeploymentConfig) map[int]int {
+	if len(deploymentConfig.Spec.Template.Spec.Containers) > 0 && len(deploymentConfig.Spec.Template.Spec.Containers[0].Ports) > 0 {
+		return GetAllContainerPorts(deploymentConfig.Spec.Template.Spec.Containers[0])
+	} else {
+		return map[int]int{}
+	}
+}

--- a/pkg/kube/deployments.go
+++ b/pkg/kube/deployments.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/skupperproject/skupper/pkg/qdr"
+	appv1 "github.com/openshift/api/apps/v1"
 	"time"
 
 	"github.com/skupperproject/skupper/pkg/utils"
@@ -423,6 +424,14 @@ func NewTransportDeployment(van *types.RouterSpec, ownerRef *metav1.OwnerReferen
 func GetContainerPort(deployment *appsv1.Deployment) map[int]int {
 	if len(deployment.Spec.Template.Spec.Containers) > 0 && len(deployment.Spec.Template.Spec.Containers[0].Ports) > 0 {
 		return GetAllContainerPorts(deployment.Spec.Template.Spec.Containers[0])
+	} else {
+		return map[int]int{}
+	}
+}
+
+func GetContainerPortForDeploymentConfig(deploymentConfig *appv1.DeploymentConfig) map[int]int {
+	if len(deploymentConfig.Spec.Template.Spec.Containers) > 0 && len(deploymentConfig.Spec.Template.Spec.Containers[0].Ports) > 0 {
+		return GetAllContainerPorts(deploymentConfig.Spec.Template.Spec.Containers[0])
 	} else {
 		return map[int]int{}
 	}

--- a/pkg/kube/deployments.go
+++ b/pkg/kube/deployments.go
@@ -3,7 +3,6 @@ package kube
 import (
 	"context"
 	"fmt"
-	appv1 "github.com/openshift/api/apps/v1"
 	"github.com/skupperproject/skupper/pkg/qdr"
 	"time"
 
@@ -424,14 +423,6 @@ func NewTransportDeployment(van *types.RouterSpec, ownerRef *metav1.OwnerReferen
 func GetContainerPort(deployment *appsv1.Deployment) map[int]int {
 	if len(deployment.Spec.Template.Spec.Containers) > 0 && len(deployment.Spec.Template.Spec.Containers[0].Ports) > 0 {
 		return GetAllContainerPorts(deployment.Spec.Template.Spec.Containers[0])
-	} else {
-		return map[int]int{}
-	}
-}
-
-func GetContainerPortForDeploymentConfig(deploymentConfig *appv1.DeploymentConfig) map[int]int {
-	if len(deploymentConfig.Spec.Template.Spec.Containers) > 0 && len(deploymentConfig.Spec.Template.Spec.Containers[0].Ports) > 0 {
-		return GetAllContainerPorts(deploymentConfig.Spec.Template.Spec.Containers[0])
 	} else {
 		return map[int]int{}
 	}

--- a/pkg/kube/deployments.go
+++ b/pkg/kube/deployments.go
@@ -3,8 +3,8 @@ package kube
 import (
 	"context"
 	"fmt"
-	"github.com/skupperproject/skupper/pkg/qdr"
 	appv1 "github.com/openshift/api/apps/v1"
+	"github.com/skupperproject/skupper/pkg/qdr"
 	"time"
 
 	"github.com/skupperproject/skupper/pkg/utils"

--- a/pkg/kube/misc.go
+++ b/pkg/kube/misc.go
@@ -16,7 +16,7 @@ package kube
 
 import (
 	"fmt"
-	appsv1client "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
+	"github.com/openshift/client-go/apps/clientset/versioned"
 	"k8s.io/client-go/kubernetes"
 	"reflect"
 	"strconv"
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func GetServiceInterfaceTarget(targetType string, targetName string, deducePort bool, namespace string, cli kubernetes.Interface, appscli *appsv1client.AppsV1Client) (*types.ServiceInterfaceTarget, error) {
+func GetServiceInterfaceTarget(targetType string, targetName string, deducePort bool, namespace string, cli kubernetes.Interface, appscli versioned.Interface) (*types.ServiceInterfaceTarget, error) {
 	if targetType == "deployment" {
 		deployment, err := cli.AppsV1().Deployments(namespace).Get(targetName, metav1.GetOptions{})
 		if err == nil {
@@ -94,7 +94,7 @@ func GetServiceInterfaceTarget(targetType string, targetName string, deducePort 
 			}
 			return &target, nil
 		} else {
-			return nil, fmt.Errorf("Could not read deployment %s: %s", targetName, err)
+			return nil, fmt.Errorf("Could not read deploymentconfig %s: %s", targetName, err)
 		}
 	} else {
 		return nil, fmt.Errorf("VAN service interface unsupported target type")


### PR DESCRIPTION
### Description
CLI commands `expose` and `bind` and definition monitor have been modified to support a the `deploymentconfig` type of target; that it is going to be available only if skupper is installed on an OpenShift cluster.


### How Has This Been Tested?

You can find the deployment files [here](https://gist.github.com/nluaces/cfebb8074b76fcd651d689500453598d).

- [x] Created a deploymentconfig in the oc cluster, exposed the deployment with Skupper and checked if the other sites had synchronised the new service.
- [x] Unexposed the deployment.
- [x]  Created a deploymentconfig in the oc cluster, created a new service through Skupper,  binded the deployment with said service and checked if the other sites had synchronised  correctly.
- [x] Unbind the deployment
- [x] Created a deploymentconfig with annotations and checked that the deployment was exposed and also if the other sites had synchronised the new service.

