### PR TITLE
Fix the output in status commands when headless services are exposed in skupper

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -350,6 +350,5 @@ type VanClientInterface interface {
 	GetIngressDefault() string
 	RevokeAccess(ctx context.Context) error
 	NetworkStatus(ctx context.Context) (*network.NetworkStatusInfo, error)
-	GetRemoteLinks(ctx context.Context, siteConfig *SiteConfig) ([]*network.RemoteLinkInfo, error)
 	GetConsoleUrl(namespace string) (string, error)
 }

--- a/client/network_status.go
+++ b/client/network_status.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/skupperproject/skupper/api/types"
-	"github.com/skupperproject/skupper/pkg/domain/kube"
 	k8s "github.com/skupperproject/skupper/pkg/kube"
 	"github.com/skupperproject/skupper/pkg/network"
 )
@@ -28,13 +27,4 @@ func (cli *VanClient) NetworkStatus(ctx context.Context) (*network.NetworkStatus
 	}
 
 	return vanInfo, nil
-}
-
-func (cli *VanClient) GetRemoteLinks(ctx context.Context, siteConfig *types.SiteConfig) ([]*network.RemoteLinkInfo, error) {
-	cfg, err := cli.getRouterConfig(ctx, cli.Namespace)
-	if err != nil {
-		return nil, err
-	}
-	linkHander := kube.NewLinkHandlerKube(cli.Namespace, siteConfig, cfg, cli.KubeClient, cli.RestConfig)
-	return linkHander.RemoteLinks(ctx)
 }

--- a/client/router_inspect.go
+++ b/client/router_inspect.go
@@ -162,7 +162,7 @@ func getSelf(sites []data.Site, siteId string) *data.Site {
 }
 
 func (cli *VanClient) exec(command []string, namespace string) (*bytes.Buffer, error) {
-	pod, err := kube.GetReadyPod(namespace, cli.KubeClient, "service-controller")
+	pod, err := kube.GetReadyPod(namespace, cli.KubeClient, "service-controller", "")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/skupper/skupper_kube_network.go
+++ b/cmd/skupper/skupper_kube_network.go
@@ -93,7 +93,7 @@ func (s *SkupperKubeNetwork) Status(cmd *cobra.Command, args []string) error {
 							routerId := strings.Split(routerStatus.Router.Name, "/")
 
 							// skip routers that belong to headless services
-							if strings.HasPrefix(routerId[1], siteStatus.Site.Name) {
+							if len(routerId) > 1 && strings.HasPrefix(routerId[1], siteStatus.Site.Name) {
 								routerItem := fmt.Sprintf("name: %s\n", routerId[1])
 								detailsRouter := map[string]string{"image name": routerStatus.Router.ImageName, "image version": routerStatus.Router.ImageVersion}
 
@@ -110,7 +110,6 @@ func (s *SkupperKubeNetwork) Status(cmd *cobra.Command, args []string) error {
 											detailsLink["cost"] = strconv.FormatUint(link.LinkCost, 10)
 										}
 										links.NewChildWithDetail(linkItem, detailsLink)
-
 									}
 								}
 							}

--- a/cmd/skupper/skupper_kube_network.go
+++ b/cmd/skupper/skupper_kube_network.go
@@ -73,17 +73,12 @@ func (s *SkupperKubeNetwork) Status(cmd *cobra.Command, args []string) error {
 
 				if len(siteStatus.RouterStatus) > 0 {
 
-					validRouterIndex := 0
-					for index, router := range siteStatus.RouterStatus {
-						// Ignore routers that belong to statefulsets for headless services and any other router
-						routerId := strings.Split(router.Router.Name, "/")
-						if strings.HasPrefix(routerId[1], router.Router.Namespace) {
-							validRouterIndex = index
-							break
-						}
+					err, index := statusManager.GetRouterIndex(&siteStatus)
+					if err != nil {
+						return err
 					}
 
-					mapSiteLink := statusManager.GetSiteLinkMapPerRouter(&siteStatus.RouterStatus[validRouterIndex], &siteStatus.Site)
+					mapSiteLink := statusManager.GetSiteLinkMapPerRouter(&siteStatus.RouterStatus[index], &siteStatus.Site)
 
 					if len(mapSiteLink) > 0 {
 						siteLinks := siteLevel.NewChild("Linked sites:")
@@ -98,7 +93,7 @@ func (s *SkupperKubeNetwork) Status(cmd *cobra.Command, args []string) error {
 							routerId := strings.Split(routerStatus.Router.Name, "/")
 
 							// skip routers that belong to headless services
-							if strings.HasPrefix(routerId[1], siteStatus.Site.Namespace) {
+							if strings.HasPrefix(routerId[1], siteStatus.Site.Name) {
 								routerItem := fmt.Sprintf("name: %s\n", routerId[1])
 								detailsRouter := map[string]string{"image name": routerStatus.Router.ImageName, "image version": routerStatus.Router.ImageVersion}
 

--- a/cmd/skupper/skupper_kube_service.go
+++ b/cmd/skupper/skupper_kube_service.go
@@ -62,7 +62,7 @@ func (s *SkupperKubeService) Status(cmd *cobra.Command, args []string) error {
 	}
 
 	mapServiceSites := statusManager.GetServiceSitesMap()
-	mapSiteTargets := statusManager.GetSiteTargetsMap()
+	mapSiteTarget := statusManager.GetSiteTargetMap()
 
 	var mapServiceLabels map[string]map[string]string
 	if err == nil {
@@ -74,10 +74,6 @@ func (s *SkupperKubeService) Status(cmd *cobra.Command, args []string) error {
 	} else {
 		l := formatter.NewList()
 		l.Item("Services exposed through Skupper:")
-		var addresses []string
-		for _, si := range currentNetworkStatus.Addresses {
-			addresses = append(addresses, si.Name)
-		}
 
 		for _, si := range currentNetworkStatus.Addresses {
 			svc := l.NewChild(fmt.Sprintf("%s (%s)", si.Name, si.Protocol))
@@ -91,7 +87,7 @@ func (s *SkupperKubeService) Status(cmd *cobra.Command, args []string) error {
 						theSite := sites.NewChildWithDetail(item, map[string]string{"policy": site.Site.Policy})
 
 						if si.ConnectorCount > 0 {
-							t := mapSiteTargets[site.Site.Identity][si.Name]
+							t := mapSiteTarget[site.Site.Identity][si.Name]
 
 							if len(t.Address) > 0 {
 								targets := theSite.NewChild("Targets:")

--- a/cmd/skupper/skupper_kube_site.go
+++ b/cmd/skupper/skupper_kube_site.go
@@ -268,7 +268,12 @@ func (s *SkupperKubeSite) Status(cmd *cobra.Command, args []string) error {
 				policies:  currentSite.Site.Policy,
 			}
 
-			mapSiteLink := statusManager.GetSiteLinkMapPerRouter(&currentSite.RouterStatus[0], &currentSite.Site)
+			err, index := statusManager.GetRouterIndex(currentSite)
+			if err != nil {
+				return err
+			}
+
+			mapSiteLink := statusManager.GetSiteLinkMapPerRouter(&currentSite.RouterStatus[index], &currentSite.Site)
 
 			totalSites := len(currentStatus.SiteStatus)
 			// the current site does not count as a connection

--- a/cmd/skupper/skupper_link.go
+++ b/cmd/skupper/skupper_link.go
@@ -227,7 +227,7 @@ func NewCmdLinkStatus(skupperClient SkupperLinkClient) *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&waitFor, "wait", 0, "The number of seconds to wait for links to become connected")
-	cmd.Flags().BoolVar(&verboseLinkStatus, "verbose", false, "Show detailed information about a link")
+	cmd.Flags().BoolVarP(&verboseLinkStatus, "verbose", "v", false, "Show detailed information about a link")
 
 	return cmd
 

--- a/cmd/skupper/skupper_mock_test.go
+++ b/cmd/skupper/skupper_mock_test.go
@@ -319,10 +319,6 @@ func (v *vanClientMock) NetworkStatus(ctx context.Context) (*network.NetworkStat
 	return &result, nil
 }
 
-func (v *vanClientMock) GetRemoteLinks(ctx context.Context, siteConfig *types.SiteConfig) ([]*network.RemoteLinkInfo, error) {
-	return nil, nil
-}
-
 func (v *vanClientMock) GetConsoleUrl(namespace string) (string, error) {
 	return "", nil
 }

--- a/pkg/kube/qdr/mgmt.go
+++ b/pkg/kube/qdr/mgmt.go
@@ -290,7 +290,7 @@ func getLocalRouterId(namespace string, clientset kubernetes.Interface, config *
 }
 
 func router_exec(command []string, namespace string, clientset kubernetes.Interface, config *restclient.Config) (*bytes.Buffer, error) {
-	pod, err := kube.GetReadyPod(namespace, clientset, "router")
+	pod, err := kube.GetReadyPod(namespace, clientset, "router", "skupper-router")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -73,7 +73,11 @@ func (s *SkupperStatus) GetRouterSiteMap() map[string]SiteStatusInfo {
 			for _, routerStatus := range siteStatus.RouterStatus {
 				// the name of the router has a "0/" as a prefix that it is needed to remove
 				routerName := strings.Split(routerStatus.Router.Name, "/")
-				mapRouterSite[routerName[1]] = siteStatus
+
+				// Remove routers that belong to statefulsets for headless services
+				if strings.HasPrefix(routerName[1], siteStatus.Site.Namespace) {
+					mapRouterSite[routerName[1]] = siteStatus
+				}
 			}
 		}
 	}
@@ -93,7 +97,6 @@ func (s *SkupperStatus) GetSiteById(siteId string) *SiteStatusInfo {
 }
 
 func (s *SkupperStatus) GetSiteLinkMapPerRouter(router *RouterStatusInfo, site *SiteInfo) map[string]LinkInfo {
-
 	routerSiteMap := s.GetRouterSiteMap()
 	siteLinkMap := make(map[string]LinkInfo)
 	if len(router.Links) > 0 {

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -71,7 +71,7 @@ func (s *SkupperStatus) GetRouterSiteMap() map[string]SiteStatusInfo {
 				routerName := strings.Split(routerStatus.Router.Name, "/")
 
 				// Remove routers that belong to statefulsets for headless services
-				if strings.HasPrefix(routerName[1], siteStatus.Site.Name) {
+				if len(routerName) > 1 && strings.HasPrefix(routerName[1], siteStatus.Site.Name) {
 					mapRouterSite[routerName[1]] = siteStatus
 				}
 			}
@@ -122,7 +122,8 @@ func (s *SkupperStatus) GetRouterIndex(site *SiteStatusInfo) (error, int) {
 	for index, router := range site.RouterStatus {
 		// Ignore routers that belong to statefulsets for headless services and any other router
 		routerId := strings.Split(router.Router.Name, "/")
-		if strings.HasPrefix(routerId[1], site.Site.Name) {
+
+		if len(routerId) > 1 && strings.HasPrefix(routerId[1], site.Site.Name) {
 			return nil, index
 
 		}

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -53,7 +53,7 @@ func TestGetSiteTargetsMap(t *testing.T) {
 	expectedSite2 := "429c2780-003d-44cc-9a91-4139885c7d20"
 	expectedService := "backend:8080"
 
-	result := skupperStatus.GetSiteTargetsMap()
+	result := skupperStatus.GetSiteTargetMap()
 
 	assert.Check(t, result[expectedSite2] == nil)
 	assert.Check(t, result[expectedSite1][expectedService].Address == expectedService)

--- a/test/integration/acceptance/custom/basic/basic.go
+++ b/test/integration/acceptance/custom/basic/basic.go
@@ -128,7 +128,7 @@ func (r *BasicTestRunner) Setup(ctx context.Context, createOptsPublic types.Site
 			"StartTimeAfter=", podStartTimeAfter, "Router component restarted - POD status:", string(podStatus))
 
 		// Check if the Volume is shared by both containers
-		podContainers, _ := kube.GetReadyPod(prv1Cluster.Namespace, prv1Cluster.VanClient.KubeClient, "router")
+		podContainers, _ := kube.GetReadyPod(prv1Cluster.Namespace, prv1Cluster.VanClient.KubeClient, "router", "skupper-router")
 		for _, container := range podContainers.Spec.Containers {
 			foundCertVol := false
 			for _, contVolume := range container.VolumeMounts {

--- a/test/integration/acceptance/custom/hello_policy/issues_test.go
+++ b/test/integration/acceptance/custom/hello_policy/issues_test.go
@@ -26,7 +26,7 @@ import (
 //
 // The pod name comes from kube.GetReadyPod for service-controller
 func seekServiceControllerAndDelete(ctx *base.ClusterContext) {
-	pod, err := kube.GetReadyPod(ctx.Namespace, ctx.VanClient.KubeClient, "service-controller")
+	pod, err := kube.GetReadyPod(ctx.Namespace, ctx.VanClient.KubeClient, "service-controller", "")
 	if err != nil {
 		log.Printf("Ignoring pod listing error '%v'", err)
 		return

--- a/test/integration/performance/common/setup.go
+++ b/test/integration/performance/common/setup.go
@@ -404,7 +404,7 @@ func tailRouterLogs(ctx context.Context, saveLogs *bool) *sync.WaitGroup {
 		var err error
 		log.Printf("Waiting for router pod to be running")
 		err = pkgutils.RetryWithContext(ctx, time.Second*5, func() (bool, error) {
-			pod, err = kube.GetReadyPod(cli.Namespace, cli.KubeClient, "router")
+			pod, err = kube.GetReadyPod(cli.Namespace, cli.KubeClient, "router", "skupper-router")
 			if pod != nil && err == nil {
 				return true, nil
 			}


### PR DESCRIPTION
Context: 
When a headless service is exposed, Skupper creates statefulsets with a pod of the router image that includes a listener or a connector, separated from the skupper-router. 

Fixed issues: 
- The service status command didn't show the targets of the headless services because the command was just checking the skupper-router.
- The link status command, when getting all the direct connections from the router,  was querying the first ready pod with the label "skupper.io/component=router". This could return sometimes the pods from the statefulsets that have the same label; and because they did not have the expected connectors (links), the command show incorrectly that the links where not connected. For the same reason, the skupper version command, some times was getting the wrong router component and it was not showing the versions of the router and the config-sync.
- The skupper status command, was getting information about the linked sites from a statefulset-router, for that reason the output was showing sites connected indirectly (and incorrectly).
- For the same reason as before, the skupper network status command was not showing always the linked sites.

