### PR TITLE
prevent warning regarding missing pem data

### DIFF
--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -175,13 +175,10 @@ func generateSimpleSecretWithCA(name string, ca *CertificateAuthority) corev1.Se
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Type: "kubernetes.io/tls",
 		Data: map[string][]byte{},
 	}
 
 	secret.Data["ca.crt"] = ca.CrtData
-	secret.Data["tls.crt"] = []byte{}
-	secret.Data["tls.key"] = []byte{}
 
 	return secret
 }


### PR DESCRIPTION
The error:

`warnings.go:70] tls: failed to find any PEM data in certificate input`

comes because a secret is created as type `kubernetes.io/tls` but has empty values for the `tls.crt` and `tls.key` entries. This change would avoid the warning.