### PR TITLE
Address flaky TestTls 

### DIFF
--- a/test/integration/examples/tls_t/job/tls_job_test.go
+++ b/test/integration/examples/tls_t/job/tls_job_test.go
@@ -1,4 +1,5 @@
-//+build job
+//go:build job
+// +build job
 
 package job
 
@@ -13,14 +14,14 @@ import (
 
 func TestTlsJob(t *testing.T) {
 
+	m := regexp.MustCompile("[ /]")
 	for _, test := range tls_t.Tests {
 		testName := fmt.Sprintf("server-%v-client-%v", test.Server.Options, strings.Join(test.Client.Options, "-"))
-		m, _ := regexp.Compile("[ /]")
 		testName = m.ReplaceAllLiteralString(testName, "-")
 
 		t.Run(testName, func(t *testing.T) {
 			addr := fmt.Sprintf("ssl-server:%v", test.Server.Port)
-			result := tls_t.SendReceive(addr, test.Client.Options, test.Seek)
+			result := tls_t.SendReceive(addr, test.Client.Options, test.Seek, testName)
 			t.Logf("Success expected: %t; result: %v", test.Success, result)
 			if (result == nil) != test.Success {
 				t.Errorf("failed: client options: %v, server options: %v, result: %v", test.Client.Options, test.Server.Options, result)

--- a/test/utils/base/cluster_test_runner.go
+++ b/test/utils/base/cluster_test_runner.go
@@ -249,6 +249,7 @@ func ConnectSimplePublicPrivate(ctx context.Context, r *ClusterTestRunnerBase) e
 	if err != nil {
 		return fmt.Errorf("error creating pub1 router: %w", err)
 	}
+	WaitSkupperRunning(pub1Cluster)
 
 	secretFile := "/tmp/" + r.Needs.NamespaceId + "_public_secret.yaml"
 	err = pub1Cluster.VanClient.ConnectorTokenCreateFile(ctx, types.DefaultVanName, secretFile)
@@ -267,6 +268,7 @@ func ConnectSimplePublicPrivate(ctx context.Context, r *ClusterTestRunnerBase) e
 	if err != nil {
 		return fmt.Errorf("error creating prv1 router: %w", err)
 	}
+	WaitSkupperRunning(prv1Cluster)
 
 	var connectorCreateOpts types.ConnectorCreateOptions = types.ConnectorCreateOptions{
 		SkupperNamespace: prv1Cluster.Namespace,


### PR DESCRIPTION
This addresses flakiness on `TestTls` with the following fixes and enhancements:

- More verbose debugging (prefixes logs from subtests that may overlap with the test name)
- Shows job output only on error or `testing.Verbose()`
- Avoid #1208 by waiting for the secret to be available before binding the service (avoids `secret already exists` error, which fails the full test)
- Introduces initial wait of 5 seconds for initial stdout flushing, in addition to 1 sec wait between lines (helps avoid subtests reading openssl's `CONNECTED` message as response to its `Halo` message)
- Resets `timeoutCh` after a `SendReceive` timeout, to avoid the test hanging when the post-test flush also times out (as the value was not being reset, no timeout message was sent in that case)
- Properly inform the original error when post-test flush times out (previously, it was only logging the error)
- Wait for Skupper to be available before token creation and linking on `ConnectSimplePublicPrivate` (avoids `error connecting public and private namespaces` errors`
- Other small enhancements

The fix on `ConnectSimplePublicPrivate` affects both the `examples` and `acceptance` testing, not just `TestTls`.

