### PR TITLE
Generate manifest after publishing images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,12 +348,12 @@ workflows:
       - build-all:
           <<: *run_for_all_branches_and_numeric_tags
       - test:
-          <<: *run_for_main_branch
+          <<: *run_for_all_branches_and_numeric_tags
       - build_and_save_test_images:
-          <<: *run_for_main_branch
+          <<: *run_for_all_branches_and_numeric_tags
 
       - main_tests_minikube_local_cluster:
-          <<: *run_for_main_branch
+          <<: *run_for_all_branches_and_numeric_tags
           pre-steps:
             - prepare_for_local_cluster_tests
           requires:
@@ -361,7 +361,7 @@ workflows:
             - build_and_save_test_images
 
       - policy_tests_minikube_local_cluster:
-          <<: *run_for_main_branch
+          <<: *run_for_all_branches_and_numeric_tags
           pre-steps:
             - prepare_for_local_cluster_tests
           requires:
@@ -369,13 +369,13 @@ workflows:
             - build_and_save_test_images
 
       - publish-github-release-images:
-          <<: *run_for_all_branches_and_numeric_tags
+          <<: *run_for_numeric_tags
           <<: *release_requires
           context:
             - skupper-org
 
       - generate-manifest:
-          <<: *run_for_all_branches_and_numeric_tags
+          <<: *run_for_numeric_tags
           <<: *release_requires
           requires:
             - publish-github-release-images
@@ -383,7 +383,7 @@ workflows:
             - skupper-org
 
       - publish-github-release-artifacts:
-          <<: *run_for_all_branches_and_numeric_tags
+          <<: *run_for_numeric_tags
           <<: *release_requires
           requires:
             - generate-manifest
@@ -566,8 +566,7 @@ jobs:
             done
             cd ${BASEDIR}
             cp "${BASEDIR}/skupper-manifest/manifest.json" "${BASEDIR}/archives"
-            cat "${BASEDIR}/skupper-manifest/manifest.json"
-            ls ${BASEDIR}/archives/
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace -prerelease -draft ${VERSION} "${BASEDIR}/archives"
 
   publish-github-release-images:
     executor:
@@ -580,11 +579,11 @@ jobs:
       - run:
           name:
           command: |
-            echo 'export SERVICE_CONTROLLER_IMAGE=quay.io/nluaces/service-controller:${CIRCLE_TAG}' >> $BASH_ENV
-            echo 'export SITE_CONTROLLER_IMAGE=quay.io/nluaces/site-controller:${CIRCLE_TAG}' >> $BASH_ENV
-            echo 'export CONFIG_SYNC_IMAGE=quay.io/nluaces/config-sync:${CIRCLE_TAG}' >> $BASH_ENV
-            echo 'export FLOW_COLLECTOR_IMAGE=quay.io/nluaces/flow-collector:${CIRCLE_TAG}' >> $BASH_ENV
-            echo 'export TEST_IMAGE=quay.io/nluaces/skupper-tests:${CIRCLE_TAG}' >> $BASH_ENV
+            echo 'export SERVICE_CONTROLLER_IMAGE=quay.io/skupper/service-controller:${CIRCLE_TAG}' >> $BASH_ENV
+            echo 'export SITE_CONTROLLER_IMAGE=quay.io/skupper/site-controller:${CIRCLE_TAG}' >> $BASH_ENV
+            echo 'export CONFIG_SYNC_IMAGE=quay.io/skupper/config-sync:${CIRCLE_TAG}' >> $BASH_ENV
+            echo 'export FLOW_COLLECTOR_IMAGE=quay.io/skupper/flow-collector:${CIRCLE_TAG}' >> $BASH_ENV
+            echo 'export TEST_IMAGE=quay.io/skupper/skupper-tests:${CIRCLE_TAG}' >> $BASH_ENV
             source $BASH_ENV
             make -e generate-client
             make -e docker-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,12 +348,12 @@ workflows:
       - build-all:
           <<: *run_for_all_branches_and_numeric_tags
       - test:
-          <<: *run_for_all_branches_and_numeric_tags
+          <<: *run_for_main_branch
       - build_and_save_test_images:
           <<: *run_for_all_branches_and_numeric_tags
 
       - main_tests_minikube_local_cluster:
-          <<: *run_for_all_branches_and_numeric_tags
+          <<: *run_for_main_branch
           pre-steps:
             - prepare_for_local_cluster_tests
           requires:
@@ -361,7 +361,7 @@ workflows:
             - build_and_save_test_images
 
       - policy_tests_minikube_local_cluster:
-          <<: *run_for_all_branches_and_numeric_tags
+          <<: *run_for_main_branch
           pre-steps:
             - prepare_for_local_cluster_tests
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,7 +350,7 @@ workflows:
       - test:
           <<: *run_for_main_branch
       - build_and_save_test_images:
-          <<: *run_for_all_branches_and_numeric_tags
+          <<: *run_for_main_branch
 
       - main_tests_minikube_local_cluster:
           <<: *run_for_main_branch
@@ -431,13 +431,13 @@ jobs:
           name: persisting images to workspace
           command: |
             mkdir /tmp/images
-            docker tag quay.io/nluaces/service-controller 0.0.0.0:5000/service-controller
+            docker tag quay.io/skupper/service-controller 0.0.0.0:5000/service-controller
             docker save 0.0.0.0:5000/service-controller | gzip > /tmp/images/service-controller.gz
-            docker tag quay.io/nluaces/config-sync 0.0.0.0:5000/config-sync
+            docker tag quay.io/skupper/config-sync 0.0.0.0:5000/config-sync
             docker save 0.0.0.0:5000/config-sync | gzip > /tmp/images/config-sync.gz
-            docker tag quay.io/nluaces/flow-collector 0.0.0.0:5000/flow-collector
+            docker tag quay.io/skupper/flow-collector 0.0.0.0:5000/flow-collector
             docker save 0.0.0.0:5000/flow-collector | gzip > /tmp/images/flow-collector.gz
-            docker tag quay.io/nluaces/skupper-tests 0.0.0.0:5000/skupper-tests
+            docker tag quay.io/skupper/skupper-tests 0.0.0.0:5000/skupper-tests
             docker save 0.0.0.0:5000/skupper-tests | gzip > /tmp/images/test-image.gz
       - persist_to_workspace:
           root: /tmp
@@ -567,6 +567,7 @@ jobs:
             cd ${BASEDIR}
             cp "${BASEDIR}/skupper-manifest/manifest.json" "${BASEDIR}/archives"
             cat "${BASEDIR}/skupper-manifest/manifest.json"
+            ls ${BASEDIR}/archives/
 
   publish-github-release-images:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,13 +431,13 @@ jobs:
           name: persisting images to workspace
           command: |
             mkdir /tmp/images
-            docker tag quay.io/skupper/service-controller 0.0.0.0:5000/service-controller
+            docker tag quay.io/nluaces/service-controller 0.0.0.0:5000/service-controller
             docker save 0.0.0.0:5000/service-controller | gzip > /tmp/images/service-controller.gz
-            docker tag quay.io/skupper/config-sync 0.0.0.0:5000/config-sync
+            docker tag quay.io/nluaces/config-sync 0.0.0.0:5000/config-sync
             docker save 0.0.0.0:5000/config-sync | gzip > /tmp/images/config-sync.gz
-            docker tag quay.io/skupper/flow-collector 0.0.0.0:5000/flow-collector
+            docker tag quay.io/nluaces/flow-collector 0.0.0.0:5000/flow-collector
             docker save 0.0.0.0:5000/flow-collector | gzip > /tmp/images/flow-collector.gz
-            docker tag quay.io/skupper/skupper-tests 0.0.0.0:5000/skupper-tests
+            docker tag quay.io/nluaces/skupper-tests 0.0.0.0:5000/skupper-tests
             docker save 0.0.0.0:5000/skupper-tests | gzip > /tmp/images/test-image.gz
       - persist_to_workspace:
           root: /tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,15 +369,24 @@ workflows:
             - build_and_save_test_images
 
       - publish-github-release-images:
-          <<: *run_for_numeric_tags
+          <<: *run_for_all_branches_and_numeric_tags
           <<: *release_requires
           context:
             - skupper-org
 
-      - publish-github-release-artifacts:
-          <<: *run_for_numeric_tags
+      - generate-manifest:
+          <<: *run_for_all_branches_and_numeric_tags
           <<: *release_requires
           requires:
+            - publish-github-release-images
+          context:
+            - skupper-org
+
+      - publish-github-release-artifacts:
+          <<: *run_for_all_branches_and_numeric_tags
+          <<: *release_requires
+          requires:
+            - generate-manifest
             - publish-github-release-images
           context:
             - skupper-org
@@ -485,15 +494,10 @@ jobs:
           goos: linux
           goarch: arm64
           platform: linux-arm64
-      - setup_remote_docker
-      - run: make generate-manifest
-      - run: mkdir skupper-manifest
-      - run: cp ./manifest.json skupper-manifest
       - persist_to_workspace:
           root: .
           paths:
             - dist
-            - skupper-manifest
 
   main_tests_minikube_local_cluster:
     executor: local_cluster_test_executor
@@ -524,6 +528,22 @@ jobs:
       - run: kubectl cluster-info
       - run_cluster_policy_tests
 
+  generate-manifest:
+    executor:
+      name: go/default
+      tag: "1.19"
+    steps:
+      - checkout
+      - go/mod-download-cached
+      - setup_remote_docker
+      - run: make generate-manifest
+      - run: mkdir skupper-manifest
+      - run: cp ./manifest.json skupper-manifest
+      - persist_to_workspace:
+          root: .
+          paths:
+            - skupper-manifest
+
   publish-github-release-artifacts:
     docker:
       - image: cibuilds/github:0.10
@@ -546,7 +566,7 @@ jobs:
             done
             cd ${BASEDIR}
             cp "${BASEDIR}/skupper-manifest/manifest.json" "${BASEDIR}/archives"
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace -prerelease -draft ${VERSION} "${BASEDIR}/archives"
+            cat "${BASEDIR}/skupper-manifest/manifest.json"
 
   publish-github-release-images:
     executor:
@@ -559,11 +579,11 @@ jobs:
       - run:
           name:
           command: |
-            echo 'export SERVICE_CONTROLLER_IMAGE=quay.io/skupper/service-controller:${CIRCLE_TAG}' >> $BASH_ENV
-            echo 'export SITE_CONTROLLER_IMAGE=quay.io/skupper/site-controller:${CIRCLE_TAG}' >> $BASH_ENV
-            echo 'export CONFIG_SYNC_IMAGE=quay.io/skupper/config-sync:${CIRCLE_TAG}' >> $BASH_ENV
-            echo 'export FLOW_COLLECTOR_IMAGE=quay.io/skupper/flow-collector:${CIRCLE_TAG}' >> $BASH_ENV
-            echo 'export TEST_IMAGE=quay.io/skupper/skupper-tests:${CIRCLE_TAG}' >> $BASH_ENV
+            echo 'export SERVICE_CONTROLLER_IMAGE=quay.io/nluaces/service-controller:${CIRCLE_TAG}' >> $BASH_ENV
+            echo 'export SITE_CONTROLLER_IMAGE=quay.io/nluaces/site-controller:${CIRCLE_TAG}' >> $BASH_ENV
+            echo 'export CONFIG_SYNC_IMAGE=quay.io/nluaces/config-sync:${CIRCLE_TAG}' >> $BASH_ENV
+            echo 'export FLOW_COLLECTOR_IMAGE=quay.io/nluaces/flow-collector:${CIRCLE_TAG}' >> $BASH_ENV
+            echo 'export TEST_IMAGE=quay.io/nluaces/skupper-tests:${CIRCLE_TAG}' >> $BASH_ENV
             source $BASH_ENV
             make -e generate-client
             make -e docker-build


### PR DESCRIPTION
### Context of the problem: 

the manifest file was been created in the `build-all` step instead of after publishing the images in quay.io, getting the wrong SHAs.

### Solution:

It was added an extra step just after publishing the images, removing the generation of the manifest from the `build-all` step. 