### PR TITLE
Fix obsolete TLS test

### DIFF
--- a/pkg/kube/qdr/tls_handler_test.go
+++ b/pkg/kube/qdr/tls_handler_test.go
@@ -266,8 +266,8 @@ func TestCheckBindingSecrets(t *testing.T) {
 				},
 				"service2": {
 					Address:          "service2",
-					TlsCertAuthority: "skupper-tls-service2",
-					TlsCredentials:   "skupper-tls-client",
+					TlsCertAuthority: "skupper-tls-client",
+					TlsCredentials:   "skupper-tls-service2",
 				},
 			},
 			mockedSecrets: []string{"skupper-tls-service2", "skupper-tls-client"},
@@ -282,8 +282,8 @@ func TestCheckBindingSecrets(t *testing.T) {
 				},
 				"service2": {
 					Address:          "service2",
-					TlsCertAuthority: "skupper-tls-service2",
-					TlsCredentials:   "skupper-tls-client",
+					TlsCertAuthority: "skupper-tls-client",
+					TlsCredentials:   "skupper-tls-service2",
 				},
 			},
 			mockedSecrets: []string{"skupper-tls-client"},
@@ -299,8 +299,8 @@ func TestCheckBindingSecrets(t *testing.T) {
 				},
 				"service2": {
 					Address:          "service2",
-					TlsCertAuthority: "skupper-tls-service2",
-					TlsCredentials:   "skupper-tls-client",
+					TlsCertAuthority: "skupper-tls-client",
+					TlsCredentials:   "skupper-tls-service2",
 				},
 			},
 			mockedSecrets: []string{"skupper-tls-service2"},
@@ -316,8 +316,8 @@ func TestCheckBindingSecrets(t *testing.T) {
 				},
 				"service2": {
 					Address:          "service2",
-					TlsCertAuthority: "skupper-tls-service2",
-					TlsCredentials:   "skupper-tls-client",
+					TlsCertAuthority: "skupper-tls-client",
+					TlsCredentials:   "skupper-tls-service2",
 				},
 			},
 			mockedSecrets: []string{},

--- a/pkg/kube/qdr/tls_handler_test.go
+++ b/pkg/kube/qdr/tls_handler_test.go
@@ -321,7 +321,7 @@ func TestCheckBindingSecrets(t *testing.T) {
 				},
 			},
 			mockedSecrets: []string{},
-			expectedError: "SslProfile skupper-tls-client for service service2 does not exist in this cluster",
+			expectedError: "SslProfile skupper-tls-service2 for service service2 does not exist in this cluster",
 		},
 	}
 	for _, test := range tests {

--- a/test/integration/examples/http/http.go
+++ b/test/integration/examples/http/http.go
@@ -53,11 +53,11 @@ var http2TlsService = types.ServiceInterface{
 }
 
 var http2TcpTlsService = types.ServiceInterface{
-	Address:        "nghttp2tcptls",
-	Protocol:       "tcp",
-	Ports:          []int{8443},
-	EnableTls:      true,
-	TlsCredentials: "skupper-tls-nghttp2tcptls",
+	Address:          "nghttp2tcptls",
+	Protocol:         "tcp",
+	Ports:            []int{8443},
+	TlsCredentials:   "skupper-tls-nghttp2tcptls",
+	TlsCertAuthority: "skupper-service-client",
 }
 
 var nginxDep = &appsv1.Deployment{


### PR DESCRIPTION
The recent merged PR about custom certificates for TLS did not have the http2 over tcp/tls test updated.