### PR TITLE
Add digest sha to the manifest file

### DIFF
--- a/cmd/manifest/manifest.go
+++ b/cmd/manifest/manifest.go
@@ -41,6 +41,11 @@ func generateManifestFile() error {
 				Repository: "https://github.com/skupperproject/skupper",
 			},
 			{
+				Name:       images.GetSiteControllerImageName(),
+				SHA:        images.GetSha(images.GetSiteControllerImageName()),
+				Repository: "https://github.com/skupperproject/skupper",
+			},
+			{
 				Name: images.GetPrometheusServerImageName(),
 				SHA:  images.GetSha(images.GetPrometheusServerImageName()),
 			},

--- a/cmd/manifest/manifest.go
+++ b/cmd/manifest/manifest.go
@@ -4,83 +4,92 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/skupperproject/skupper/pkg/images"
-	"github.com/spf13/cobra"
 	"os"
+	"os/exec"
+	"strings"
 )
 
 type SkupperImage struct {
 	Name       string `yaml:"name"`
+	SHA        string `yaml:"sha"`
 	Repository string `yaml:"repository,omitempty"`
 }
 
-func generateManifestFile() error {
-
-	// Define an array of images.
-	skupperImages := []SkupperImage{
-		{
-			Name:       images.GetRouterImageName(),
-			Repository: "https://github.com/skupperproject/skupper-router",
-		},
-		{
-			Name:       images.GetServiceControllerImageName(),
-			Repository: "https://github.com/skupperproject/skupper",
-		},
-		{
-			Name:       images.GetConfigSyncImageName(),
-			Repository: "https://github.com/skupperproject/skupper",
-		},
-		{
-			Name:       images.GetFlowCollectorImageName(),
-			Repository: "https://github.com/skupperproject/skupper",
-		},
-		{
-			Name: images.GetPrometheusServerImageName(),
-		},
+func getSha(imageName string) string {
+	// Pull the image
+	pullCmd := exec.Command("docker", "pull", imageName)
+	if err := pullCmd.Run(); err != nil {
+		fmt.Printf("Error pulling image: %v", err)
+		return err.Error()
 	}
+
+	// Get the image digest
+	digestCmd := exec.Command("docker", "inspect", "--format='{{index .RepoDigests 0}}'", imageName)
+	digestBytes, err := digestCmd.Output()
+	if err != nil {
+		fmt.Printf("Error getting image digest: %v", err)
+		return err.Error()
+	}
+
+	imageWithoutTag := strings.Split(imageName, ":")[0]
+
+	// Extract and print the digest
+	parsedDigest := strings.ReplaceAll(strings.ReplaceAll(string(digestBytes), "'", ""), "\n", "")
+	digest := strings.TrimPrefix(strings.Trim(parsedDigest, "'"), imageWithoutTag+"@")
+
+	return digest
+}
+
+func main() {
 
 	// Define a struct for the manifest file.
 	manifest := struct {
 		Images []SkupperImage `json:"images"`
 	}{
-		Images: skupperImages,
+		Images: []SkupperImage{
+			{
+				Name:       images.GetRouterImageName(),
+				SHA:        getSha(images.GetRouterImageName()),
+				Repository: "https://github.com/skupperproject/skupper-router",
+			},
+			{
+				Name:       images.GetServiceControllerImageName(),
+				SHA:        getSha(images.GetServiceControllerImageName()),
+				Repository: "https://github.com/skupperproject/skupper",
+			},
+			{
+				Name:       images.GetConfigSyncImageName(),
+				SHA:        getSha(images.GetConfigSyncImageName()),
+				Repository: "https://github.com/skupperproject/skupper",
+			},
+			{
+				Name:       images.GetFlowCollectorImageName(),
+				SHA:        getSha(images.GetFlowCollectorImageName()),
+				Repository: "https://github.com/skupperproject/skupper",
+			},
+			{
+				Name: images.GetPrometheusServerImageName(),
+				SHA:  getSha(images.GetPrometheusServerImageName()),
+			},
+		},
 	}
 
 	// Encode the manifest image list as JSON.
 	manifestListJSON, err := json.MarshalIndent(manifest, "", "   ")
 	if err != nil {
-		return fmt.Errorf("Error encoding manifest image list: %v\n", err)
+		panic(fmt.Errorf("Error encoding manifest image list: %v\n", err))
 
 	}
 
 	// Create a new file.
 	file, err := os.Create("manifest.json")
 	if err != nil {
-		fmt.Errorf("Error creating file: %v\n", err)
+		panic(fmt.Errorf("Error creating file: %v\n", err))
 	}
 
 	// Write the JSON data to the file.
 	_, err = file.Write(manifestListJSON)
 	if err != nil {
-		return fmt.Errorf("Error writing to file: %v\n", err)
-	}
-
-	return nil
-}
-
-func main() {
-	var command = &cobra.Command{
-		Use:   "manifest",
-		Short: "generates a manifest.json file",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return generateManifestFile()
-		},
-	}
-
-	command.Execute()
-
-	if err := command.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		panic(fmt.Errorf("Error writing to file: %v\n", err))
 	}
 }

--- a/cmd/manifest/manifest.go
+++ b/cmd/manifest/manifest.go
@@ -5,39 +5,12 @@ import (
 	"fmt"
 	"github.com/skupperproject/skupper/pkg/images"
 	"os"
-	"os/exec"
-	"strings"
 )
 
 type SkupperImage struct {
 	Name       string `yaml:"name"`
 	SHA        string `yaml:"sha"`
 	Repository string `yaml:"repository,omitempty"`
-}
-
-func getSha(imageName string) string {
-	// Pull the image
-	pullCmd := exec.Command("docker", "pull", imageName)
-	if err := pullCmd.Run(); err != nil {
-		fmt.Printf("Error pulling image: %v", err)
-		return err.Error()
-	}
-
-	// Get the image digest
-	digestCmd := exec.Command("docker", "inspect", "--format='{{index .RepoDigests 0}}'", imageName)
-	digestBytes, err := digestCmd.Output()
-	if err != nil {
-		fmt.Printf("Error getting image digest: %v", err)
-		return err.Error()
-	}
-
-	imageWithoutTag := strings.Split(imageName, ":")[0]
-
-	// Extract and print the digest
-	parsedDigest := strings.ReplaceAll(strings.ReplaceAll(string(digestBytes), "'", ""), "\n", "")
-	digest := strings.TrimPrefix(strings.Trim(parsedDigest, "'"), imageWithoutTag+"@")
-
-	return digest
 }
 
 func main() {
@@ -49,27 +22,27 @@ func main() {
 		Images: []SkupperImage{
 			{
 				Name:       images.GetRouterImageName(),
-				SHA:        getSha(images.GetRouterImageName()),
+				SHA:        images.GetSha(images.GetRouterImageName()),
 				Repository: "https://github.com/skupperproject/skupper-router",
 			},
 			{
 				Name:       images.GetServiceControllerImageName(),
-				SHA:        getSha(images.GetServiceControllerImageName()),
+				SHA:        images.GetSha(images.GetServiceControllerImageName()),
 				Repository: "https://github.com/skupperproject/skupper",
 			},
 			{
 				Name:       images.GetConfigSyncImageName(),
-				SHA:        getSha(images.GetConfigSyncImageName()),
+				SHA:        images.GetSha(images.GetConfigSyncImageName()),
 				Repository: "https://github.com/skupperproject/skupper",
 			},
 			{
 				Name:       images.GetFlowCollectorImageName(),
-				SHA:        getSha(images.GetFlowCollectorImageName()),
+				SHA:        images.GetSha(images.GetFlowCollectorImageName()),
 				Repository: "https://github.com/skupperproject/skupper",
 			},
 			{
 				Name: images.GetPrometheusServerImageName(),
-				SHA:  getSha(images.GetPrometheusServerImageName()),
+				SHA:  images.GetSha(images.GetPrometheusServerImageName()),
 			},
 		},
 	}

--- a/pkg/images/image_utils.go
+++ b/pkg/images/image_utils.go
@@ -168,6 +168,11 @@ func GetPrometheusImageRegistry() string {
 	return imageRegistry
 }
 
+func GetSiteControllerImageName() string {
+	imageRegistry := GetImageRegistry()
+	return strings.Join([]string{imageRegistry, SiteControllerImageName}, "/")
+}
+
 func GetSha(imageName string) string {
 	// Pull the image
 	pullCmd := exec.Command("docker", "pull", imageName)

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -6,6 +6,7 @@ const (
 	ServiceControllerImageName string = "service-controller:master"
 	ConfigSyncImageName        string = "config-sync:master"
 	FlowCollectorImageName     string = "flow-collector:master"
+	SiteControllerImageName    string = "site-controller:master"
 	PrometheusImageRegistry    string = "quay.io/prometheus"
 	PrometheusServerImageName  string = "prometheus:v2.42.0"
 )


### PR DESCRIPTION
- Added the digest sha from each image into the manifest file
- Refactored code: command removal

Note:  Docker client provides the ID of the image (that can change every time the image is pulled) but not the digest. It can be parsed from the output after pulling the image though, but the code would be unnecessarily complicated. 

This is an example of the output:
```
{
   "images": [
      {
         "Name": "quay.io/skupper/skupper-router:main",
         "SHA": "sha256:0d7c2a959feb0702ae20ea19f0f71a31e0f88bf7be811eae995ea669beca6697",
         "Repository": "https://github.com/skupperproject/skupper-router"
      },
      {
         "Name": "quay.io/skupper/service-controller:master",
         "SHA": "sha256:c0d47298942083d30a6a89be055bd48049fdba37857b77fb94f748ca383ad211",
         "Repository": "https://github.com/skupperproject/skupper"
      },
      {
         "Name": "quay.io/skupper/config-sync:master",
         "SHA": "sha256:5562756d830b26a36b890b0445e0924e50e0fea000614ea2d1311bdaaf6fb142",
         "Repository": "https://github.com/skupperproject/skupper"
      },
      {
         "Name": "quay.io/skupper/flow-collector:master",
         "SHA": "sha256:3ec5a0aa2b7433ef3f622cb89ca942e2db5473c283a0941e2663b15c87477db1",
         "Repository": "https://github.com/skupperproject/skupper"
      },
      {
         "Name": "quay.io/prometheus/prometheus:v2.42.0",
         "SHA": "sha256:d2ab0a27783fd4ad96a8853e2847b99a0be0043687b8a5d1ebfb2dd3fa4fd1b8",
         "Repository": ""
      }
   ]
}
```