### PR TITLE
Update now changes both oauth-proxy and prometheus images

### DIFF
--- a/client/router_update.go
+++ b/client/router_update.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/skupperproject/skupper/pkg/utils/configs"
 	"io/ioutil"
 	"log"
 	"net"
@@ -14,6 +13,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/skupperproject/skupper/pkg/utils/configs"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/skupperproject/skupper/pkg/images"
@@ -666,6 +667,31 @@ func (cli *VanClient) RouterUpdateVersionInNamespace(ctx context.Context, hup bo
 			updateController = true
 		}
 	}
+	desiredOauthProxyImage := images.GetOauthProxyImageName()
+	for i, container := range controller.Spec.Template.Spec.Containers {
+		if container.Name == "oauth-proxy" {
+			if controller.Spec.Template.Spec.Containers[i].Image != desiredOauthProxyImage {
+				controller.Spec.Template.Spec.Containers[i].Image = desiredOauthProxyImage
+				updateController = true
+			}
+		}
+	}
+	prometheus, err := cli.KubeClient.AppsV1().Deployments(namespace).Get(context.TODO(), types.PrometheusDeploymentName, metav1.GetOptions{})
+	updatePrometheus := false
+	if err == nil {
+		desiredPrometheusImage := images.GetPrometheusServerImageName()
+		if desiredPrometheusImage != prometheus.Spec.Template.Spec.Containers[0].Image {
+			prometheus.Spec.Template.Spec.Containers[0].Image = desiredPrometheusImage
+			touch(prometheus)
+			_, err = cli.KubeClient.AppsV1().Deployments(namespace).Update(context.TODO(), prometheus, metav1.UpdateOptions{})
+			if err != nil {
+				return false, err
+			}
+			updatePrometheus = true
+		}
+	} else if !errors.IsNotFound(err) {
+		return false, err
+	}
 	if kube.CheckProbesForControllerContainer(&controller.Spec.Template.Spec.Containers[0]) {
 		updateController = true
 	}
@@ -776,7 +802,7 @@ func (cli *VanClient) RouterUpdateVersionInNamespace(ctx context.Context, hup bo
 			return true, err
 		}
 	}
-	return updateRouter || updateController || updateSite, nil
+	return updateRouter || updateController || updateSite || updatePrometheus, nil
 }
 
 func (cli *VanClient) renameRouterConfigFile(namespace string) (bool, error) {

--- a/cmd/site-controller/deploy-watch-all-ns.yaml
+++ b/cmd/site-controller/deploy-watch-all-ns.yaml
@@ -63,6 +63,7 @@ rules:
   - watch
   - create
   - delete
+  - update
 - apiGroups:
     - apps.openshift.io
   resources:

--- a/cmd/site-controller/deploy-watch-current-ns.yaml
+++ b/cmd/site-controller/deploy-watch-current-ns.yaml
@@ -54,6 +54,7 @@ rules:
   - watch
   - create
   - delete
+  - update
 - apiGroups:
     - apps.openshift.io
   resources:
@@ -94,6 +95,7 @@ rules:
   - watch
   - create
   - delete
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/pkg/kube/volumes.go
+++ b/pkg/kube/volumes.go
@@ -37,6 +37,12 @@ func AppendConfigVolume(volumes *[]corev1.Volume, mounts *[]corev1.VolumeMount, 
 }
 
 func AppendSecretVolumeWithVolumeName(volumes *[]corev1.Volume, mounts *[]corev1.VolumeMount, secretName string, volumeName string, path string) {
+	for vi, v := range *volumes {
+		if v.Name == volumeName {
+			*volumes = append((*volumes)[:vi], (*volumes)[vi+1:]...)
+			break
+		}
+	}
 	*volumes = append(*volumes, corev1.Volume{
 		Name: volumeName,
 		VolumeSource: corev1.VolumeSource{
@@ -45,6 +51,12 @@ func AppendSecretVolumeWithVolumeName(volumes *[]corev1.Volume, mounts *[]corev1
 			},
 		},
 	})
+	for mi, m := range *mounts {
+		if m.Name == volumeName || m.MountPath == path {
+			*mounts = append((*mounts)[:mi], (*mounts)[mi+1:]...)
+			break
+		}
+	}
 	*mounts = append(*mounts, corev1.VolumeMount{
 		Name:      volumeName,
 		MountPath: path,


### PR DESCRIPTION
* Add missing site-controller update rules to roles and routes
* Prevents adding duplicated volumes or mounts (name or path)