### PR TITLE
Generate a Manifest file per release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -528,6 +528,8 @@ jobs:
                 tar -zcf "${BASEDIR}/archives/skupper-cli-${VERSION}-$p.tgz" *
               fi
             done
+            make -e generate-manifest
+            cp ${BASEDIR}/manifest.json ${BASEDIR}/archives
             cd ${BASEDIR}
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace -prerelease -draft ${VERSION} "${BASEDIR}/archives"
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /get
 /config-sync
 /flow-collector
+/manifest
 
 # Test binary, built with `go test -c`
 *.test
@@ -25,3 +26,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Generated files
+manifest.json

--- a/Makefile
+++ b/Makefile
@@ -113,5 +113,5 @@ release/darwin/skupper: cmd/skupper/skupper.go
 release/darwin.zip: release/darwin/skupper
 	zip -j release/darwin.zip release/darwin/skupper
 
-generate-manifest:
+generate-manifest: build-manifest
 	./manifest

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TEST_BINARIES_FOLDER := ${PWD}/test/integration/bin
 DOCKER := docker
 LDFLAGS := -X github.com/skupperproject/skupper/pkg/version.Version=${VERSION}
 
-all: build-cmd build-get build-config-sync build-controllers build-tests
+all: build-cmd build-get build-config-sync build-controllers build-tests build-manifest
 
 build-tests:
 	mkdir -p ${TEST_BINARIES_FOLDER}
@@ -38,6 +38,9 @@ build-config-sync:
 	go build -ldflags="${LDFLAGS}"  -o config-sync cmd/config-sync/main.go cmd/config-sync/config_sync.go
 
 build-controllers: build-site-controller build-service-controller build-flow-collector
+
+build-manifest:
+	go build -ldflags="${LDFLAGS}"  -o manifest ./cmd/manifest
 
 docker-build-test-image:
 	${DOCKER} build -t ${TEST_IMAGE} -f Dockerfile.ci-test .
@@ -88,7 +91,7 @@ test:
 	go test -v -count=1 ./pkg/... ./cmd/... ./client/...
 
 clean:
-	rm -rf skupper service-controller site-controller release get config-sync ${TEST_BINARIES_FOLDER}
+	rm -rf skupper service-controller site-controller release get config-sync manifest ${TEST_BINARIES_FOLDER}
 
 package: release/windows.zip release/darwin.zip release/linux.tgz
 
@@ -109,3 +112,6 @@ release/darwin/skupper: cmd/skupper/skupper.go
 
 release/darwin.zip: release/darwin/skupper
 	zip -j release/darwin.zip release/darwin/skupper
+
+generate-manifest:
+	./manifest

--- a/cmd/manifest/manifest.go
+++ b/cmd/manifest/manifest.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/skupperproject/skupper/pkg/images"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+type SkupperImage struct {
+	Name       string `yaml:"name"`
+	Repository string `yaml:"repository,omitempty"`
+}
+
+func generateManifestFile() error {
+
+	// Define an array of images.
+	skupperImages := []SkupperImage{
+		{
+			Name:       images.GetRouterImageName(),
+			Repository: "https://github.com/skupperproject/skupper-router",
+		},
+		{
+			Name:       images.GetServiceControllerImageName(),
+			Repository: "https://github.com/skupperproject/skupper",
+		},
+		{
+			Name:       images.GetConfigSyncImageName(),
+			Repository: "https://github.com/skupperproject/skupper",
+		},
+		{
+			Name:       images.GetFlowCollectorImageName(),
+			Repository: "https://github.com/skupperproject/skupper",
+		},
+	}
+
+	// Define a struct for the manifest file.
+	manifest := struct {
+		Images []SkupperImage `json:"images"`
+	}{
+		Images: skupperImages,
+	}
+
+	// Encode the manifest image list as JSON.
+	manifestListJSON, err := json.MarshalIndent(manifest, "", "   ")
+	if err != nil {
+		return fmt.Errorf("Error encoding manifest image list: %v\n", err)
+
+	}
+
+	// Create a new file.
+	file, err := os.Create("manifest.json")
+	if err != nil {
+		fmt.Errorf("Error creating file: %v\n", err)
+	}
+
+	// Write the JSON data to the file.
+	_, err = file.Write(manifestListJSON)
+	if err != nil {
+		return fmt.Errorf("Error writing to file: %v\n", err)
+	}
+
+	return nil
+}
+
+func main() {
+	var command = &cobra.Command{
+		Use:   "manifest",
+		Short: "generates a manifest.json file",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return generateManifestFile()
+		},
+	}
+
+	command.Execute()
+
+	if err := command.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/manifest/manifest.go
+++ b/cmd/manifest/manifest.go
@@ -33,6 +33,9 @@ func generateManifestFile() error {
 			Name:       images.GetFlowCollectorImageName(),
 			Repository: "https://github.com/skupperproject/skupper",
 		},
+		{
+			Name: images.GetPrometheusServerImageName(),
+		},
 	}
 
 	// Define a struct for the manifest file.


### PR DESCRIPTION
This change generates a `manifest.json` file with the images that Skupper uses by default.

This is an example of the content:
```
{
   "images": [
      {
         "Name": "quay.io/skupper/skupper-router:main",
         "Repository": "https://github.com/skupperproject/skupper-router"
      },
      {
         "Name": "quay.io/skupper/service-controller:master",
         "Repository": "https://github.com/skupperproject/skupper"
      },
      {
         "Name": "quay.io/skupper/config-sync:master",
         "Repository": "https://github.com/skupperproject/skupper"
      },
      {
         "Name": "quay.io/skupper/flow-collector:master",
         "Repository": "https://github.com/skupperproject/skupper"
      }
   ]
}

```
The file will be published along the artifacts in GitHub's release page.

Fixes #924 