### PR TITLE
support for dataConnectionCount tuning option in router

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -58,14 +58,15 @@ type Tuning struct {
 
 type RouterOptions struct {
 	Tuning
-	Logging            []RouterLogConfig
-	DebugMode          string
-	MaxFrameSize       int
-	MaxSessionFrames   int
-	IngressHost        string
-	ServiceAnnotations map[string]string
-	LoadBalancerIp     string
-	DisableMutualTLS   bool
+	Logging             []RouterLogConfig
+	DebugMode           string
+	MaxFrameSize        int
+	MaxSessionFrames    int
+	DataConnectionCount string
+	IngressHost         string
+	ServiceAnnotations  map[string]string
+	LoadBalancerIp      string
+	DisableMutualTLS    bool
 }
 
 type ControllerOptions struct {

--- a/client/site_config_create.go
+++ b/client/site_config_create.go
@@ -55,22 +55,23 @@ const (
 	SiteConfigPrometheusServerMemoryLimitKey    string = "prometheus-server-memory-limit"
 
 	// router options
-	SiteConfigRouterConsoleKey            string = "router-console"
-	SiteConfigRouterLoggingKey            string = "router-logging"
-	SiteConfigRouterDebugModeKey          string = "router-debug-mode"
-	SiteConfigRouterCpuKey                string = "router-cpu"
-	SiteConfigRouterMemoryKey             string = "router-memory"
-	SiteConfigRouterCpuLimitKey           string = "router-cpu-limit"
-	SiteConfigRouterMemoryLimitKey        string = "router-memory-limit"
-	SiteConfigRouterAffinityKey           string = "router-pod-affinity"
-	SiteConfigRouterAntiAffinityKey       string = "router-pod-antiaffinity"
-	SiteConfigRouterNodeSelectorKey       string = "router-node-selector"
-	SiteConfigRouterMaxFrameSizeKey       string = "xp-router-max-frame-size"
-	SiteConfigRouterMaxSessionFramesKey   string = "xp-router-max-session-frames"
-	SiteConfigRouterIngressHostKey        string = "router-ingress-host"
-	SiteConfigRouterServiceAnnotationsKey string = "router-service-annotations"
-	SiteConfigRouterLoadBalancerIp        string = "router-load-balancer-ip"
-	SiteConfigRouterDisableMutualTLS      string = "router-disable-mutual-tls"
+	SiteConfigRouterConsoleKey             string = "router-console"
+	SiteConfigRouterLoggingKey             string = "router-logging"
+	SiteConfigRouterDebugModeKey           string = "router-debug-mode"
+	SiteConfigRouterCpuKey                 string = "router-cpu"
+	SiteConfigRouterMemoryKey              string = "router-memory"
+	SiteConfigRouterCpuLimitKey            string = "router-cpu-limit"
+	SiteConfigRouterMemoryLimitKey         string = "router-memory-limit"
+	SiteConfigRouterAffinityKey            string = "router-pod-affinity"
+	SiteConfigRouterAntiAffinityKey        string = "router-pod-antiaffinity"
+	SiteConfigRouterNodeSelectorKey        string = "router-node-selector"
+	SiteConfigRouterMaxFrameSizeKey        string = "xp-router-max-frame-size"
+	SiteConfigRouterMaxSessionFramesKey    string = "xp-router-max-session-frames"
+	SiteConfigRouterDataConnectionCountKey string = "router-data-connection-count"
+	SiteConfigRouterIngressHostKey         string = "router-ingress-host"
+	SiteConfigRouterServiceAnnotationsKey  string = "router-service-annotations"
+	SiteConfigRouterLoadBalancerIp         string = "router-load-balancer-ip"
+	SiteConfigRouterDisableMutualTLS       string = "router-disable-mutual-tls"
 
 	// controller options
 	SiteConfigServiceControllerKey            string = "service-controller"
@@ -234,6 +235,9 @@ func (cli *VanClient) SiteConfigCreate(ctx context.Context, spec types.SiteConfi
 	}
 	if spec.Router.MaxSessionFrames != types.RouterMaxSessionFramesDefault {
 		siteConfig.Data[SiteConfigRouterMaxSessionFramesKey] = strconv.Itoa(spec.Router.MaxSessionFrames)
+	}
+	if spec.Router.DataConnectionCount != "" {
+		siteConfig.Data[SiteConfigRouterDataConnectionCountKey] = spec.Router.DataConnectionCount
 	}
 	if len(spec.Router.ServiceAnnotations) > 0 {
 		var annotations []string

--- a/client/site_config_inspect.go
+++ b/client/site_config_inspect.go
@@ -228,6 +228,9 @@ func (cli *VanClient) SiteConfigInspectInNamespace(ctx context.Context, input *c
 	} else {
 		result.Spec.Router.MaxSessionFrames = types.RouterMaxSessionFramesDefault
 	}
+	if routerDataConnectionCount, ok := siteConfig.Data[SiteConfigRouterDataConnectionCountKey]; ok && routerDataConnectionCount != "" {
+		result.Spec.Router.DataConnectionCount = routerDataConnectionCount
+	}
 
 	if routerServiceAnnotations, ok := siteConfig.Data[SiteConfigRouterServiceAnnotationsKey]; ok {
 		result.Spec.Router.ServiceAnnotations = asMap(splitWithEscaping(routerServiceAnnotations, ',', '\\'))

--- a/cmd/skupper/skupper_kube_site.go
+++ b/cmd/skupper/skupper_kube_site.go
@@ -140,6 +140,7 @@ func (s *SkupperKubeSite) CreateFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&routerCreateOpts.Router.IngressHost, "router-ingress-host", "", "Host through which node is accessible when using nodeport as ingress.")
 	cmd.Flags().StringVar(&routerCreateOpts.Router.LoadBalancerIp, "router-load-balancer-ip", "", "Load balancer ip that will be used for router service, if supported by cloud provider")
 	cmd.Flags().BoolVarP(&routerCreateOpts.Router.DisableMutualTLS, "router-disable-mutual-tls", "", false, "Disables client authentication through TLS of sites linking to this site")
+	cmd.Flags().StringVarP(&routerCreateOpts.Router.DataConnectionCount, "router-data-connection-count", "", "", "Configures the number of data connections the router will use when linking to other routers")
 
 	cmd.Flags().StringVar(&routerCreateOpts.Controller.Cpu, "controller-cpu", "", "CPU request for controller pods")
 	cmd.Flags().StringVar(&routerCreateOpts.Controller.Memory, "controller-memory", "", "Memory request for controller pods")

--- a/pkg/qdr/qdr.go
+++ b/pkg/qdr/qdr.go
@@ -69,6 +69,7 @@ func InitialConfig(id string, siteId string, version string, edge bool, helloAge
 
 func InitialConfigSkupperRouter(id string, siteId string, version string, edge bool, helloAge int, options types.RouterOptions) RouterConfig {
 	routerConfig := InitialConfig(id, siteId, version, edge, helloAge)
+	routerConfig.Metadata.DataConnectionCount = options.DataConnectionCount
 
 	if options.Logging != nil {
 		ConfigureRouterLogging(&routerConfig, options.Logging)
@@ -411,10 +412,11 @@ const (
 )
 
 type RouterMetadata struct {
-	Id                 string `json:"id,omitempty"`
-	Mode               Mode   `json:"mode,omitempty"`
-	HelloMaxAgeSeconds string `json:"helloMaxAgeSeconds,omitempty"`
-	Metadata           string `json:"metadata,omitempty"`
+	Id                  string `json:"id,omitempty"`
+	Mode                Mode   `json:"mode,omitempty"`
+	HelloMaxAgeSeconds  string `json:"helloMaxAgeSeconds,omitempty"`
+	DataConnectionCount string `json:"dataConnectionCount,omitempty"`
+	Metadata            string `json:"metadata,omitempty"`
 }
 
 type SslProfile struct {


### PR DESCRIPTION
This requires an updated router that supports the option to be usable.