### PR TITLE
Added "routes/custom-host" resource in ClusterRole needed by OCP

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -157,7 +157,7 @@ var ControllerPolicyRule = []rbacv1.PolicyRule{
 	{
 		Verbs:     []string{"get", "list", "watch"},
 		APIGroups: []string{"route.openshift.io"},
-		Resources: []string{"routes"},
+		Resources: []string{"routes", "routes/custom-host"},
 	},
 	{
 		Verbs:     []string{"get", "list", "watch"},


### PR DESCRIPTION
Fixes skupperproject/skupper-operator#21

Cfr. https://github.com/skupperproject/skupper-operator/pull/35