### PR TITLE
Podman commands now verify if site exists before executing

### DIFF
--- a/cmd/skupper/skupper_podman.go
+++ b/cmd/skupper/skupper_podman.go
@@ -18,12 +18,12 @@ var SkupperPodmanCommands = []string{
 }
 
 type SkupperPodman struct {
-	cli     *clientpodman.PodmanRestClient
-	curSite *podman.Site
-	site    *SkupperPodmanSite
-	token   *SkupperPodmanToken
-	link    *SkupperPodmanLink
-	service *SkupperPodmanService
+	cli         *clientpodman.PodmanRestClient
+	currentSite *podman.Site
+	site        *SkupperPodmanSite
+	token       *SkupperPodmanToken
+	link        *SkupperPodmanLink
+	service     *SkupperPodmanService
 }
 
 func (s *SkupperPodman) Site() SkupperSiteClient {
@@ -118,10 +118,10 @@ func (s *SkupperPodman) NewClient(cmd *cobra.Command, args []string) {
 		fmt.Println()
 		os.Exit(1)
 	}
-	curSite, err := siteHandler.Get()
+	currentSite, err := siteHandler.Get()
 	if isInitCmd {
 		// Validating if site is already initialized
-		if err == nil && curSite != nil {
+		if err == nil && currentSite != nil {
 			fmt.Printf("Skupper has already been initialized for user '" + podman.Username + "'.")
 			fmt.Println()
 			os.Exit(0)
@@ -134,8 +134,8 @@ func (s *SkupperPodman) NewClient(cmd *cobra.Command, args []string) {
 			os.Exit(0)
 		}
 	}
-	if curSite != nil {
-		s.curSite = curSite.(*podman.Site)
+	if currentSite != nil {
+		s.currentSite = currentSite.(*podman.Site)
 	}
 }
 

--- a/cmd/skupper/skupper_podman.go
+++ b/cmd/skupper/skupper_podman.go
@@ -19,6 +19,7 @@ var SkupperPodmanCommands = []string{
 
 type SkupperPodman struct {
 	cli     *clientpodman.PodmanRestClient
+	curSite *podman.Site
 	site    *SkupperPodmanSite
 	token   *SkupperPodmanToken
 	link    *SkupperPodmanLink
@@ -132,6 +133,9 @@ func (s *SkupperPodman) NewClient(cmd *cobra.Command, args []string) {
 			fmt.Println()
 			os.Exit(1)
 		}
+	}
+	if curSite != nil {
+		s.curSite = curSite.(*podman.Site)
 	}
 }
 

--- a/cmd/skupper/skupper_podman.go
+++ b/cmd/skupper/skupper_podman.go
@@ -124,14 +124,14 @@ func (s *SkupperPodman) NewClient(cmd *cobra.Command, args []string) {
 		if err == nil && curSite != nil {
 			fmt.Printf("Skupper has already been initialized for user '" + podman.Username + "'.")
 			fmt.Println()
-			os.Exit(1)
+			os.Exit(0)
 		}
 	} else if cmd.Name() != "version" {
 		// All other commands, but version, must stop now
 		if err != nil {
 			fmt.Printf("Skupper is not enabled for user '%s'", podman.Username)
 			fmt.Println()
-			os.Exit(1)
+			os.Exit(0)
 		}
 	}
 	if curSite != nil {

--- a/cmd/skupper/skupper_podman_link.go
+++ b/cmd/skupper/skupper_podman_link.go
@@ -26,14 +26,14 @@ func (s *SkupperPodmanLink) Create(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error decoding token - %w", err)
 	}
 
-	linkHandler := podman.NewLinkHandlerPodman(s.podman.curSite, s.podman.cli)
+	linkHandler := podman.NewLinkHandlerPodman(s.podman.currentSite, s.podman.cli)
 	return linkHandler.Create(&secret, connectorCreateOpts.Name, int(connectorCreateOpts.Cost))
 }
 
 func (s *SkupperPodmanLink) CreateFlags(cmd *cobra.Command) {}
 
 func (s *SkupperPodmanLink) Delete(cmd *cobra.Command, args []string) error {
-	linkHandler := podman.NewLinkHandlerPodman(s.podman.curSite, s.podman.cli)
+	linkHandler := podman.NewLinkHandlerPodman(s.podman.currentSite, s.podman.cli)
 	return linkHandler.Delete(connectorRemoveOpts.Name)
 }
 
@@ -63,10 +63,10 @@ func (s *SkupperPodmanLink) LinkHandler() domain.LinkHandler {
 	if s.linkHandler != nil {
 		return s.linkHandler
 	}
-	if s.podman.curSite == nil {
+	if s.podman.currentSite == nil {
 		return nil
 	}
-	sitePodman := s.podman.curSite
+	sitePodman := s.podman.currentSite
 	s.linkHandler = podman.NewLinkHandlerPodman(sitePodman, s.podman.cli)
 	return s.linkHandler
 }

--- a/cmd/skupper/skupper_podman_link.go
+++ b/cmd/skupper/skupper_podman_link.go
@@ -18,39 +18,22 @@ type SkupperPodmanLink struct {
 }
 
 func (s *SkupperPodmanLink) Create(cmd *cobra.Command, args []string) error {
-	siteHandler, err := podman.NewSitePodmanHandler("")
-	if err != nil {
-		return fmt.Errorf("error communicating with podman - %w", err)
-	}
-	site, err := siteHandler.Get()
-	if err != nil {
-		return fmt.Errorf("error retrieving site information - %w", err)
-	}
-
 	// reading secret from file
 	var secret corev1.Secret
 	serializer := json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme, json.SerializerOptions{Yaml: true})
-	_, _, err = serializer.Decode(connectorCreateOpts.Yaml, nil, &secret)
+	_, _, err := serializer.Decode(connectorCreateOpts.Yaml, nil, &secret)
 	if err != nil {
 		return fmt.Errorf("error decoding token - %w", err)
 	}
 
-	linkHandler := podman.NewLinkHandlerPodman(site.(*podman.Site), s.podman.cli)
+	linkHandler := podman.NewLinkHandlerPodman(s.podman.curSite, s.podman.cli)
 	return linkHandler.Create(&secret, connectorCreateOpts.Name, int(connectorCreateOpts.Cost))
 }
 
 func (s *SkupperPodmanLink) CreateFlags(cmd *cobra.Command) {}
 
 func (s *SkupperPodmanLink) Delete(cmd *cobra.Command, args []string) error {
-	siteHandler, err := podman.NewSitePodmanHandler("")
-	if err != nil {
-		return fmt.Errorf("error communicating with podman - %w", err)
-	}
-	site, err := siteHandler.Get()
-	if err != nil {
-		return fmt.Errorf("error retrieving site information - %w", err)
-	}
-	linkHandler := podman.NewLinkHandlerPodman(site.(*podman.Site), s.podman.cli)
+	linkHandler := podman.NewLinkHandlerPodman(s.podman.curSite, s.podman.cli)
 	return linkHandler.Delete(connectorRemoveOpts.Name)
 }
 
@@ -80,15 +63,10 @@ func (s *SkupperPodmanLink) LinkHandler() domain.LinkHandler {
 	if s.linkHandler != nil {
 		return s.linkHandler
 	}
-	siteHandler, err := podman.NewSitePodmanHandler("")
-	if err != nil {
+	if s.podman.curSite == nil {
 		return nil
 	}
-	site, err := siteHandler.Get()
-	if err != nil {
-		return nil
-	}
-	sitePodman := site.(*podman.Site)
+	sitePodman := s.podman.curSite
 	s.linkHandler = podman.NewLinkHandlerPodman(sitePodman, s.podman.cli)
 	return s.linkHandler
 }

--- a/cmd/skupper/skupper_podman_site.go
+++ b/cmd/skupper/skupper_podman_site.go
@@ -161,7 +161,7 @@ func (s *SkupperPodmanSite) List(cmd *cobra.Command, args []string) error {
 func (s *SkupperPodmanSite) ListFlags(cmd *cobra.Command) {}
 
 func (s *SkupperPodmanSite) Status(cmd *cobra.Command, args []string) error {
-	site := s.podman.curSite
+	site := s.podman.currentSite
 	routerMgr := podman.NewRouterEntityManagerPodman(s.podman.cli)
 	routers, err := routerMgr.QueryAllRouters()
 	if err != nil {
@@ -241,7 +241,7 @@ func (s *SkupperPodmanSite) Update(cmd *cobra.Command, args []string) error {
 func (s *SkupperPodmanSite) UpdateFlags(cmd *cobra.Command) {}
 
 func (s *SkupperPodmanSite) Version(cmd *cobra.Command, args []string) error {
-	site := s.podman.curSite
+	site := s.podman.currentSite
 	if site == nil {
 		return fmt.Errorf("Skupper is not enabled for user '%s'", podman.Username)
 	}

--- a/cmd/skupper/skupper_podman_site.go
+++ b/cmd/skupper/skupper_podman_site.go
@@ -211,9 +211,8 @@ func (s *SkupperPodmanSite) Status(cmd *cobra.Command, args []string) error {
 
 	fmt.Println()
 
-	podmanSite := site.(*podman.Site)
-	if podmanSite.EnableFlowCollector {
-		fmt.Println("The site console url is: ", podmanSite.GetConsoleUrl())
+	if site.EnableFlowCollector {
+		fmt.Println("The site console url is: ", site.GetConsoleUrl())
 		fmt.Println("The credentials for internal console-auth mode are held in podman volume: 'skupper-console-users'")
 	}
 

--- a/cmd/skupper/skupper_podman_site.go
+++ b/cmd/skupper/skupper_podman_site.go
@@ -161,16 +161,7 @@ func (s *SkupperPodmanSite) List(cmd *cobra.Command, args []string) error {
 func (s *SkupperPodmanSite) ListFlags(cmd *cobra.Command) {}
 
 func (s *SkupperPodmanSite) Status(cmd *cobra.Command, args []string) error {
-	siteHandler, err := podman.NewSitePodmanHandler("")
-	if err != nil {
-		return err
-	}
-	site, err := siteHandler.Get()
-	if err != nil {
-		fmt.Printf("Skupper is not enabled for '%s'\n", podman.Username)
-		return nil
-	}
-
+	site := s.podman.curSite
 	routerMgr := podman.NewRouterEntityManagerPodman(s.podman.cli)
 	routers, err := routerMgr.QueryAllRouters()
 	if err != nil {
@@ -250,16 +241,10 @@ func (s *SkupperPodmanSite) Update(cmd *cobra.Command, args []string) error {
 func (s *SkupperPodmanSite) UpdateFlags(cmd *cobra.Command) {}
 
 func (s *SkupperPodmanSite) Version(cmd *cobra.Command, args []string) error {
-	siteHandler, err := podman.NewSitePodmanHandler("")
-	if err != nil {
-		return fmt.Errorf("Unable to communicate with Skupper - %w", err)
+	site := s.podman.curSite
+	if site == nil {
+		return fmt.Errorf("Skupper is not enabled for user '%s'", podman.Username)
 	}
-
-	site, err := siteHandler.Get()
-	if err != nil {
-		return fmt.Errorf("Unable to retrieve site information - %w", err)
-	}
-
 	for _, deploy := range site.GetDeployments() {
 		for _, component := range deploy.GetComponents() {
 			if component.Name() == types.TransportDeploymentName {

--- a/cmd/skupper/skupper_podman_site.go
+++ b/cmd/skupper/skupper_podman_site.go
@@ -72,12 +72,6 @@ func (s *SkupperPodmanSite) Create(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Unable to initialize Skupper - %w", err)
 	}
 
-	// Validating if site is already initialized
-	curSite, err := siteHandler.Get()
-	if err == nil && curSite != nil {
-		return fmt.Errorf("Skupper has already been initialized for user '" + podman.Username + "'.")
-	}
-
 	// Validating ingress type
 	if routerCreateOpts.Ingress != types.IngressNoneString {
 		// Validating ingress hosts (required as certificates must have valid hosts)
@@ -238,7 +232,11 @@ func (s *SkupperPodmanSite) Status(cmd *cobra.Command, args []string) error {
 func (s *SkupperPodmanSite) StatusFlags(cmd *cobra.Command) {}
 
 func (s *SkupperPodmanSite) NewClient(cmd *cobra.Command, args []string) {
-	s.podman.NewClient(cmd, args)
+	var initArgs []string
+	if cmd.Name() == "init" && len(s.flags.PodmanEndpoint) > 0 {
+		initArgs = append(initArgs, s.flags.PodmanEndpoint)
+	}
+	s.podman.NewClient(cmd, initArgs)
 }
 
 func (s *SkupperPodmanSite) Platform() types.Platform {

--- a/cmd/skupper/skupper_podman_token.go
+++ b/cmd/skupper/skupper_podman_token.go
@@ -21,15 +21,7 @@ func (s *SkupperPodmanToken) Create(cmd *cobra.Command, args []string) error {
 	secretFile := args[0]
 
 	// Determining ingress host
-	siteHandler, err := podman.NewSitePodmanHandler("")
-	if err != nil {
-		return fmt.Errorf("error retrieving site information - %w", err)
-	}
-	site, err := siteHandler.Get()
-	if err != nil {
-		return fmt.Errorf("error inspecting site - %w", err)
-	}
-	sitePodman := site.(*podman.Site)
+	sitePodman := s.podman.curSite
 	if sitePodman.IsEdge() {
 		return fmt.Errorf("Edge configuration cannot accept connections")
 	}

--- a/cmd/skupper/skupper_podman_token.go
+++ b/cmd/skupper/skupper_podman_token.go
@@ -21,7 +21,7 @@ func (s *SkupperPodmanToken) Create(cmd *cobra.Command, args []string) error {
 	secretFile := args[0]
 
 	// Determining ingress host
-	sitePodman := s.podman.curSite
+	sitePodman := s.podman.currentSite
 	if sitePodman.IsEdge() {
 		return fmt.Errorf("Edge configuration cannot accept connections")
 	}

--- a/test/utils/skupper/cli/status.go
+++ b/test/utils/skupper/cli/status.go
@@ -110,7 +110,7 @@ func (s *StatusTester) validateMainContent(platform types.Platform, cluster *bas
 	} else if platform == types.PlatformPodman {
 		mainContent = append(mainContent, fmt.Sprintf("Skupper is enabled for \"%s\"", podman.Username))
 		if s.NotEnabled {
-			notEnabledContent := fmt.Sprintf("Skupper is not enabled for '%s'", podman.Username)
+			notEnabledContent := fmt.Sprintf("Skupper is not enabled for user '%s'", podman.Username)
 			if !strings.Contains(stdout, notEnabledContent) {
 				return fmt.Errorf("error validating not enabled message - expected: %s - stdout: %s", notEnabledContent, stdout)
 			}


### PR DESCRIPTION
Some commands were not verifying if site exists before executing actions,
giving users inappropriate  error messages. Now this validation is done for
all podman commands in a standard way.