### PR TITLE
Fix unused error value identified by `go vet`

### DIFF
--- a/test/utils/skupper/cli/gateway/delete.go
+++ b/test/utils/skupper/cli/gateway/delete.go
@@ -100,7 +100,8 @@ func (d *DeleteTester) Run(platform types.Platform, cluster *base.ClusterContext
 	for _, cm := range cmList.Items {
 		gwName, ok := cm.Annotations["skupper.io/gateway-name"]
 		if ok && gwName == gatewayName {
-			fmt.Errorf("gateway configmap still exists")
+			err = fmt.Errorf("gateway configmap still exists")
+			return
 		}
 	}
 


### PR DESCRIPTION
I am not sure if there's more to do, I just applied the pattern used previously in that function here as well.