### PR TITLE
Clearer error when exec attempt times out on container that never starts

### DIFF
--- a/client/policy_validator.go
+++ b/client/policy_validator.go
@@ -417,7 +417,7 @@ func (p *PolicyAPIClient) execGet(args ...string) (*PolicyAPIResult, error) {
 			}, nil
 		}
 		if os.IsTimeout(err) {
-			err = notEnabledErr
+			err = fmt.Errorf("Timed out trying to communicate with the API: %v", err)
 		} else if err != notEnabledErr {
 			err = fmt.Errorf("Unable to communicate with the API: %v", err)
 		}


### PR DESCRIPTION
At present, if you have a pod that is slow to start (or doesn't start at all), and you try to create a token, the error message states that skupper is not installed in the namespace, when it clearly is. This fixes the error to more clearly identify the problem.