### PR TITLE
unexpose command: Fix error message

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -61,7 +61,7 @@ type SkupperServiceClient interface {
 	UnbindFlags(cmd *cobra.Command)
 	Unexpose(cmd *cobra.Command, args []string) error
 	UnexposeFlags(cmd *cobra.Command) error
-	UnExposeArgs(cmd *cobra.Command, args []string) error
+	UnexposeArgs(cmd *cobra.Command, args []string) error
 }
 
 type SkupperDebugClient interface {
@@ -554,7 +554,7 @@ func NewCmdUnexpose(skupperCli SkupperServiceClient) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "unexpose",
 		Short:  "Unexpose a set of pods previously exposed through a Skupper address",
-		Args:   skupperCli.UnExposeArgs,
+		Args:   skupperCli.UnexposeArgs,
 		PreRun: skupperCli.NewClient,
 		RunE:   skupperCli.Unexpose,
 	}

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -61,6 +61,7 @@ type SkupperServiceClient interface {
 	UnbindFlags(cmd *cobra.Command)
 	Unexpose(cmd *cobra.Command, args []string) error
 	UnexposeFlags(cmd *cobra.Command) error
+	UnExposeArgs(cmd *cobra.Command, args []string) error
 }
 
 type SkupperDebugClient interface {
@@ -553,7 +554,7 @@ func NewCmdUnexpose(skupperCli SkupperServiceClient) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "unexpose",
 		Short:  "Unexpose a set of pods previously exposed through a Skupper address",
-		Args:   skupperCli.ExposeArgs,
+		Args:   skupperCli.UnExposeArgs,
 		PreRun: skupperCli.NewClient,
 		RunE:   skupperCli.Unexpose,
 	}

--- a/cmd/skupper/skupper_cluster_test.go
+++ b/cmd/skupper/skupper_cluster_test.go
@@ -1039,7 +1039,7 @@ func TestUnexposeWithCluster(t *testing.T) {
 			args:            []string{},
 			expectedCapture: "",
 			expectedOutput:  "",
-			expectedError:   "expose target and name must be specified (e.g. 'skupper expose deployment <name>')",
+			expectedError:   "target and name must be specified (e.g. 'skupper unexpose deployment <name>')",
 			realCluster:     false,
 		},
 		{
@@ -1047,7 +1047,7 @@ func TestUnexposeWithCluster(t *testing.T) {
 			args:            []string{"deployment"},
 			expectedCapture: "",
 			expectedOutput:  "",
-			expectedError:   "expose target and name must be specified (e.g. 'skupper expose deployment <name>')",
+			expectedError:   "target and name must be specified (e.g. 'skupper unexpose deployment <name>')",
 			realCluster:     false,
 		},
 		{

--- a/cmd/skupper/skupper_kube_expose.go
+++ b/cmd/skupper/skupper_kube_expose.go
@@ -96,16 +96,7 @@ func (s *SkupperKubeService) Expose(cmd *cobra.Command, args []string) error {
 }
 
 func (s *SkupperKubeService) ExposeArgs(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 || (!strings.Contains(args[0], "/") && len(args) < 2) {
-		return fmt.Errorf("expose target and name must be specified (e.g. 'skupper expose deployment <name>')")
-	}
-	if len(args) > 2 {
-		return fmt.Errorf("illegal argument: %s", args[2])
-	}
-	if len(args) > 1 && strings.Contains(args[0], "/") {
-		return fmt.Errorf("extra argument: %s", args[1])
-	}
-	return s.verifyTargetTypeFromArgs(args)
+	return s.checkCommonExposeArgs(cmd.Name(), args)
 }
 
 func (s *SkupperKubeService) ExposeFlags(cmd *cobra.Command) {
@@ -150,9 +141,13 @@ func (s *SkupperKubeService) UnexposeFlags(cmd *cobra.Command) error {
 	return nil
 }
 
-func (s *SkupperKubeService) UnExposeArgs(cmd *cobra.Command, args []string) error {
+func (s *SkupperKubeService) UnexposeArgs(cmd *cobra.Command, args []string) error {
+	return s.checkCommonExposeArgs(cmd.Name(), args)
+}
+
+func (s *SkupperKubeService) checkCommonExposeArgs(command string, args []string) error {
 	if len(args) < 1 || (!strings.Contains(args[0], "/") && len(args) < 2) {
-		return fmt.Errorf("target and name must be specified (e.g. 'skupper unexpose deployment <name>')")
+		return fmt.Errorf("%s target and name must be specified (e.g. 'skupper %s deployment <name>')", command, command)
 	}
 	if len(args) > 2 {
 		return fmt.Errorf("illegal argument: %s", args[2])

--- a/cmd/skupper/skupper_kube_expose.go
+++ b/cmd/skupper/skupper_kube_expose.go
@@ -149,3 +149,16 @@ func (s *SkupperKubeService) UnexposeFlags(cmd *cobra.Command) error {
 	cmd.Use = "unexpose [deployment <name>|pods <selector>|statefulset <statefulsetname>|service <name>|deploymentconfig <name>]"
 	return nil
 }
+
+func (s *SkupperKubeService) UnExposeArgs(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 || (!strings.Contains(args[0], "/") && len(args) < 2) {
+		return fmt.Errorf("target and name must be specified (e.g. 'skupper unexpose deployment <name>')")
+	}
+	if len(args) > 2 {
+		return fmt.Errorf("illegal argument: %s", args[2])
+	}
+	if len(args) > 1 && strings.Contains(args[0], "/") {
+		return fmt.Errorf("extra argument: %s", args[1])
+	}
+	return s.verifyTargetTypeFromArgs(args)
+}

--- a/cmd/skupper/skupper_podman_service.go
+++ b/cmd/skupper/skupper_podman_service.go
@@ -423,3 +423,36 @@ func (s *SkupperPodmanService) UnexposeFlags(cmd *cobra.Command) error {
 	cmd.Use = "unexpose [host hostOrIP]"
 	return nil
 }
+
+func (s *SkupperPodmanService) UnExposeArgs(cmd *cobra.Command, args []string) error {
+	address, err := cmd.Flags().GetString("address")
+	if err != nil || address == "" {
+		return fmt.Errorf("--address is required")
+	}
+	if exposeOpts.Address != "" && len(exposeOpts.Ports) == 0 {
+		return fmt.Errorf("--port is required")
+	}
+	if len(args) < 2 {
+		return fmt.Errorf("Target type and target value must all be specified (e.g. 'skupper unexpose <target-type> <target-value>')")
+	}
+	if len(args) > 2 {
+		return fmt.Errorf("illegal argument: %s", args[2])
+	}
+	if !utils.StringSliceContains(ValidBindTypes, args[0]) {
+		return fmt.Errorf("invalid target type: %s - valid target types are: %s", args[0], ValidBindTypes)
+	}
+	switch args[0] {
+	case BindTypeHost:
+		host := args[1]
+		if args[1] == "" {
+			return fmt.Errorf("a hostname or IP is required")
+		}
+		if net.ParseIP(host) == nil {
+			parsedUrl, err := url.Parse("http://" + host)
+			if err != nil || parsedUrl.Hostname() != host {
+				return fmt.Errorf("invalid hostname or ip")
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/skupper/skupper_podman_service.go
+++ b/cmd/skupper/skupper_podman_service.go
@@ -346,36 +346,7 @@ func (s *SkupperPodmanService) Expose(cmd *cobra.Command, args []string) error {
 }
 
 func (s *SkupperPodmanService) ExposeArgs(cmd *cobra.Command, args []string) error {
-	address, err := cmd.Flags().GetString("address")
-	if err != nil || address == "" {
-		return fmt.Errorf("--address is required")
-	}
-	if exposeOpts.Address != "" && len(exposeOpts.Ports) == 0 {
-		return fmt.Errorf("--port is required")
-	}
-	if len(args) < 2 {
-		return fmt.Errorf("Target type and target value must all be specified (e.g. 'skupper expose <target-type> <target-value>')")
-	}
-	if len(args) > 2 {
-		return fmt.Errorf("illegal argument: %s", args[2])
-	}
-	if !utils.StringSliceContains(ValidBindTypes, args[0]) {
-		return fmt.Errorf("invalid target type: %s - valid target types are: %s", args[0], ValidBindTypes)
-	}
-	switch args[0] {
-	case BindTypeHost:
-		host := args[1]
-		if args[1] == "" {
-			return fmt.Errorf("a hostname or IP is required")
-		}
-		if net.ParseIP(host) == nil {
-			parsedUrl, err := url.Parse("http://" + host)
-			if err != nil || parsedUrl.Hostname() != host {
-				return fmt.Errorf("invalid hostname or ip")
-			}
-		}
-	}
-	return nil
+	return s.checkCommonExposeArgs(cmd, args)
 }
 
 func (s *SkupperPodmanService) ExposeFlags(cmd *cobra.Command) {
@@ -424,7 +395,11 @@ func (s *SkupperPodmanService) UnexposeFlags(cmd *cobra.Command) error {
 	return nil
 }
 
-func (s *SkupperPodmanService) UnExposeArgs(cmd *cobra.Command, args []string) error {
+func (s *SkupperPodmanService) UnexposeArgs(cmd *cobra.Command, args []string) error {
+	return s.checkCommonExposeArgs(cmd, args)
+}
+
+func (s *SkupperPodmanService) checkCommonExposeArgs(cmd *cobra.Command, args []string) error {
 	address, err := cmd.Flags().GetString("address")
 	if err != nil || address == "" {
 		return fmt.Errorf("--address is required")
@@ -433,7 +408,7 @@ func (s *SkupperPodmanService) UnExposeArgs(cmd *cobra.Command, args []string) e
 		return fmt.Errorf("--port is required")
 	}
 	if len(args) < 2 {
-		return fmt.Errorf("Target type and target value must all be specified (e.g. 'skupper unexpose <target-type> <target-value>')")
+		return fmt.Errorf("Target type and target value must all be specified (e.g. 'skupper %s <target-type> <target-value>')", cmd.Name())
 	}
 	if len(args) > 2 {
 		return fmt.Errorf("illegal argument: %s", args[2])

--- a/cmd/skupper/skupper_test.go
+++ b/cmd/skupper/skupper_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"github.com/spf13/cobra"
 	"os"
 	"testing"
 	"time"
@@ -93,8 +94,11 @@ func TestExposeTargetArgs(t *testing.T) {
 	genericError := "expose target and name must be specified (e.g. 'skupper expose deployment <name>')"
 	targetError := "target type must be one of: [deployment, statefulset, pods, service, deploymentconfig]"
 
+	cmd := cobra.Command{
+		Use: "expose",
+	}
 	e := func(args []string) error {
-		return s.ExposeArgs(nil, args)
+		return s.ExposeArgs(&cmd, args)
 	}
 
 	assert.Error(t, e([]string{}), genericError)


### PR DESCRIPTION
> The skupper unexpose command shows text for the expose command.

```
# skupper unexpose
Error: expose target and name must be specified (e.g. 'skupper expose deployment <name>')
Usage:
  skupper unexpose [flags]Flags:
      --address string   Skupper address the target was exposed as
  -h, --help             help for unexposeGlobal Flags:
  -c, --context string      The kubeconfig context to use
      --kubeconfig string   Path to the kubeconfig file to use
  -n, --namespace string    The Kubernetes namespace to use
      --platform string     The platform type to use [kubernetes, podman]# skupper version
client version                 1.4.1 
```