### PR TITLE
use adminport instead of `host` network

### DIFF
--- a/client/gateway.go
+++ b/client/gateway.go
@@ -596,7 +596,7 @@ func (cli *VanClient) setupGatewayConfig(ctx context.Context, gatewayName string
 	}
 	gatewayConfig.Listeners["amqp"] = qdr.Listener{
 		Name: "amqp",
-		Host: "localhost",
+		Host: "0.0.0.0",
 		Port: int32(amqpPort),
 	}
 
@@ -735,6 +735,8 @@ func (cli *VanClient) gatewayStartContainer(ctx context.Context, gatewayName str
 	}
 
 	siteId, _ := getGatewaySiteId(gatewayDir)
+	adminUrl, _ := getRouterUrl(gatewayDir)
+	adminPort := strings.Split(adminUrl, ":")
 	containerCmd := gatewayType
 	containerCmdArgs := []string{
 		"run",
@@ -743,8 +745,8 @@ func (cli *VanClient) gatewayStartContainer(ctx context.Context, gatewayName str
 		"-d",
 		"--name",
 		gatewayName,
-		"--network",
-		"host",
+		"-p",
+		adminPort[len(adminPort)-1] + ":" + adminPort[len(adminPort)-1],
 		"-e",
 		"SKUPPER_SITE_ID=gateway" + "_" + gatewayName + "_" + siteId,
 		"-e",


### PR DESCRIPTION
a first approach to address #816 

Use the admin port mapped explicitly when launching the container.

This fixes the `gateway status` and most of the commands related to binding, as it does not need to expose new ports. 

Missing: 
- Restart the container when a new port needs to be opened when forwarding from Kubernetes.
- Test if this affects podman 