### PR TITLE
update node version 

### DIFF
--- a/Dockerfile.flow-collector
+++ b/Dockerfile.flow-collector
@@ -10,7 +10,7 @@ COPY . .
 
 RUN make
 
-FROM node:16.17 AS console-builder
+FROM node:18.18.2 AS console-builder
 
 WORKDIR /skupper-console/
 ADD https://github.com/skupperproject/skupper-console/archive/main.tar.gz .


### PR DESCRIPTION
Fixing incompatibility issue when building test images at the CI:
```
 => ERROR [console-builder 6/6] RUN yarn install && yarn build             0.5s
------
 > [console-builder 6/6] RUN yarn install && yarn build:
#0 0.357 yarn install v1.22.19
#0 0.436 [1/5] Validating package.json...
#0 0.440 error skupper-web-console@1.5.0: The engine "node" is incompatible with this module. Expected version ">=18.17.1". Got "16.17.1"
#0 0.450 error Found incompatible module.
#0 0.450 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
------
ERROR: failed to solve: executor failed running [/bin/sh -c yarn install && yarn build]: exit code: 1
make: *** [Makefile:57: docker-build] Error 1
```