### PR TITLE
Check the existence of proxy services when exposing stateful sets

### DIFF
--- a/cmd/service-controller/controller.go
+++ b/cmd/service-controller/controller.go
@@ -95,14 +95,6 @@ func hasProxyAnnotation(service corev1.Service) bool {
 	}
 }
 
-func getProxyName(name string) string {
-	return name + "-proxy"
-}
-
-func getServiceName(name string) string {
-	return strings.TrimSuffix(name, "-proxy")
-}
-
 func hasSkupperAnnotation(service corev1.Service, annotation string) bool {
 	_, ok := service.ObjectMeta.Annotations[annotation]
 	return ok

--- a/cmd/service-controller/controller.go
+++ b/cmd/service-controller/controller.go
@@ -674,6 +674,9 @@ func (c *Controller) ensureHeadlessProxyFor(bindings *service.ServiceBindings, s
 	}
 
 	_, err = kube.CheckProxyStatefulSet(images.GetRouterImageDetails(), serviceInterface, statefulset, config, c.vanClient.Namespace, c.vanClient.KubeClient)
+	if err != nil {
+		event.Recordf(ServiceControllerError, "Error creating new proxy stateful set: %s", err)
+	}
 	return err
 }
 
@@ -685,6 +688,9 @@ func (c *Controller) createHeadlessProxyFor(bindings *service.ServiceBindings) e
 	}
 
 	_, err = kube.NewProxyStatefulSet(images.GetRouterImageDetails(), serviceInterface, config, c.vanClient.Namespace, c.vanClient.KubeClient)
+	if err != nil {
+		event.Recordf(ServiceControllerError, "Error creating new proxy stateful set: %s", err)
+	}
 	return err
 }
 

--- a/pkg/kube/deployments.go
+++ b/pkg/kube/deployments.go
@@ -116,6 +116,11 @@ func NewProxyStatefulSet(image types.ImageDetails, serviceInterface types.Servic
 	svcName := serviceInterface.Address
 	if serviceInterface.IsOfLocalOrigin() {
 		svcName += "-proxy"
+		proxyService, err := cli.CoreV1().Services(namespace).Get(context.TODO(), svcName, metav1.GetOptions{})
+		if err == nil && proxyService != nil {
+			return nil, fmt.Errorf("service %s already exists in the cluster, use any other name to expose the statefulset with a headless service", svcName)
+		}
+
 		_, err = NewHeadlessService(svcName, serviceInterface.Address, serviceInterface.Ports, serviceInterface.Ports, serviceInterface.Labels, &ownerRef, namespace, cli)
 		if err != nil {
 			return nil, err

--- a/pkg/kube/services.go
+++ b/pkg/kube/services.go
@@ -47,16 +47,6 @@ func GetService(name string, namespace string, kubeclient kubernetes.Interface) 
 	return current, err
 }
 
-func NewHeadlessServiceForAddress(address string, ports []int, targetPorts []int, labels map[string]string, owner *metav1.OwnerReference, namespace string, kubeclient kubernetes.Interface) (*corev1.Service, error) {
-	selector := map[string]string{
-		"internal.skupper.io/service": address,
-	}
-	service := makeServiceObjectForAddress(address, ports, targetPorts, labels, selector, owner)
-	service.Spec.ClusterIP = "None"
-
-	return createServiceFromObject(service, namespace, kubeclient)
-}
-
 func NewHeadlessService(name string, address string, ports []int, targetPorts []int, labels map[string]string, owner *metav1.OwnerReference, namespace string, kubeclient kubernetes.Interface) (*corev1.Service, error) {
 	selector := map[string]string{
 		"internal.skupper.io/service": address,


### PR DESCRIPTION
 Fixes #1031 
- The CLI will return as an output that there is already a service whose name matches `<services-name>-proxy` when exposing a stateful set with the `--headless` option
- If the statefulset was not exposed through the CLI, the controller will check it as well and an event will be generated, visible with the command `skupper debug events`

This pull request also fixes #1011 
