### PR TITLE
TCP TLS testing (#960)

### DIFF
--- a/Dockerfile.ci-test
+++ b/Dockerfile.ci-test
@@ -11,6 +11,8 @@ RUN make
 
 FROM registry.access.redhat.com/ubi8-minimal
 
+RUN microdnf install openssl && microdnf clean all
+
 WORKDIR /app
 COPY --from=builder /go/src/app/test/integration/bin ./
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ build-tests:
 	go test -c -tags=job -v ./test/integration/examples/bookinfo/job -o ${TEST_BINARIES_FOLDER}/bookinfo_test
 	go test -c -tags=job -v ./test/integration/examples/mongodb/job -o ${TEST_BINARIES_FOLDER}/mongo_test
 	go test -c -tags=job -v ./test/integration/examples/custom/hipstershop/job -o ${TEST_BINARIES_FOLDER}/grpcclient_test
+	go test -c -tags=job -v ./test/integration/examples/tls_t/job -o ${TEST_BINARIES_FOLDER}/tls_test
 
 build-cmd:
 	go build -ldflags="${LDFLAGS}"  -o skupper ./cmd/skupper
@@ -102,4 +103,3 @@ release/darwin/skupper: cmd/skupper/skupper.go
 
 release/darwin.zip: release/darwin/skupper
 	zip -j release/darwin.zip release/darwin/skupper
-

--- a/test/integration/examples/tls_t/job/tls_job_test.go
+++ b/test/integration/examples/tls_t/job/tls_job_test.go
@@ -1,0 +1,32 @@
+//+build job
+
+package job
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/skupperproject/skupper/test/integration/examples/tls_t"
+)
+
+func TestTlsJob(t *testing.T) {
+
+	for _, test := range tls_t.Tests {
+		testName := fmt.Sprintf("server-%v-client-%v", test.Server.Options, strings.Join(test.Client.Options, "-"))
+		m, _ := regexp.Compile("[ /]")
+		testName = m.ReplaceAllLiteralString(testName, "-")
+
+		t.Run(testName, func(t *testing.T) {
+			addr := fmt.Sprintf("ssl-server:%v", test.Server.Port)
+			result := tls_t.SendReceive(addr, test.Client.Options, test.Seek)
+			t.Logf("Success expected: %t; result: %v", test.Success, result)
+			if (result == nil) != test.Success {
+				t.Errorf("failed: client options: %v, server options: %v, result: %v", test.Client.Options, test.Server.Options, result)
+			}
+		})
+
+	}
+
+}

--- a/test/integration/examples/tls_t/tls_t.go
+++ b/test/integration/examples/tls_t/tls_t.go
@@ -1,0 +1,756 @@
+//go:build integration || smoke || examples || job
+// +build integration smoke examples job
+
+// This test is based on the tcp_echo example test.  However, instead
+// of using a tcp echo server, it uses openssl's s_server and s_client
+// for the communication, with a service that is tls-enabled.
+//
+// Here, the tests consist of using different s_server and s_client
+// flags to check how the skupper-router reacts to them.  In all cases,
+// we write a string through the connection and read its response (on
+// the server, we're using -rev, so the response is the reverse of what
+// we just sent).
+package tls_t
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/skupperproject/skupper/test/utils/base"
+	"github.com/skupperproject/skupper/test/utils/constants"
+	"github.com/skupperproject/skupper/test/utils/k8s"
+
+	"github.com/skupperproject/skupper/api/types"
+	"gotest.tools/assert"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func int32Ptr(i int32) *int32 { return &i }
+
+// A skupper service with EnableTls
+var service = types.ServiceInterface{
+	Address:        "ssl-server",
+	Protocol:       "tcp",
+	Ports:          serverPortsInt(),
+	EnableTls:      true,
+	TlsCredentials: "skupper-tls-ssl-server",
+}
+
+// The options will be sent to openssl s_server's call from cmd.Exec, but
+// that command will be executing 'sh -c', so any redirections, variables
+// or quoted arguments are accepted in this single string; they'll just
+// be concatenated to the rest of the command before execution
+type serverProfile struct {
+	Port    int32
+	Options string
+}
+
+var plainServer = serverProfile{
+	Port:    8443,
+	Options: "",
+}
+
+var tls1Server = serverProfile{
+	Port:    8444,
+	Options: "-tls1",
+}
+
+var tls1_1Server = serverProfile{
+	Port:    8445,
+	Options: "-tls1_1",
+}
+
+var tls1_2Server = serverProfile{
+	Port:    8446,
+	Options: "-tls1_2",
+}
+
+var tls1_3Server = serverProfile{
+	Port:    8447,
+	Options: "-tls1_3",
+}
+
+// These are no longer supported by the openssl client, so we
+// cannot test with them
+// var ssl2Server = serverProfile{
+// 	Port:    8448,
+// 	Options: "-ssl2",
+// }
+// var ssl3Server = serverProfile{
+// 	Port:    8449,
+// 	Options: "-ssl3",
+// }
+
+var alpnServer = serverProfile{
+	Port:    8449,
+	Options: "-alpn test_proto1",
+}
+
+var npnServer = serverProfile{
+	Port:    8450,
+	Options: "-nextprotoneg test_proto1 -no_tls1_3",
+}
+
+// Compression
+var compServer = serverProfile{
+	Port:    8451,
+	Options: "-comp",
+}
+
+var noTicketServer = serverProfile{
+	Port:    8452,
+	Options: "-no_ticket -no_tls1_3",
+}
+
+var prefServer = serverProfile{
+	Port:    8453,
+	Options: "-serverpref",
+}
+
+var bugsServer = serverProfile{
+	Port:    8454,
+	Options: "-bugs",
+}
+
+// We do not currently support SNI
+var sniServer = serverProfile{
+	Port: 8455,
+	Options: "-servername ssl-server " +
+		"-cert2 /cert/tls.crt " +
+		"-key2 /cert/tls.key ",
+}
+
+var servers = []serverProfile{
+	plainServer,
+	tls1Server,
+	tls1_1Server,
+	tls1_2Server,
+	tls1_3Server,
+	alpnServer,
+	npnServer,
+	compServer,
+	noTicketServer,
+	prefServer,
+	bugsServer,
+	sniServer,
+}
+
+// Returns a string with a shell line consisting of multiple commands to be
+// run in background, and a final 'wait' command.  It's to be used in an
+// invocation to 'sh -c'
+func testServers() string {
+	var resp string
+	for _, s := range servers {
+		resp += "openssl s_server " +
+			"-cert /cert/tls.crt " +
+			"-key /cert/tls.key " +
+			"-servername_fatal " +
+			// The client is not presenting a certificate, so we do not use these
+			// "-Verify 10 " +
+			// "-verify_return_error " +
+			"-brief " +
+			"-rev "
+		resp += fmt.Sprintf("--port %d %v & ", s.Port, s.Options)
+	}
+	resp += "wait"
+	return resp
+}
+
+// The ports to be exposed by the container hosting the SSL server
+func serverPorts() (resp []apiv1.ContainerPort) {
+	for _, s := range servers {
+		resp = append(resp,
+			apiv1.ContainerPort{
+
+				Protocol:      apiv1.ProtocolTCP,
+				ContainerPort: s.Port,
+			})
+	}
+	return
+}
+
+// A list of ports the server will be listening to.  It will be used on the
+// Skupper service
+func serverPortsInt() (resp []int) {
+	for _, s := range servers {
+		resp = append(resp, int(s.Port))
+	}
+	return
+}
+
+// The options will be sent to openssl s_client's call via cmd.Exec,
+// as provided
+type clientProfile struct {
+	Options []string
+}
+
+var plainClient = clientProfile{
+	Options: []string{},
+}
+
+var tls1Client = clientProfile{
+	Options: []string{"-tls1"},
+}
+
+var tls1_1Client = clientProfile{
+	Options: []string{"-tls1_1"},
+}
+
+var tls1_2Client = clientProfile{
+	Options: []string{"-tls1_2"},
+}
+
+var tls1_3Client = clientProfile{
+	Options: []string{"-tls1_3"},
+}
+
+// No longer supported by openssl cli
+// var ssl3Client = clientProfile{
+// 	Options: []string{"-ssl3"},
+// }
+
+var reconnectClient = clientProfile{
+	Options: []string{"-reconnect"},
+}
+
+var bugsClient = clientProfile{
+	Options: []string{"-bugs"},
+}
+
+var compClient = clientProfile{
+	Options: []string{"-comp"},
+}
+
+var alpnClient = clientProfile{
+	Options: []string{"-alpn", "test_proto1"},
+}
+
+var npnClient = clientProfile{
+	Options: []string{"-nextprotoneg", "test_proto1", "-no_tls1_3"},
+}
+
+// We do not currently support SNI
+var sniClient = clientProfile{
+	Options: []string{"-servername", "ssl-server"},
+}
+
+var Tests = []struct {
+	Client  clientProfile
+	Server  serverProfile
+	Success bool
+	// a string to be sought in the initial openssl cli output.  No match is a failure
+	Seek string
+}{
+	// plainClient with a variety of servers
+	{
+		Client:  plainClient,
+		Server:  plainServer,
+		Success: true,
+	}, {
+		Client:  plainClient,
+		Server:  tls1Server,
+		Success: false,
+	}, {
+		Client:  plainClient,
+		Server:  tls1_1Server,
+		Success: false,
+	}, {
+		Client:  plainClient,
+		Server:  tls1_2Server,
+		Success: true,
+	}, {
+		Client:  plainClient,
+		Server:  tls1_3Server,
+		Success: true,
+	}, {
+		Client:  plainClient,
+		Server:  alpnServer,
+		Success: true,
+	}, {
+		Client:  plainClient,
+		Server:  npnServer,
+		Success: true,
+	}, {
+		// TLS compression is insecure; we want to make sure
+		// it is not active, even if we ask for it
+		Client:  plainClient,
+		Server:  compServer,
+		Seek:    "Compression: NONE",
+		Success: true,
+	}, {
+		Client:  plainClient,
+		Server:  noTicketServer,
+		Success: true,
+	}, {
+		Client:  plainClient,
+		Server:  prefServer,
+		Success: true,
+	}, {
+		Client:  plainClient,
+		Server:  bugsServer,
+		Success: true,
+	}, {
+		Client:  plainClient,
+		Server:  sniServer,
+		Success: false,
+	},
+	// plainServer with a variety of clients
+	{
+		Client:  tls1Client,
+		Server:  plainServer,
+		Success: false,
+	}, {
+		Client:  tls1_1Client,
+		Server:  plainServer,
+		Success: false,
+	}, {
+		Client:  tls1_2Client,
+		Server:  plainServer,
+		Success: true,
+	}, {
+		Client:  tls1_3Client,
+		Server:  plainServer,
+		Success: true,
+	}, {
+		Client:  bugsClient,
+		Server:  plainServer,
+		Success: true,
+	}, {
+		// TLS compression is insecure; we want to make sure
+		// it is not active, even if we ask for it
+		Client:  compClient,
+		Server:  plainServer,
+		Seek:    "Compression: NONE",
+		Success: true,
+	}, {
+		Client:  alpnClient,
+		Server:  plainServer,
+		Seek:    "ALPN protocol: test_proto1",
+		Success: false,
+	}, {
+		Client:  npnClient,
+		Server:  plainServer,
+		Seek:    "Next protocol: (1) proto_test1",
+		Success: false,
+	}, {
+		// This works but shouldn't.  The problem, however, is on the
+		// test.  The client is asking about SNI, the server responds
+		// with its 'main' cert and responder, which are the same as
+		// the ones accessible via SNI, so the client is fine with it.
+		//
+		// A proper test should have different certificate and responder
+		// behind the 'main' and the 'SNI' names.  However, as we do
+		// not support SNI at the moment, we're not putting time into that.
+		Client:  sniClient,
+		Server:  plainServer,
+		Success: true,
+	},
+	// matching cases (ie both client and server are non-plain)
+	{
+		// TLS compression is insecure; we want to make sure
+		// it is not active, even if we ask for it
+		Client:  compClient,
+		Server:  compServer,
+		Seek:    "Compression: NONE",
+		Success: true,
+	}, {
+		Client: alpnClient,
+		Server: alpnServer,
+		// TODO: this is a known error; change this once it is fixed
+		Success: false,
+		Seek:    "ALPN protocol: test_proto1",
+	}, {
+		Client: npnClient,
+		Server: npnServer,
+		// We do not support NPN.
+		Success: false,
+		Seek:    "Next protocol: (1) proto_test1",
+	}, {
+		Client:  sniClient,
+		Server:  sniServer,
+		Success: false,
+	},
+	// TODO: This often fails, and causes further tests to fail, if it comes
+	//       first: why does that happen, and why does it not impact tests
+	//       coming from the next job run?
+	//       That's under investigation on skupper-router #864.  Once that
+	//       is closed, move this to the top of the list and reactivate it.
+	//	{
+	//		Client:  reconnectClient,
+	//		Server:  plainServer,
+	//		Success: true,
+	//	},
+}
+
+// This is a deployment of Skupper test image, running the different
+// openssl s_server processes generated by testServers()
+var Deployment *appsv1.Deployment = &appsv1.Deployment{
+	TypeMeta: metav1.TypeMeta{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "ssl-server",
+	},
+	Spec: appsv1.DeploymentSpec{
+		Replicas: int32Ptr(1),
+		Selector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"application": "ssl-server"},
+		},
+		Template: apiv1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"application": "ssl-server",
+				},
+			},
+			Spec: apiv1.PodSpec{
+				Containers: []apiv1.Container{
+					{
+						Name:            "ssl-server",
+						Image:           k8s.GetTestImage(),
+						ImagePullPolicy: k8s.GetTestImagePullPolicy(),
+						Args: []string{
+							"sh", "-c",
+							testServers(),
+						},
+						Ports: serverPorts(),
+						VolumeMounts: []apiv1.VolumeMount{
+							{
+								Name:      "cert",
+								MountPath: "/cert",
+							},
+						},
+					},
+				},
+				Volumes: []apiv1.Volume{
+					{
+						Name: "cert",
+						VolumeSource: apiv1.VolumeSource{
+							Secret: &apiv1.SecretVolumeSource{
+								SecretName: "skupper-tls-ssl-server",
+								//DefaultMode: 0420,
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+func Run(ctx context.Context, t *testing.T, r base.ClusterTestRunner) {
+	defer tearDown(ctx, t, r)
+	setup(ctx, t, r)
+	runTests(t, r)
+}
+
+func tearDown(ctx context.Context, t *testing.T, r base.ClusterTestRunner) {
+	pub1Cluster, _ := r.GetPublicContext(1)
+
+	t.Logf("Deleting skupper service")
+	_ = pub1Cluster.VanClient.ServiceInterfaceRemove(ctx, service.Address)
+
+	t.Logf("Deleting deployment...")
+	_ = pub1Cluster.VanClient.KubeClient.AppsV1().Deployments(pub1Cluster.Namespace).Delete(Deployment.Name, &metav1.DeleteOptions{})
+}
+
+func setup(ctx context.Context, t *testing.T, r base.ClusterTestRunner) {
+	pub1Cluster, _ := r.GetPublicContext(1)
+	publicDeploymentsClient := pub1Cluster.VanClient.KubeClient.AppsV1().Deployments(pub1Cluster.Namespace)
+
+	// We need to create the service interface before the deployment, because
+	// the deployment needs to mount the secret created by the service
+	err := pub1Cluster.VanClient.ServiceInterfaceCreate(ctx, &service)
+	assert.Assert(t, err)
+
+	fmt.Println("Creating deployment...")
+	result, err := publicDeploymentsClient.Create(Deployment)
+	assert.Assert(t, err)
+
+	fmt.Printf("Created deployment %q.\n", result.GetObjectMeta().GetName())
+
+	fmt.Printf("Listing deployments in namespace %q:\n", pub1Cluster.Namespace)
+	list, err := publicDeploymentsClient.List(metav1.ListOptions{})
+	assert.Assert(t, err)
+
+	for _, d := range list.Items {
+		fmt.Printf(" * %s (%d replicas)\n", d.Name, *d.Spec.Replicas)
+	}
+
+	err = pub1Cluster.VanClient.ServiceInterfaceBind(ctx, &service, "deployment", "ssl-server", "tcp", map[int]int{})
+	assert.Assert(t, err)
+}
+
+func runTests(t *testing.T, r base.ClusterTestRunner) {
+
+	endTime := time.Now().Add(constants.ImagePullingAndResourceCreationTimeout)
+
+	pub1Cluster, err := r.GetPublicContext(1)
+	assert.Assert(t, err)
+
+	prv1Cluster, err := r.GetPrivateContext(1)
+	assert.Assert(t, err)
+
+	_, err = k8s.WaitForSkupperServiceToBeCreatedAndReadyToUse(pub1Cluster.Namespace, pub1Cluster.VanClient.KubeClient, "ssl-server")
+	assert.Assert(t, err)
+
+	_, err = k8s.WaitForSkupperServiceToBeCreatedAndReadyToUse(prv1Cluster.Namespace, prv1Cluster.VanClient.KubeClient, "ssl-server")
+	assert.Assert(t, err)
+
+	jobName := "ssl-client"
+	jobCmd := []string{"/app/tls_test", "-test.run", "TestTlsJob", "-test.v"}
+
+	// Note here we are executing the same test, but in two different
+	// namespaces (or clusters); the same service will exist in both clusters
+	// because of the skupper connections and the "skupper exposed"
+	// deployment.
+	_, err = k8s.CreateTestJobWithSecret(pub1Cluster.Namespace, pub1Cluster.VanClient.KubeClient, jobName, jobCmd, "skupper-tls-ssl-server")
+	assert.Assert(t, err)
+
+	_, err = k8s.CreateTestJobWithSecret(prv1Cluster.Namespace, prv1Cluster.VanClient.KubeClient, jobName, jobCmd, "skupper-tls-ssl-server")
+	assert.Assert(t, err)
+
+	endTime = time.Now().Add(constants.ImagePullingAndResourceCreationTimeout)
+
+	rb := r.(*base.ClusterTestRunnerBase)
+	job, err := k8s.WaitForJob(pub1Cluster.Namespace, pub1Cluster.VanClient.KubeClient, jobName, endTime.Sub(time.Now()))
+	if err != nil || job.Status.Succeeded != 1 {
+		rb.DumpTestInfo(jobName)
+		logs, _ := k8s.GetJobsLogs(pub1Cluster.Namespace, pub1Cluster.VanClient.KubeClient, jobName, true)
+		log.Printf("%s job output: %s", jobName, logs)
+	}
+	assert.Assert(t, err)
+	pub1Cluster.KubectlExec("logs job/" + jobName)
+	k8s.AssertJob(t, job)
+
+	job, err = k8s.WaitForJob(prv1Cluster.Namespace, prv1Cluster.VanClient.KubeClient, jobName, endTime.Sub(time.Now()))
+	if err != nil || job.Status.Succeeded != 1 {
+		rb.DumpTestInfo(jobName)
+		logs, _ := k8s.GetJobsLogs(prv1Cluster.Namespace, prv1Cluster.VanClient.KubeClient, jobName, true)
+		log.Printf("%s job output: %s", jobName, logs)
+	}
+	assert.Assert(t, err)
+	prv1Cluster.KubectlExec("logs job/" + jobName)
+	k8s.AssertJob(t, job)
+
+}
+
+// openssl s_client sends a lot of output on connection to the stdout.  We
+// cannot ignore it with -quiet, as the information there can be useful.
+// However, we cannot send it to stderr either, as the command does not provide
+// such functionality.  So, we just flush it on the log.  Network commands may
+// take a while to show everything, so we give the command some time to
+// complete.
+// 'seek', if given, is a string to be searched for on the initial flush.  If
+// given and not found, return an error.
+func flushStdOut(outputCh <-chan string, seek string) error {
+	log.Printf("Flushing stdout")
+
+	var found bool
+
+	if seek == "" {
+		found = true
+	}
+
+	var count int
+
+outer:
+	for {
+		count++
+		timeoutCh := time.After(time.Second)
+		var line string
+		var ok bool
+
+		select {
+		case line, ok = <-outputCh:
+		case <-timeoutCh:
+			log.Printf("Flush complete")
+			break outer
+		}
+		if !ok {
+			return fmt.Errorf("command output finished during initial stdout flush")
+		}
+		log.Printf("  %v", line)
+		if strings.Contains(line, seek) {
+			found = true
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("stdout flush did not match string %q", seek)
+	}
+	return nil
+
+}
+
+// This is used by the job.  It creates the connection, flushes the
+// initial output, sends the payload, reads and validates the
+// response.
+//
+// The connection is created to `addr`, and additional options to
+// s_client can be given in `options`.  If provided, the initial
+// output will be searched for the `seek` string.  If that is not
+// found, the function fails.
+func SendReceive(addr string, options []string, seek string) error {
+	defer func() {
+		log.Println("SendReceive completed")
+	}()
+	cmdArgs := []string{
+		"s_client",
+		"-verify_return_error",
+		"-connect",
+		addr,
+		"-CAfile",
+		"/tmp/certs/skupper-tls-ssl-server/ca.crt",
+		"-no_ign_eof",
+		"-verify_hostname", "ssl-server",
+		"-tlsextdebug",
+	}
+	cmdArgs = append(cmdArgs, options...)
+
+	// there is no reason to keep the command waiting for output
+	// buffer space to be available: at first, we want to flush it
+	// all out, then we read just one line after one write.  So, we
+	// read as much as we can without blocking.
+	//
+	// This channel will be closed on EOF or any other error when
+	// reading the command's stdout.
+	var outputCh = make(chan string, 100)
+
+	doneCh := make(chan error)
+	go func(doneCh chan error) {
+
+		strEcho := "Halo\n"
+
+		log.Println("Starting openssl s_client...")
+		log.Printf("Executing command openssl %v", cmdArgs)
+		cmd := exec.Command("openssl", cmdArgs...)
+		// We're not processing stderr, so just send it to the main stderr;
+		// we'll get it on the logs, then.
+		cmd.Stderr = os.Stderr
+
+		pipeIn, err := cmd.StdinPipe()
+		if err != nil {
+			doneCh <- fmt.Errorf("error opening stdin pipe: %w", err)
+			return
+		}
+		defer pipeIn.Close()
+
+		pipeOut, err := cmd.StdoutPipe()
+		if err != nil {
+			doneCh <- fmt.Errorf("error opening stdout pipe: %w", err)
+			return
+		}
+
+		err = cmd.Start()
+		if err != nil {
+			doneCh <- fmt.Errorf("error starting command: %w", err)
+		}
+		defer func() {
+			log.Printf("Closing stdin pipe...")
+			pipeIn.Close()
+			log.Printf("Waiting for the command to complete...")
+			err := cmd.Wait()
+			if err != nil {
+				log.Printf("After wait, the command returned an error: %v", err)
+			}
+			log.Printf("...done")
+		}()
+
+		pReader := bufio.NewReader(pipeOut)
+
+		go func() {
+			for {
+				line, err := pReader.ReadString('\n')
+				outputCh <- line
+				if err == io.EOF {
+					log.Printf("Read EOF")
+					close(outputCh)
+					return
+				}
+				if err != nil {
+					log.Printf("non-EOF error reading command output: %v", err)
+					close(outputCh)
+					return
+				}
+			}
+		}()
+
+		err = flushStdOut(outputCh, seek)
+		if err != nil {
+			doneCh <- err
+			return
+		}
+
+		log.Println("Sending data")
+		_, err = pipeIn.Write([]byte(strEcho))
+		if err != nil {
+			doneCh <- fmt.Errorf("write to server failed: %w", err)
+			return
+		}
+
+		log.Println("Receiving reply")
+
+		reply := <-outputCh
+
+		log.Printf("Sent to server = %q", strEcho)
+		log.Printf("Reply from server = %q", string(reply))
+
+		if len(reply) == len(strEcho) {
+			// We're using openssl s_server -rev, so we have to revert
+			// what we send to check the response
+			for i_c, c := range []byte(strings.Trim(strEcho, "\n")) {
+				i_r := len(reply) - 2 - i_c
+				r := reply[i_r]
+
+				if r != c {
+					doneCh <- fmt.Errorf("response from server different than expected: %s (%d/%q != %d/%q)", string(reply), i_r, r, i_c, c)
+				}
+			}
+		} else {
+
+			doneCh <- fmt.Errorf("response length from server different than expected: %s", string(reply))
+		}
+
+		doneCh <- nil
+	}(doneCh)
+	timeoutCh := time.After(time.Minute)
+
+	// This will cause job to fail and a retry to occur if the job is hung
+	var err error
+	select {
+	case err = <-doneCh:
+	case <-timeoutCh:
+		err = fmt.Errorf("timed out waiting for SendReceive function to finish")
+	}
+
+	log.Print("Flushing stdout after test")
+	// Otherwise, output gets mixed with the next test
+	for {
+		select {
+		case line, ok := <-outputCh:
+			if !ok {
+				// We're done here, so we just return whatever err we got before
+				return err
+			}
+			log.Printf("  %v", line)
+		case <-timeoutCh:
+			if err != nil {
+				log.Printf("timed out waiting for SendReceive, but received an error befor: %v", err)
+			}
+			return fmt.Errorf("timed out waiting for SendReceive function to finish")
+		}
+	}
+}

--- a/test/integration/examples/tls_test.go
+++ b/test/integration/examples/tls_test.go
@@ -1,0 +1,19 @@
+//go:build integration || smoke || examples
+// +build integration smoke examples
+
+package examples
+
+import (
+	"context"
+	"testing"
+
+	"github.com/skupperproject/skupper/test/integration/examples/tls_t"
+	"github.com/skupperproject/skupper/test/utils/constants"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)
+
+func TestTls(t *testing.T) {
+	ctx, cancelFn := context.WithTimeout(context.Background(), constants.ImagePullingAndResourceCreationTimeout)
+	defer cancelFn()
+	tls_t.Run(ctx, t, testRunner)
+}

--- a/test/integration/performance/common/perfrunner.go
+++ b/test/integration/performance/common/perfrunner.go
@@ -33,13 +33,18 @@ func RunPerformanceTest(perfTest PerformanceTest) error {
 	log.Printf("- Running performance test for: %s", app.Name)
 	stepLog.Printf(app.Description)
 
+	err, svc, skupperSvc := createService(app)
+	if err != nil {
+		return err
+	}
+
 	// Deploying server app
 	if err := deployServer(app); err != nil {
 		return err
 	}
 
-	// Expose the target service
-	if err := exposeService(app); err != nil {
+	// Bind needs to be after deployment, for the TLS case
+	if err := bindService(app, *svc, skupperSvc); err != nil {
 		return err
 	}
 
@@ -143,7 +148,7 @@ func runClientJobs(perfTest PerformanceTest) error {
 	return nil
 }
 
-func exposeService(app PerformanceApp) error {
+func createService(app PerformanceApp) (error, *ServiceInfo, *types.ServiceInterface) {
 	serverCluster, _ := getServerCluster()
 	// Creating skupper service
 	if skupperSites > 0 {
@@ -155,25 +160,17 @@ func exposeService(app PerformanceApp) error {
 			Ports:    []int{svc.Port},
 		}
 
+		if app.TlsCredentials != "" {
+			skupperSvc.TlsCredentials = app.TlsCredentials
+			skupperSvc.EnableTls = true
+		}
+
 		// Creating service
 		stepLog.Printf("- Creating service %s (port %d)", skupperSvc.Address, skupperSvc.Ports)
 		if err := serverCluster.VanClient.ServiceInterfaceCreate(context.Background(), skupperSvc); err != nil {
-			return fmt.Errorf("error creating skupper service %s - %v", svc.Address, err)
+			return fmt.Errorf("error creating skupper service %s - %v", svc.Address, err), nil, nil
 		}
-		// Binding the service to the deployment
-		err := serverCluster.VanClient.ServiceInterfaceBind(context.Background(), skupperSvc, "deployment", app.Server.Deployment.Name, skupperSvc.Protocol, map[int]int{svc.Port: svc.Port})
-		if err != nil {
-			return fmt.Errorf("error binding service %s - %v", svc.Address, err)
-		}
-
-		// Waiting for service to be available across all namespaces/clusters
-		for i := 1; i <= testRunner.Needs.PublicClusters; i++ {
-			ctx, _ := testRunner.GetPublicContext(i)
-			_, err := k8s.WaitForSkupperServiceToBeCreatedAndReadyToUse(ctx.Namespace, ctx.VanClient.KubeClient, skupperSvc.Address)
-			if err != nil {
-				return fmt.Errorf("timedout waiting for service %s to be ready - %v", skupperSvc.Address, err)
-			}
-		}
+		return nil, &svc, skupperSvc
 	} else {
 		svc := app.Service
 		stepLog.Printf("- Creating service %s (port %d) - without Skupper", svc.Address, svc.Port)
@@ -192,7 +189,29 @@ func exposeService(app PerformanceApp) error {
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("error creating kubernetes service %s - %v", svc.Address, err)
+			return fmt.Errorf("error creating kubernetes service %s - %v", svc.Address, err), nil, nil
+		}
+	}
+	return nil, nil, nil
+}
+
+func bindService(app PerformanceApp, svc ServiceInfo, skupperSvc *types.ServiceInterface) error {
+	serverCluster, err := getServerCluster()
+	if err != nil {
+		return fmt.Errorf("failed to bind service: %w", err)
+	}
+	// Binding the service to the deployment
+	err = serverCluster.VanClient.ServiceInterfaceBind(context.Background(), skupperSvc, "deployment", app.Server.Deployment.Name, skupperSvc.Protocol, map[int]int{svc.Port: svc.Port})
+	if err != nil {
+		return fmt.Errorf("error binding service %s - %v", svc.Address, err)
+	}
+
+	// Waiting for service to be available across all namespaces/clusters
+	for i := 1; i <= testRunner.Needs.PublicClusters; i++ {
+		ctx, _ := testRunner.GetPublicContext(i)
+		_, err := k8s.WaitForSkupperServiceToBeCreatedAndReadyToUse(ctx.Namespace, ctx.VanClient.KubeClient, skupperSvc.Address)
+		if err != nil {
+			return fmt.Errorf("timedout waiting for service %s to be ready - %v", skupperSvc.Address, err)
 		}
 	}
 	return nil

--- a/test/integration/performance/common/types.go
+++ b/test/integration/performance/common/types.go
@@ -45,6 +45,7 @@ type PerformanceApp struct {
 	Client         *ClientInfo        `json:"client"`
 	ThroughputUnit ThroughputUnitType `json:"throughputUnit,omitempty"`
 	LatencyUnit    LatencyUnitType    `json:"latencyUnit,omitempty"`
+	TlsCredentials string             `json:"tlsCredentials"`
 }
 
 type ServerInfo struct {

--- a/test/integration/performance/redis_tls_test.go
+++ b/test/integration/performance/redis_tls_test.go
@@ -1,0 +1,243 @@
+//go:build integration || performance
+// +build integration performance
+
+// This is a copy of the Redis test, adapted for services that are
+// configured with --enable-tls
+package performance
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/skupperproject/skupper/test/integration/performance/common"
+	"github.com/skupperproject/skupper/test/utils/base"
+	"github.com/skupperproject/skupper/test/utils/k8s"
+	"gotest.tools/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type RedisTestTls common.PerformanceApp
+
+func TestRedisTls(t *testing.T) {
+	settings := parseRedisSettings()
+	a := &RedisTest{
+		Name:        "redis-tls",
+		Description: "Redis performance test using redis-benchmark with TLS",
+		Service: common.ServiceInfo{
+			Address:  "redis-server-tls",
+			Protocol: "tcp",
+			Adaptor:  common.AdaptorTCP,
+			Port:     6379,
+		},
+		Server:         getRedisTlsServerInfo(settings),
+		Client:         getRedisTlsClientInfo(settings),
+		ThroughputUnit: common.ThroughputUnitMsgs,
+		LatencyUnit:    common.LatencyUnitMs,
+		TlsCredentials: "skupper-tls-redis-server-tls",
+	}
+	assert.Assert(t, common.RunPerformanceTest(a))
+}
+
+func (p *RedisTestTls) App() common.PerformanceApp {
+	return common.PerformanceApp(*p)
+}
+
+func (p *RedisTestTls) Validate(serverCluster, clientCluster *base.ClusterContext, job common.JobInfo) common.Result {
+	res := common.Result{}
+
+	log.Println("validating client result")
+	// Saving job logs
+	logs, err := k8s.GetJobLogs(clientCluster.Namespace, clientCluster.VanClient.KubeClient, job.Name)
+	if err != nil {
+		res.SetError(err)
+		return res
+	}
+	buf := bytes.NewBufferString(logs)
+
+	throughputRegex, _ := regexp.Compile(`throughput summary: (\d+\.\d+) requests per second`)
+	latencyRegex, _ := regexp.Compile(`\s+(\d+\.\d+)\s+\d+\.\d+\s+(\d+\.\d+)\s+\d+\.\d+\s+(\d+\.\d+)\s+\d+\.\d+`)
+
+	var line string
+	for {
+		line, err = buf.ReadString('\n')
+		if err != nil {
+			if err != io.EOF {
+				res.SetError(fmt.Errorf("error reading logs: %v", err))
+				return res
+			} else {
+				break
+			}
+		}
+		if throughputRegex.MatchString(line) {
+			match := throughputRegex.FindStringSubmatch(line)
+			if res.Throughput, err = strconv.ParseFloat(match[1], 64); err != nil {
+				res.SetError(fmt.Errorf("error parsing throughput: %v", err))
+				return res
+			}
+		} else if latencyRegex.MatchString(line) {
+			match := latencyRegex.FindStringSubmatch(line)
+			if res.LatencyAvg, err = strconv.ParseFloat(match[1], 64); err != nil {
+				res.SetError(fmt.Errorf("error parsing latency average: %v", err))
+				return res
+			}
+			if res.Latency50, err = strconv.ParseFloat(match[2], 64); err != nil {
+				res.SetError(fmt.Errorf("error parsing latency 50%%: %v", err))
+				return res
+			}
+			if res.Latency99, err = strconv.ParseFloat(match[3], 64); err != nil {
+				res.SetError(fmt.Errorf("error parsing latency 99%%: %v", err))
+				return res
+			}
+		}
+	}
+
+	return res
+}
+
+func getRedisTlsJobs(settings *redisSettings) []common.JobInfo {
+	var jobs []common.JobInfo
+	var testCount int
+	var found bool
+	image := "redis"
+	for _, clients := range settings.clients {
+		testNameCount := map[string]int{}
+		for _, testName := range settings.tests {
+			jobTestName := strings.ToLower(testName)
+			jobTestName = strings.ReplaceAll(jobTestName, "_", "")
+			if testCount, found = testNameCount[jobTestName]; found {
+				testCount++
+				testNameCount[jobTestName] = testCount
+				jobTestName += "-" + strconv.Itoa(testCount)
+			} else {
+				testNameCount[jobTestName] = 1
+				jobTestName += "-1"
+			}
+			jobName := fmt.Sprintf("redis-tls-benchmark-%s-clients-%d", jobTestName, clients)
+			labels := map[string]string{"job": jobName}
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   jobName,
+					Labels: labels,
+				},
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   jobName,
+							Labels: labels,
+						},
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "volume-cert",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "skupper-service-client",
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Name: "redis-benchmark", Image: image,
+									Command: []string{
+										"redis-benchmark",
+										"-n", strconv.Itoa(settings.requests),
+										"-c", strconv.Itoa(clients),
+										"-t", testName,
+										"-d", strconv.Itoa(settings.dataSize),
+										"-h", "redis-server-tls",
+										"--tls", "--cacert", "/cert/ca.crt",
+										// We have no client certs
+										// "--cert", "/cert/tls.crt",
+										// "--key", "/cert/tls.key",
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "volume-cert",
+											MountPath: "/cert",
+										},
+									},
+								},
+							},
+							RestartPolicy: corev1.RestartPolicyNever,
+						},
+					},
+				},
+			}
+			jobs = append(jobs, common.JobInfo{
+				Name:    jobName,
+				Clients: clients,
+				Job:     job,
+			})
+		}
+	}
+	return jobs
+}
+
+func getRedisTlsClientInfo(settings *redisSettings) *common.ClientInfo {
+	cli := &common.ClientInfo{
+		Name: "redis-benchmark",
+		Resources: common.ResourceSettings{
+			Memory: settings.memory,
+			CPU:    settings.cpu,
+		},
+		Settings: settings.env,
+		Timeout:  settings.jobTimeout,
+		Jobs:     getRedisTlsJobs(settings),
+	}
+	return cli
+}
+
+func getRedisTlsServerInfo(settings *redisSettings) *common.ServerInfo {
+	return &common.ServerInfo{
+		Name: "redis-server-tls",
+		Resources: common.ResourceSettings{
+			Memory: settings.memory,
+			CPU:    settings.cpu,
+		},
+		Settings:   settings.env,
+		Deployment: getRedisTlsDeployment(),
+	}
+}
+
+func getRedisTlsDeployment() *appsv1.Deployment {
+	dep, _ := k8s.NewDeployment(
+		"redis-server-tls",
+		"",
+		k8s.DeploymentOpts{
+			Image:  "redis",
+			Labels: map[string]string{"app": "redis-server-tls"},
+			Args: []string{
+				"redis-server",
+				"--tls-auth-clients", "no", // We have no client certs
+				"--tls-ca-cert-file", "/cert/ca.crt",
+				"--tls-cert-file", "/cert/tls.crt",
+				"--tls-key-file", "/cert/tls.key",
+				"--tls-port", "6379", "--port", "0",
+				"--stop-writes-on-bgsave-error", "no",
+			},
+			SecretMounts: []k8s.SecretMount{
+				{
+					Name:      "server-cert",
+					MountPath: "/cert",
+					Secret:    "skupper-tls-redis-server-tls",
+				}, {
+					// this is not necessary for the test, but helps debugging
+					Name:      "client-cert",
+					MountPath: "/client-cert",
+					Secret:    "skupper-service-client",
+				},
+			},
+		},
+	)
+	return dep
+}

--- a/test/utils/k8s/job.go
+++ b/test/utils/k8s/job.go
@@ -24,6 +24,24 @@ func GetTestImage() string {
 	return testImage
 }
 
+// Allows to control when Skupper test images (quay.io/skupper/skupper-tests)
+// will be pulled.  The variable is TEST_IMAGE_PULL_POLICY, and the accepted
+// values are PullIfNotPresent, PullNever and PullAlways (the default, if none
+// set).  If an invalid value is provided, it is passed as-is to K8S, which may
+// refuse it.
+func GetTestImagePullPolicy() apiv1.PullPolicy {
+	policy := os.Getenv("TEST_IMAGE_PULL_POLICY")
+	if policy == "" || policy == "PullAlways" {
+		return apiv1.PullAlways
+	} else if policy == "PullIfNotPresent" {
+		return apiv1.PullIfNotPresent
+	} else if policy == "PullNever" {
+		return apiv1.PullNever
+	} else {
+		return apiv1.PullPolicy(policy)
+	}
+}
+
 func int32Ptr(i int32) *int32 { return &i }
 
 func CreateTestJob(ns string, kubeClient kubernetes.Interface, name string, command []string) (*batchv1.Job, error) {
@@ -57,7 +75,7 @@ func CreateTestJob(ns string, kubeClient kubernetes.Interface, name string, comm
 							Env: []apiv1.EnvVar{
 								{Name: "JOB", Value: name},
 							},
-							ImagePullPolicy: apiv1.PullAlways,
+							ImagePullPolicy: GetTestImagePullPolicy(),
 						},
 					},
 					RestartPolicy: apiv1.RestartPolicyNever,
@@ -112,7 +130,7 @@ func CreateTestJobWithSecret(ns string, kubeClient kubernetes.Interface, name st
 							Env: []apiv1.EnvVar{
 								{Name: "JOB", Value: name},
 							},
-							ImagePullPolicy: apiv1.PullAlways,
+							ImagePullPolicy: GetTestImagePullPolicy(),
 						},
 					},
 					RestartPolicy: apiv1.RestartPolicyNever,


### PR DESCRIPTION
Two tests are provided

- TestTls is based on the tcp_echo test, but uses openssl s_server / s_client instead of the echo image
- TestRedisTls is a copy of the performance test TestRedis, adapted for TLS use. Like the original, it is also used as an integration test, with a simpler run

These add to the testing created on #923

Additionally:

* Added GetTestImagePullPolicy to allow for configuration by env var