### PR TITLE
All integration tests to dump namespaces info on failure

### DIFF
--- a/test/integration/acceptance/custom/edge_connectivity/edge_connectivity.go
+++ b/test/integration/acceptance/custom/edge_connectivity/edge_connectivity.go
@@ -192,6 +192,13 @@ func (r *EdgeConnectivityTestRunner) Run(ctx context.Context, testcase *TestCase
 
 	r.Setup(ctx, testcase, t)
 	defer r.TearDown(ctx, testcase) // pass in testcase as arg, get rid of current_testcase global.
+	defer r.DumpOnFailure(t, testcase)
 	err := r.RunTests(testcase, ctx, t)
 	assert.Assert(t, err)
+}
+
+func (r *EdgeConnectivityTestRunner) DumpOnFailure(t *testing.T, testcase *TestCase) {
+	if t.Failed() {
+		r.DumpTestInfo("edgecon-" + testcase.name)
+	}
 }

--- a/test/integration/acceptance/custom/headless/headless.go
+++ b/test/integration/acceptance/custom/headless/headless.go
@@ -3,15 +3,16 @@ package headless
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/skupperproject/skupper/client"
 	"github.com/skupperproject/skupper/test/utils/tools"
 	apiv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"log"
-	"strings"
-	"testing"
-	"time"
 
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/pkg/kube"
@@ -340,6 +341,7 @@ func (r *BasicTestRunner) TearDown(ctx context.Context) {
 func (r *BasicTestRunner) Run(ctx context.Context, t *testing.T) {
 
 	defer r.TearDown(ctx)
+	defer r.DumpOnFailure(t)
 	pub1Cluster, err := r.GetPublicContext(1)
 	assert.Assert(t, err)
 	prv1Cluster, err := r.GetPrivateContext(1)
@@ -389,4 +391,10 @@ func (r *BasicTestRunner) Run(ctx context.Context, t *testing.T) {
 		t.Logf("Testing: %s\n", testDoc)
 		r.TestAccessToPods(ctx, t)
 	})
+}
+
+func (r *BasicTestRunner) DumpOnFailure(t *testing.T) {
+	if t.Failed() {
+		r.DumpTestInfo(r.Needs.NamespaceId)
+	}
 }

--- a/test/integration/acceptance/custom/token/token_test.go
+++ b/test/integration/acceptance/custom/token/token_test.go
@@ -50,6 +50,9 @@ func TestToken(t *testing.T) {
 
 	// teardown once test completes
 	tearDownFn := func() {
+		if t.Failed() {
+			runner.DumpTestInfo(needs.NamespaceId)
+		}
 		log.Println("entering teardown")
 		_ = pub.DeleteNamespace()
 		_ = prv.DeleteNamespace()

--- a/test/integration/examples/bookinfo/bookinfo.go
+++ b/test/integration/examples/bookinfo/bookinfo.go
@@ -28,7 +28,6 @@ func RunTests(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) 
 	job, err := k8s.WaitForJob(pub1Cluster.Namespace, pub1Cluster.VanClient.KubeClient, jobName, constants.ImagePullingAndResourceCreationTimeout)
 	if err != nil {
 		pub1Cluster.KubectlExec("logs job/" + jobName)
-		r.DumpTestInfo(jobName)
 	}
 	assert.Assert(t, err)
 	k8s.AssertJob(t, job)

--- a/test/integration/examples/custom/helloworld/helloworld_test.go
+++ b/test/integration/examples/custom/helloworld/helloworld_test.go
@@ -58,6 +58,9 @@ func TestHelloWorldCLI(t *testing.T) {
 
 	// teardown once test completes
 	tearDownFn := func() {
+		if t.Failed() {
+			runner.DumpTestInfo(needs.NamespaceId)
+		}
 		log.Println("entering teardown")
 		_ = pub.DeleteNamespace()
 		_ = prv.DeleteNamespace()

--- a/test/integration/examples/http/http.go
+++ b/test/integration/examples/http/http.go
@@ -493,9 +493,6 @@ func runHeyTesWithParameter(t *testing.T, cluster *base.ClusterContext, numOfWor
 		t.Helper()
 		job, err := k8s.WaitForJob(cc.Namespace, cc.VanClient.KubeClient, jobName, constants.ImagePullingAndResourceCreationTimeout)
 		_, _ = cc.KubectlExec("logs job/" + jobName)
-		if err != nil {
-			cc.DumpTestInfo(jobName)
-		}
 		assert.Assert(t, err)
 		k8s.AssertJob(t, job)
 	}
@@ -607,9 +604,6 @@ func runTests(t *testing.T, r base.ClusterTestRunner) {
 		t.Helper()
 		job, err := k8s.WaitForJob(cc.Namespace, cc.VanClient.KubeClient, jobName, constants.ImagePullingAndResourceCreationTimeout)
 		_, _ = cc.KubectlExec("logs job/" + jobName)
-		if err != nil {
-			cc.DumpTestInfo(jobName)
-		}
 		assert.Assert(t, err)
 		k8s.AssertJob(t, job)
 	}

--- a/test/integration/examples/mongodb/mongo.go
+++ b/test/integration/examples/mongodb/mongo.go
@@ -61,9 +61,6 @@ func RunTests(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) 
 			quit(1);
 		}'
 	`)
-	if err != nil {
-		r.DumpTestInfo(jobName)
-	}
 	assert.Assert(t, err)
 
 	// Let's wait until the election is settled, for a maximum of 5 min
@@ -89,9 +86,6 @@ func RunTests(ctx context.Context, t *testing.T, r *base.ClusterTestRunnerBase) 
 	jobLogs, _ := k8s.GetJobsLogs(pubCluster1.Namespace, pubCluster1.VanClient.KubeClient, jobName, true)
 	t.Logf("%s logs:", jobName)
 	t.Logf(jobLogs)
-	if err != nil {
-		r.DumpTestInfo(jobName)
-	}
 	assert.Assert(t, err)
 
 	k8s.AssertJob(t, job)

--- a/test/integration/examples/tcp_echo/tcp_echo.go
+++ b/test/integration/examples/tcp_echo/tcp_echo.go
@@ -142,19 +142,12 @@ func runTests(t *testing.T, r base.ClusterTestRunner) {
 
 	endTime = time.Now().Add(constants.ImagePullingAndResourceCreationTimeout)
 
-	rb := r.(*base.ClusterTestRunnerBase)
 	job, err := k8s.WaitForJob(pub1Cluster.Namespace, pub1Cluster.VanClient.KubeClient, jobName, endTime.Sub(time.Now()))
-	if err != nil {
-		rb.DumpTestInfo(jobName)
-	}
 	assert.Assert(t, err)
 	pub1Cluster.KubectlExec("logs job/" + jobName)
 	k8s.AssertJob(t, job)
 
 	job, err = k8s.WaitForJob(prv1Cluster.Namespace, prv1Cluster.VanClient.KubeClient, jobName, endTime.Sub(time.Now()))
-	if err != nil {
-		rb.DumpTestInfo(jobName)
-	}
 	assert.Assert(t, err)
 	prv1Cluster.KubectlExec("logs job/" + jobName)
 	k8s.AssertJob(t, job)
@@ -177,7 +170,6 @@ func runTests(t *testing.T, r base.ClusterTestRunner) {
 		// Asserting job output
 		logs, err := k8s.GetJobLogs(cluster.Namespace, cluster.VanClient.KubeClient, ncJob.Name)
 		if jobErr != nil || err != nil {
-			rb.DumpTestInfo(ncJob.Name)
 			log.Printf("%s job output: %s", ncJob.Name, logs)
 		}
 		assert.Assert(t, jobErr)

--- a/test/integration/examples/tls_t/tls_t.go
+++ b/test/integration/examples/tls_t/tls_t.go
@@ -527,7 +527,6 @@ func runTests(t *testing.T, r base.ClusterTestRunner) {
 	rb := r.(*base.ClusterTestRunnerBase)
 	job, err := k8s.WaitForJob(pub1Cluster.Namespace, pub1Cluster.VanClient.KubeClient, jobName, endTime.Sub(time.Now()))
 	if err != nil || job.Status.Succeeded != 1 {
-		rb.DumpTestInfo(jobName)
 		logs, _ := k8s.GetJobsLogs(pub1Cluster.Namespace, pub1Cluster.VanClient.KubeClient, jobName, true)
 		log.Printf("%s job output: %s", jobName, logs)
 	}
@@ -537,7 +536,6 @@ func runTests(t *testing.T, r base.ClusterTestRunner) {
 
 	job, err = k8s.WaitForJob(prv1Cluster.Namespace, prv1Cluster.VanClient.KubeClient, jobName, endTime.Sub(time.Now()))
 	if err != nil || job.Status.Succeeded != 1 {
-		rb.DumpTestInfo(jobName)
 		logs, _ := k8s.GetJobsLogs(prv1Cluster.Namespace, prv1Cluster.VanClient.KubeClient, jobName, true)
 		log.Printf("%s job output: %s", jobName, logs)
 	}

--- a/test/integration/examples/tls_t/tls_t.go
+++ b/test/integration/examples/tls_t/tls_t.go
@@ -524,7 +524,6 @@ func runTests(t *testing.T, r base.ClusterTestRunner) {
 
 	endTime = time.Now().Add(constants.ImagePullingAndResourceCreationTimeout)
 
-	rb := r.(*base.ClusterTestRunnerBase)
 	job, err := k8s.WaitForJob(pub1Cluster.Namespace, pub1Cluster.VanClient.KubeClient, jobName, endTime.Sub(time.Now()))
 	if err != nil || job.Status.Succeeded != 1 {
 		logs, _ := k8s.GetJobsLogs(pub1Cluster.Namespace, pub1Cluster.VanClient.KubeClient, jobName, true)

--- a/test/utils/base/test_common.go
+++ b/test/utils/base/test_common.go
@@ -90,6 +90,7 @@ func RunBasicTopologyTests(m *testing.M, topology BasicTopologySetup) {
 	}
 
 	// Running package level tests
-	m.Run()
-
+	if code := m.Run(); code != 0 {
+		testRunner.DumpTestInfo(namespaceId)
+	}
 }


### PR DESCRIPTION
* Added an explicit call to dump test info for `custom` integration tests
* Removed unnecessary calls to dump test info from basic acceptance and example tests, since RunBasicTopologyTests is now calling it for all of those in the acceptance and examples packages