### PR TITLE
add manifest dependency to the artifacts publication step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,6 +355,8 @@ workflows:
       - publish-github-release-artifacts:
           <<: *run_for_numeric_tags
           <<: *release_requires
+          requires:
+            - generate_manifest
 
       - publish-github-release-images:
           <<: *run_for_numeric_tags


### PR DESCRIPTION
The circle ci build executes the steps `generate_manifest` and `publish-github-release-artifacts` at the same time, and the manifest is available in the workspace. 

It is needed to add a dependency to be able to have the manifest file when publishing the artifacts in GitHub.