### PR TITLE
Disable CGO for CI Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,12 @@ orbs:
     go: circleci/go@1.7.1
 
 executors:
+  go_cimg:
+    docker:
+      - image: cimg/go:1.20
+    environment:
+      CGO_ENABLED: 0
+
   local_cluster_test_executor:
     machine:
       image: ubuntu-2204:2022.10.2
@@ -411,8 +417,7 @@ workflows:
 jobs:
   test:
     executor:
-      name: go/default
-      tag: "1.20"
+      name: go_cimg
     steps:
       - checkout
       - run:
@@ -467,8 +472,7 @@ jobs:
 
   build-all:
     executor:
-      name: go/default
-      tag: "1.20"
+      name: go_cimg
     steps:
       - checkout
       - go/mod-download-cached
@@ -551,8 +555,7 @@ jobs:
 
   generate-manifest:
     executor:
-      name: go/default
-      tag: "1.20"
+      name: go_cimg
     steps:
       - checkout
       - go/mod-download-cached
@@ -591,8 +594,7 @@ jobs:
 
   publish-github-release-images:
     executor:
-      name: go/default
-      tag: "1.20"
+      name: go_cimg
     steps:
       - checkout
       - setup_remote_docker
@@ -612,8 +614,7 @@ jobs:
 
   publish-github-main-images:
     executor:
-      name: go/default
-      tag: "1.20"
+      name: go_cimg
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,6 +298,12 @@ commands:
             go build -ldflags "-X github.com/skupperproject/skupper/pkg/version.Version=${VERSION}"
             -o dist/<< parameters.platform >>/skupper<< parameters.exesuffix >>
             ./cmd/skupper
+      - run:
+          name: Audit << parameters.platform >>
+          command: >-
+            sha512sum dist/<< parameters.platform >>/skupper<< parameters.exesuffix >>;
+            file dist/<< parameters.platform >>/skupper<< parameters.exesuffix >>;
+            go version -m dist/<< parameters.platform >>/skupper<< parameters.exesuffix >>;
 
   podman-latest:
     description: "Install latest podman v4 or higher"


### PR DESCRIPTION
Currently releases contain a linux/amd64 skupper-cli asset built with CGO, the default behavior for the go toolchain for native builds. The consequence of this is a less portable executable. This change disables CGO for our tests and builds in CircleCI, and will produce statically linked pure go executables for all platforms uniformly.