### PR TITLE
update protobuf version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/loads v0.21.1 // indirect
 	github.com/go-openapi/spec v0.20.4 // indirect
-	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/gofuzz v1.0.0 // indirect


### PR DESCRIPTION
Our TwistLock scan is detecting the vulnerable `github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d` module in the Skupper images.

I see that you are using a `replace` directive to remove it but it still triggers an alert because the version is present in the `go.mod` file.