### PR TITLE
make incoming links optional in the link status command

### DIFF
--- a/cmd/skupper/skupper_link.go
+++ b/cmd/skupper/skupper_link.go
@@ -223,7 +223,7 @@ func NewCmdLinkStatus(skupperClient SkupperLinkClient) *cobra.Command {
 	cmd.Flags().IntVar(&waitFor, "wait", 0, "The number of seconds to wait for links to become connected")
 	cmd.Flags().BoolVar(&verboseLinkStatus, "verbose", false, "Show detailed information about a link")
 	cmd.Flags().DurationVar(&remoteInfoTimeout, "timeout", time.Second*5, "Configurable timeout for retrieving information about remote links")
-	cmd.Flags().BoolVar(&showRemoteLinks, "show-remote", false, "Show incoming links from other sites")
+	cmd.Flags().BoolVar(&showRemoteLinks, "show-incoming-links", false, "Show incoming links from other sites")
 
 	return cmd
 

--- a/doc/adr/0003-show-incoming-links-as-optional.md
+++ b/doc/adr/0003-show-incoming-links-as-optional.md
@@ -1,0 +1,20 @@
+# 3. Show incoming links as optional
+
+Date: 2023-05-10
+
+## Status
+
+Accepted
+
+## Context
+
+The flow-collector will address situations where requesting remote information, such as network or link status, results in a timeout.
+
+## Decision
+
+To minimize timeouts, remote link information will be optional. 
+The default timeout will be reduced from 2 minutes to 5 seconds.
+
+## Consequences
+
+A new flag called `show-remote` will display remote link information in the `link status` command.

--- a/doc/adr/0003-show-incoming-links-as-optional.md
+++ b/doc/adr/0003-show-incoming-links-as-optional.md
@@ -17,4 +17,4 @@ The default timeout will be reduced from 2 minutes to 5 seconds.
 
 ## Consequences
 
-A new flag called `show-remote` will display remote link information in the `link status` command.
+A new flag will display remote link information in the `link status` command.


### PR DESCRIPTION
- New flag `show-remote` to include remote link information in the `link status` command.
- Default timeout for the remote links changed from 2 minutes to 5 seconds.
