### PR TITLE
Fix statefulset cross-namespace

### DIFF
--- a/pkg/service/bindings.go
+++ b/pkg/service/bindings.go
@@ -118,6 +118,17 @@ func (bindings *ServiceBindings) AsServiceInterface() types.ServiceInterface {
 	if bindings.ingressBinding != nil {
 		mode = bindings.ingressBinding.Mode()
 	}
+
+	targets := []types.ServiceInterfaceTarget{}
+	for key, egress := range bindings.targets {
+		targets = append(targets, types.ServiceInterfaceTarget{
+			Name:      egress.name,
+			Selector:  egress.Selector,
+			Service:   egress.service,
+			Namespace: key.namespace,
+		})
+	}
+
 	return types.ServiceInterface{
 		Address:                  bindings.Address,
 		Protocol:                 bindings.protocol,
@@ -132,6 +143,7 @@ func (bindings *ServiceBindings) AsServiceInterface() types.ServiceInterface {
 		TlsCredentials:           bindings.TlsCredentials,
 		TlsCertAuthority:         bindings.TlsCertAuthority,
 		PublishNotReadyAddresses: bindings.PublishNotReadyAddresses,
+		Targets:                  targets,
 	}
 }
 

--- a/pkg/service/bindings_test.go
+++ b/pkg/service/bindings_test.go
@@ -530,6 +530,7 @@ func TestNewServiceBindings(t *testing.T) {
 				}
 			}
 			si := b.AsServiceInterface()
+			si.Targets = nil
 			copy := s.service
 			copy.Targets = nil
 			assert.DeepEqual(t, si, copy)


### PR DESCRIPTION
# What is it?

While testing 1.4.0-rc1 release I stumbled upon an issue while exposing a statefulset cross-namespace due to the tcp/http connector host address to be referring to the current namespace instead of the one specified by the `--target-namespace` flag.