### PR TITLE
add explicit per-pod type annotation

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -65,6 +65,7 @@ type RouterOptions struct {
 	DataConnectionCount string
 	IngressHost         string
 	ServiceAnnotations  map[string]string
+	PodAnnotations      map[string]string
 	LoadBalancerIp      string
 	DisableMutualTLS    bool
 }
@@ -73,6 +74,7 @@ type ControllerOptions struct {
 	Tuning
 	IngressHost        string
 	ServiceAnnotations map[string]string
+	PodAnnotations     map[string]string
 	LoadBalancerIp     string
 }
 
@@ -91,6 +93,7 @@ type PrometheusServerOptions struct {
 	AuthMode       string
 	User           string
 	Password       string
+	PodAnnotations map[string]string
 }
 
 type SiteConfigSpec struct {

--- a/client/router_create.go
+++ b/client/router_create.go
@@ -121,7 +121,13 @@ func (cli *VanClient) GetVanPrometheusServerSpec(options types.SiteConfigSpec, v
 	for key, value := range van.PrometheusServer.LabelSelector {
 		van.PrometheusServer.Labels[key] = value
 	}
-	van.PrometheusServer.Annotations = options.Annotations
+	van.PrometheusServer.Annotations = map[string]string{}
+	for key, value := range options.Annotations {
+		van.PrometheusServer.Annotations[key] = value
+	}
+	for key, value := range options.PrometheusServer.PodAnnotations {
+		van.PrometheusServer.Annotations[key] = value
+	}
 	for key, value := range options.Labels {
 		van.PrometheusServer.Labels[key] = value
 	}
@@ -256,7 +262,13 @@ func (cli *VanClient) GetVanControllerSpec(options types.SiteConfigSpec, van *ty
 	for key, value := range van.Controller.LabelSelector {
 		van.Controller.Labels[key] = value
 	}
-	van.Controller.Annotations = options.Annotations
+	van.Controller.Annotations = map[string]string{}
+	for key, value := range options.Annotations {
+		van.Controller.Annotations[key] = value
+	}
+	for key, value := range options.Controller.PodAnnotations {
+		van.Controller.Annotations[key] = value
+	}
 	for key, value := range options.Labels {
 		van.Controller.Labels[key] = value
 	}
@@ -682,6 +694,9 @@ func (cli *VanClient) GetRouterSpecFromOpts(options types.SiteConfigSpec, siteId
 	}
 	van.Transport.Annotations = types.TransportPrometheusAnnotations
 	for key, value := range options.Annotations {
+		van.Transport.Annotations[key] = value
+	}
+	for key, value := range options.Router.PodAnnotations {
 		van.Transport.Annotations[key] = value
 	}
 	runAsNonRoot := true

--- a/client/router_update.go
+++ b/client/router_update.go
@@ -1041,10 +1041,19 @@ func (cli *VanClient) RouterUpdateAnnotations(ctx context.Context, settings *cor
 	if err != nil {
 		return false, err
 	}
-	updated, err := cli.updateAnnotationsOnDeployment(ctx, settings.ObjectMeta.Namespace, types.ControllerDeploymentName, siteConfig.Spec.Annotations)
+
+	controllerAnnotations := map[string]string{}
+	for key, value := range siteConfig.Spec.Annotations {
+		controllerAnnotations[key] = value
+	}
+	for key, value := range siteConfig.Spec.Controller.PodAnnotations {
+		controllerAnnotations[key] = value
+	}
+	updated, err := cli.updateAnnotationsOnDeployment(ctx, settings.ObjectMeta.Namespace, types.ControllerDeploymentName, controllerAnnotations)
 	if err != nil {
 		return updated, err
 	}
+
 	transportAnnotations := map[string]string{}
 	for key, value := range types.TransportPrometheusAnnotations {
 		transportAnnotations[key] = value
@@ -1052,10 +1061,26 @@ func (cli *VanClient) RouterUpdateAnnotations(ctx context.Context, settings *cor
 	for key, value := range siteConfig.Spec.Annotations {
 		transportAnnotations[key] = value
 	}
+	for key, value := range siteConfig.Spec.Router.PodAnnotations {
+		transportAnnotations[key] = value
+	}
 	updated, err = cli.updateAnnotationsOnDeployment(ctx, settings.ObjectMeta.Namespace, types.TransportDeploymentName, transportAnnotations)
 	if err != nil {
 		return updated, err
 	}
+
+	prometheusAnnotations := map[string]string{}
+	for key, value := range siteConfig.Spec.Annotations {
+		prometheusAnnotations[key] = value
+	}
+	for key, value := range siteConfig.Spec.PrometheusServer.PodAnnotations {
+		prometheusAnnotations[key] = value
+	}
+	updated, err = cli.updateAnnotationsOnDeployment(ctx, settings.ObjectMeta.Namespace, types.PrometheusDeploymentName, prometheusAnnotations)
+	if err != nil {
+		return updated, err
+	}
+
 	return updated, nil
 }
 

--- a/cmd/site-controller/README.md
+++ b/cmd/site-controller/README.md
@@ -65,6 +65,8 @@ ConfigMaps allow you to manage a Skupper site using a ConfigMap named `skupper-s
 
 `data:router-service-annotations` - Annotations to add to skupper router service
 
+`data:router-pod-annotations` - Annotations to add to skupper router pod
+
 `data:router-load-balancer-ip` - Load balancer ip that will be used for router service, if supported by cloud provider
 
 `data:service-controller` - (true/false) Run the service controller.
@@ -88,6 +90,8 @@ ConfigMaps allow you to manage a Skupper site using a ConfigMap named `skupper-s
 `data:controller-ingress-host` - Host through which node is accessible when using nodeport as ingress.
 
 `data:controller-service-annotations` - Annotations to add to skupper controller service
+
+`data:controller-pod-annotations` - Annotations to add to skupper controller pod
 
 `data:controller-load-balancer-ip` - Load balancer ip that will be used for controller service, if supported by cloud provider
 

--- a/cmd/skupper/skupper_kube.go
+++ b/cmd/skupper/skupper_kube.go
@@ -83,10 +83,13 @@ func (s *SkupperKube) Options(rootCmd *cobra.Command) {
 }
 
 type kubeInit struct {
-	annotations                  []string
-	ingressAnnotations           []string
-	routerServiceAnnotations     []string
-	controllerServiceAnnotations []string
+	annotations                    []string
+	ingressAnnotations             []string
+	routerServiceAnnotations       []string
+	routerPodAnnotations           []string
+	controllerServiceAnnotations   []string
+	controllerPodAnnotations       []string
+	prometheusServerPodAnnotations []string
 }
 
 func (s *SkupperKube) NewClient(cmd *cobra.Command, args []string) {

--- a/cmd/skupper/skupper_kube_site.go
+++ b/cmd/skupper/skupper_kube_site.go
@@ -48,9 +48,12 @@ func (s *SkupperKubeSite) Create(cmd *cobra.Command, args []string) error {
 	routerCreateOpts.Labels = asMap(initFlags.labels)
 	routerCreateOpts.IngressAnnotations = asMap(s.kubeInit.ingressAnnotations)
 	routerCreateOpts.Router.ServiceAnnotations = asMap(s.kubeInit.routerServiceAnnotations)
+	routerCreateOpts.Router.PodAnnotations = asMap(s.kubeInit.routerPodAnnotations)
 	routerCreateOpts.Router.MaxFrameSize = types.RouterMaxFrameSizeDefault
 	routerCreateOpts.Router.MaxSessionFrames = types.RouterMaxSessionFramesDefault
 	routerCreateOpts.Controller.ServiceAnnotations = asMap(s.kubeInit.controllerServiceAnnotations)
+	routerCreateOpts.Controller.PodAnnotations = asMap(s.kubeInit.controllerPodAnnotations)
+	routerCreateOpts.PrometheusServer.PodAnnotations = asMap(s.kubeInit.prometheusServerPodAnnotations)
 	if err := routerCreateOpts.CheckIngress(); err != nil {
 		return err
 	}
@@ -109,7 +112,10 @@ func (s *SkupperKubeSite) CreateFlags(cmd *cobra.Command) {
 	s.kubeInit.ingressAnnotations = []string{}
 	s.kubeInit.annotations = []string{}
 	s.kubeInit.routerServiceAnnotations = []string{}
+	s.kubeInit.routerPodAnnotations = []string{}
 	s.kubeInit.controllerServiceAnnotations = []string{}
+	s.kubeInit.controllerPodAnnotations = []string{}
+	s.kubeInit.prometheusServerPodAnnotations = []string{}
 	cmd.Flags().BoolVarP(&routerCreateOpts.EnableConsole, "enable-console", "", false, "Enable skupper console must be used in conjunction with '--enable-flow-collector' flag")
 	cmd.Flag("ingress").Usage += " If not specified route is used when available, otherwise loadbalancer is used."
 	cmd.Flags().StringVarP(&routerCreateOpts.IngressHost, "ingress-host", "", "", "Hostname or alias by which the ingress route or proxy can be reached")
@@ -122,7 +128,10 @@ func (s *SkupperKubeSite) CreateFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&s.kubeInit.ingressAnnotations, "ingress-annotations", []string{}, "Annotations to add to skupper ingress")
 	cmd.Flags().StringSliceVar(&s.kubeInit.annotations, "annotations", []string{}, "Annotations to add to skupper pods")
 	cmd.Flags().StringSliceVar(&s.kubeInit.routerServiceAnnotations, "router-service-annotations", []string{}, "Annotations to add to skupper router service")
+	cmd.Flags().StringSliceVar(&s.kubeInit.routerPodAnnotations, "router-pod-annotations", []string{}, "Annotations to add to skupper router pod")
 	cmd.Flags().StringSliceVar(&s.kubeInit.controllerServiceAnnotations, "controller-service-annotation", []string{}, "Annotations to add to skupper controller service")
+	cmd.Flags().StringSliceVar(&s.kubeInit.controllerPodAnnotations, "controller-pod-annotation", []string{}, "Annotations to add to skupper controller pod")
+	cmd.Flags().StringSliceVar(&s.kubeInit.prometheusServerPodAnnotations, "prometheus-server-pod-annotation", []string{}, "Annotations to add to skupper prometheus pod")
 	cmd.Flags().BoolVarP(&routerCreateOpts.EnableServiceSync, "enable-service-sync", "", true, "Participate in cross-site service synchronization")
 	cmd.Flags().DurationVar(&routerCreateOpts.SiteTtl, "service-sync-site-ttl", 0, "Time after which stale services, i.e. those whose site has not been heard from, created through service-sync are removed.")
 	cmd.Flags().BoolVarP(&routerCreateOpts.EnableFlowCollector, "enable-flow-collector", "", false, "Enable cross-site flow collection for the application network")


### PR DESCRIPTION
New keys in the `skupper-site` configmap to explicitly set annotations for `service-controller`, `router` and `prometheus` pods.