### PR TITLE
Fix: make sure that the images are published before generating the manifest file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ workflows:
           <<: *run_for_numeric_tags
           <<: *release_requires
           requires:
-            - publish-github-releases-images
+            - publish-github-release-images
           context:
             - skupper-org
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,15 +368,17 @@ workflows:
             - test
             - build_and_save_test_images
 
-      - publish-github-release-artifacts:
+      - publish-github-release-images:
           <<: *run_for_numeric_tags
           <<: *release_requires
           context:
             - skupper-org
 
-      - publish-github-release-images:
+      - publish-github-release-artifacts:
           <<: *run_for_numeric_tags
           <<: *release_requires
+          requires:
+            - publish-github-releases-images
           context:
             - skupper-org
 
@@ -483,6 +485,7 @@ jobs:
           goos: linux
           goarch: arm64
           platform: linux-arm64
+      - setup_remote_docker
       - run: make generate-manifest
       - run: mkdir skupper-manifest
       - run: cp ./manifest.json skupper-manifest


### PR DESCRIPTION
The skupper-control plane SHAs do not match with the ones published in quay.

The artifacts of the release (the manifest.json is one of them) are generated at the same time that the images are being published.  For example, in the case of the service controller, the sha that was published in the manifest.json is

`b02149f7f21de2618056224c1dd8539070dea0f8cfd544fc10622bdacc07f850`

that appears in the historical data[1]  that is different from the current one: 
`06f3ef0047c6f473094c037a7584f24ca0c5dfb3d7953627bf4593a49c78ff42`

[1] https://quay.io/repository/skupper/service-controller?tab=history