### PR TITLE
remove generate manifest step 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,15 +348,9 @@ workflows:
             - test
             - build_and_push_test_images
 
-      - generate_manifest:
-          <<: *run_for_numeric_tags
-          <<: *release_requires
-
       - publish-github-release-artifacts:
           <<: *run_for_numeric_tags
           <<: *release_requires
-          requires:
-            - generate_manifest
 
       - publish-github-release-images:
           <<: *run_for_numeric_tags
@@ -481,28 +475,14 @@ jobs:
           goos: linux
           goarch: arm64
           platform: linux-arm64
-
+      - run: make generate-manifest
+      - run: mkdir skupper-manifest
+      - run: cp ./manifest.json skupper-manifest
       - persist_to_workspace:
           root: .
           paths:
-              - dist
-
-  generate_manifest:
-    executor:
-      name: go/default
-      tag: "1.19"
-    steps:
-      - checkout
-      - run:
-          name: Create and move manifest
-          command: |
-            make generate-manifest
-            mkdir tmp
-            mv manifest.json ./tmp
-      - persist_to_workspace:
-          root: .
-          paths:
-            - tmp/manifest.json
+            - dist
+            - skupper-manifest
 
   main_tests_minikube_local_cluster:
     executor: local_cluster_test_executor
@@ -551,9 +531,8 @@ jobs:
                 tar -zcf "${BASEDIR}/archives/skupper-cli-${VERSION}-$p.tgz" *
               fi
             done
-            ls tmp
-            cp tmp/manifest.json ${BASEDIR}/archives
             cd ${BASEDIR}
+            cp "${BASEDIR}/skupper-manifest/manifest.json" "${BASEDIR}/archives"
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace -prerelease -draft ${VERSION} "${BASEDIR}/archives"
 
   publish-github-release-images:


### PR DESCRIPTION
- the manifest file will be generated in the same step as the compilations.
- fix: using the correct directory when adding the manifest file in the release draft as an artifact.