### PR TITLE
Fix: policy tests skupper init

### DIFF
--- a/test/integration/acceptance/custom/hello_policy/init_test.go
+++ b/test/integration/acceptance/custom/hello_policy/init_test.go
@@ -50,8 +50,6 @@ func skupperInitEdgeTestScenario(ctx *base.ClusterContext, prefix string, withPo
 				// skupper init - edge mode, no console and unsecured
 				&cli.InitTester{
 					ConsoleAuth:           "unsecured",
-					ConsoleUser:           "admin",
-					ConsolePassword:       "admin",
 					Ingress:               "none",
 					RouterLogging:         "trace",
 					RouterMode:            "edge",


### PR DESCRIPTION
Removed user and password for unsecured initialization of skupper in policy tests