### PR TITLE
Improvements to the cleanup of podman sites

### DIFF
--- a/client/podman/container.go
+++ b/client/podman/container.go
@@ -340,7 +340,7 @@ func (p *PodmanRestClient) ContainerExec(id string, command []string) (string, e
 	}
 	result, err := p.RestClient.Submit(execOp)
 	if err != nil {
-		return "", fmt.Errorf("error executing command: %v", err)
+		return "", fmt.Errorf("error executing command on %s: %v", id, err)
 	}
 	resp, ok := result.(*models.IDResponse)
 	if !ok {

--- a/client/podman/volume.go
+++ b/client/podman/volume.go
@@ -52,6 +52,7 @@ func (p *PodmanRestClient) VolumeRemove(id string) error {
 	cli := volumes.New(p.RestClient, formats)
 	params := volumes.NewVolumeDeleteLibpodParams()
 	params.Name = id
+	params.Force = boolTrue()
 	_, err = cli.VolumeDeleteLibpod(params)
 	if err != nil {
 		return err

--- a/cmd/skupper/skupper_podman.go
+++ b/cmd/skupper/skupper_podman.go
@@ -136,6 +136,12 @@ func (s *SkupperPodman) NewClient(cmd *cobra.Command, args []string) {
 		if err != nil {
 			fmt.Printf("Skupper is not enabled for user '%s'", podman.Username)
 			fmt.Println()
+			if siteHandler.AnyResourceLeft() {
+				fmt.Println("Reason:", err)
+				fmt.Println()
+				fmt.Println("There are podman resources missing or left from an earlier installation")
+				fmt.Println("To clean them up, run: skupper delete")
+			}
 			os.Exit(0)
 		}
 	}

--- a/cmd/skupper/skupper_podman.go
+++ b/cmd/skupper/skupper_podman.go
@@ -7,7 +7,7 @@ import (
 	"github.com/skupperproject/skupper/api/types"
 	clientpodman "github.com/skupperproject/skupper/client/podman"
 	"github.com/skupperproject/skupper/pkg/domain/podman"
-	"github.com/skupperproject/skupper/test/utils"
+	"github.com/skupperproject/skupper/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -107,7 +107,7 @@ func (s *SkupperPodman) NewClient(cmd *cobra.Command, args []string) {
 	if err != nil {
 		if exitOnError {
 			fmt.Printf("Podman endpoint is not available: %s",
-				utils.StrDefault(endpoint, clientpodman.GetDefaultPodmanEndpoint()))
+				utils.DefaultStr(endpoint, clientpodman.GetDefaultPodmanEndpoint()))
 			fmt.Println()
 			os.Exit(1)
 		}
@@ -131,8 +131,8 @@ func (s *SkupperPodman) NewClient(cmd *cobra.Command, args []string) {
 			fmt.Println()
 			os.Exit(0)
 		}
-	} else if cmd.Name() != "version" {
-		// All other commands, but version, must stop now
+	} else if !utils.StringSliceContains([]string{"version", "delete"}, cmd.Name()) {
+		// All other commands, but version and delete, must stop now
 		if err != nil {
 			fmt.Printf("Skupper is not enabled for user '%s'", podman.Username)
 			fmt.Println()

--- a/cmd/skupper/skupper_podman_site.go
+++ b/cmd/skupper/skupper_podman_site.go
@@ -204,6 +204,11 @@ func (s *SkupperPodmanSite) Delete(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("Unable to delete Skupper - %w", err)
 	}
+	if s.podman.currentSite == nil && !siteHandler.AnyResourceLeft() {
+		fmt.Printf("Skupper is not enabled for user '%s'", podman.Username)
+		fmt.Println()
+		return nil
+	}
 	err = siteHandler.Delete()
 	if err != nil {
 		return err

--- a/cmd/skupper/skupper_podman_site.go
+++ b/cmd/skupper/skupper_podman_site.go
@@ -142,6 +142,7 @@ Recommendation:
 	}
 
 	// Initializing
+	cmd.SilenceUsage = true
 	err = siteHandler.Create(site)
 	if err != nil {
 		return fmt.Errorf("Error initializing Skupper - %w", err)
@@ -198,13 +199,10 @@ func (s *SkupperPodmanSite) CreateFlags(cmd *cobra.Command) {
 }
 
 func (s *SkupperPodmanSite) Delete(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
 	siteHandler, err := podman.NewSitePodmanHandler("")
 	if err != nil {
 		return fmt.Errorf("Unable to delete Skupper - %w", err)
-	}
-	curSite, err := siteHandler.Get()
-	if err != nil || curSite == nil {
-		return err
 	}
 	err = siteHandler.Delete()
 	if err != nil {

--- a/pkg/domain/podman/site_test.go
+++ b/pkg/domain/podman/site_test.go
@@ -4,13 +4,26 @@
 package podman
 
 import (
+	_ "embed"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/client/container"
+	"github.com/skupperproject/skupper/client/podman"
 	"github.com/skupperproject/skupper/pkg/domain"
+	"github.com/skupperproject/skupper/pkg/images"
 	"github.com/skupperproject/skupper/pkg/utils"
 	"gotest.tools/assert"
+)
+
+var (
+	//go:embed update/skrouterd.json
+	skrouterdJson string
+	//go:embed update/skupper-services.json
+	skupperServicesJson string
 )
 
 func TestSiteHandler(t *testing.T) {
@@ -114,4 +127,270 @@ func TestSiteHandler(t *testing.T) {
 			assert.Equal(t, scenarioSite.PrometheusOpts.Password, podmanSite.PrometheusOpts.Password)
 		})
 	}
+}
+
+func TestSiteHandlerDeleteBrokenSite(t *testing.T) {
+	siteHandler, err := NewSitePodmanHandler(getEndpoint())
+	assert.Assert(t, err)
+
+	// counting containers and volumes
+	countContainersAndVolumes := func() (int, int) {
+		// Saving number of containers and volumes before initializing skupper
+		// Asserting number of container and volumes are > 1
+		containers, err := siteHandler.cli.ContainerList()
+		containerCount := len(containers)
+		assert.Assert(t, err)
+		volumes, err := siteHandler.cli.VolumeList()
+		volumeCount := len(volumes)
+		assert.Assert(t, err)
+		return containerCount, volumeCount
+	}
+
+	// retrieve totals before site creation
+	containersBefore, volumesBefore := countContainersAndVolumes()
+
+	// Initializing skupper
+	site := &Site{
+		SiteCommon: &domain.SiteCommon{
+			Name: "site-podman-fc-ingress",
+		},
+		IngressHosts:        []string{"127.0.0.1"},
+		EnableFlowCollector: true,
+		EnableConsole:       true,
+		AuthMode:            "internal",
+		ConsoleUser:         "internal",
+		ConsolePassword:     "internal",
+		PrometheusOpts: types.PrometheusServerOptions{
+			ExternalServer: "http://10.0.0.1:8080/v1",
+			AuthMode:       "internal",
+			User:           "admin",
+			Password:       "admin",
+		},
+	}
+
+	// Create a podman site
+	err = siteHandler.Create(site)
+	assert.Assert(t, err)
+
+	// remove site
+	defer func() {
+		_ = siteHandler.Delete()
+	}()
+
+	// Validating container and volume counts after creation
+	containersAfterCreate, volumesAfterCreate := countContainersAndVolumes()
+	assert.Equal(t, containersAfterCreate, containersBefore+4)
+	assert.Equal(t, volumesAfterCreate, volumesBefore+14)
+
+	//
+	// Removing mandatory volume
+	err = siteHandler.cli.VolumeRemove(types.TransportConfigMapName)
+	assert.Assert(t, err)
+
+	// Forcing site to be in a bad state
+	err = siteHandler.Delete()
+	assert.Assert(t, err)
+
+	// Asserting number of containers and volumes are back to original state
+	containersAfterDelete, volumesAfterDelete := countContainersAndVolumes()
+	assert.Equal(t, containersBefore, containersAfterDelete)
+	assert.Equal(t, volumesBefore, volumesAfterDelete)
+}
+
+func TestSiteHandlerDeleteBrokenSiteMock(t *testing.T) {
+	cli := podman.NewPodmanClientMock(mockContainers())
+	mock := cli.RestClient.(*podman.RestClientMock)
+	assert.Assert(t, mock.MockVolumeFiles(mockVolumes()))
+	defer func() {
+		_ = mock.CleanupMockVolumeDir()
+	}()
+
+	// must NOT be removed after SiteHandler.Delete() is called
+	mock.Volumes["my-volume"] = &container.Volume{
+		Name: "my-volume",
+		Labels: map[string]string{
+			"my-label": "my-value",
+		},
+	}
+
+	sh := NewSitePodmanHandlerFromCli(cli)
+	site, err := sh.Get()
+	assert.Assert(t, err)
+	assert.Assert(t, site != nil)
+
+	// verify mock site is in good state
+	assert.Assert(t, err)
+
+	// validating number of containers and volumes before removal
+	containers, err := cli.ContainerList()
+	assert.Assert(t, err)
+	assert.Equal(t, len(containers), 5)
+	volumes, err := cli.VolumeList()
+	assert.Assert(t, err)
+	assert.Equal(t, len(volumes), 13)
+
+	// force a site get to be in a bad state
+	delete(mock.Volumes, types.TransportConfigMapName)
+	site, err = sh.Get()
+	assert.Assert(t, err != nil)
+	assert.Assert(t, site == nil)
+
+	// validating delete removed remaining resources
+	err = sh.Delete()
+	assert.Assert(t, err)
+
+	// assert container not owned by skupper remains
+	containers, err = cli.ContainerList()
+	assert.Assert(t, err)
+	assert.Equal(t, len(containers), 1)
+
+	// assert volume not owned by skupper remains
+	volumes, err = cli.VolumeList()
+	assert.Assert(t, err)
+	assert.Equal(t, len(volumes), 1)
+
+}
+
+func mockContainers() []*container.Container {
+	return []*container.Container{
+		{
+			ID:    strings.Replace(uuid.New().String(), "-", "", -1),
+			Name:  "skupper-router",
+			Image: images.GetRouterImageName(),
+			Labels: map[string]string{
+				"application":          "skupper",
+				"skupper.io/component": "skupper-router",
+			},
+			Networks: map[string]container.ContainerNetworkInfo{
+				"skupper": {
+					ID:        "skupper",
+					IPAddress: "172.17.0.10",
+					Gateway:   "172.17.0.1",
+					Aliases:   []string{"skupper-router"},
+					//Aliases:   []string{"skupper", "service-controller"},
+				},
+			},
+			Ports: []container.Port{
+				{Host: "55671", HostIP: "", Target: "55671", Protocol: "tcp"},
+				{Host: "45671", HostIP: "", Target: "45671", Protocol: "tcp"},
+			},
+			Running:   true,
+			CreatedAt: time.Now(),
+			StartedAt: time.Now(),
+		},
+		{
+			ID:    strings.Replace(uuid.New().String(), "-", "", -1),
+			Name:  "skupper-controller-podman",
+			Image: images.GetControllerPodmanImageName(),
+			Labels: map[string]string{
+				"application":          "skupper",
+				"skupper.io/component": "skupper-controller-podman",
+			},
+			Networks: map[string]container.ContainerNetworkInfo{
+				"skupper": {
+					ID:        "skupper",
+					IPAddress: "172.17.0.11",
+					Gateway:   "172.17.0.1",
+					Aliases:   []string{"skupper", "service-controller-podman"},
+				},
+			},
+			Running:   true,
+			CreatedAt: time.Now(),
+			StartedAt: time.Now(),
+		}, {
+			ID:    strings.Replace(uuid.New().String(), "-", "", -1),
+			Name:  "flow-collector",
+			Image: images.GetFlowCollectorImageName(),
+			Labels: map[string]string{
+				"application":          "skupper",
+				"skupper.io/component": "flow-collector",
+			},
+			Networks: map[string]container.ContainerNetworkInfo{
+				"skupper": {
+					ID:        "skupper",
+					IPAddress: "172.17.0.12",
+					Gateway:   "172.17.0.1",
+					Aliases:   []string{"flow-collector"},
+				},
+			},
+			Ports: []container.Port{
+				{Host: "8010", HostIP: "", Target: "8010", Protocol: "tcp"},
+			},
+			Running:   true,
+			CreatedAt: time.Now(),
+			StartedAt: time.Now(),
+		}, {
+			ID:    strings.Replace(uuid.New().String(), "-", "", -1),
+			Name:  "nginx-service",
+			Image: images.GetRouterImageName(),
+			Labels: map[string]string{
+				"application":        "skupper",
+				"skupper.io/address": "nginx",
+			},
+			Networks: map[string]container.ContainerNetworkInfo{
+				"skupper": {
+					ID:        "skupper",
+					IPAddress: "172.17.0.13",
+					Gateway:   "172.17.0.1",
+					Aliases:   []string{"nginx-service"},
+				},
+			},
+			Ports: []container.Port{
+				{Host: "8080", HostIP: "", Target: "8080", Protocol: "tcp"},
+			},
+			Running:   true,
+			CreatedAt: time.Now(),
+			StartedAt: time.Now(),
+		}, {
+			ID:     strings.Replace(uuid.New().String(), "-", "", -1),
+			Name:   "nginx",
+			Image:  "docker.io/nginxinc/nginx-unprivileged:stable-alpine",
+			Labels: map[string]string{},
+			Networks: map[string]container.ContainerNetworkInfo{
+				"skupper": {
+					ID:        "skupper",
+					IPAddress: "172.17.0.14",
+					Gateway:   "172.17.0.1",
+					Aliases:   []string{"nginx"},
+				},
+			},
+			Running:   true,
+			CreatedAt: time.Now(),
+			StartedAt: time.Now(),
+		},
+	}
+}
+
+func mockVolumes() (map[string]*container.Volume, map[string]map[string]string) {
+	var volumes = map[string]*container.Volume{}
+	var volumesFiles = map[string]map[string]string{}
+	addSkupperVolume := func(name string) {
+		volumes[name] = &container.Volume{Name: name, Labels: map[string]string{"application": "skupper"}}
+	}
+	addSkupperVolume("skupper-console-certs")
+	addSkupperVolume("skupper-console-users")
+	addSkupperVolume("skupper-internal")
+	addSkupperVolume("skupper-local-ca")
+	addSkupperVolume("skupper-local-client")
+	addSkupperVolume("skupper-local-server")
+	addSkupperVolume("skupper-router-certs")
+	addSkupperVolume("skupper-service-ca")
+	addSkupperVolume("skupper-service-client")
+	addSkupperVolume("skupper-services")
+	addSkupperVolume("skupper-site-ca")
+	addSkupperVolume("skupper-site-server")
+
+	// volumes content
+	volumesFiles["skupper-internal"] = map[string]string{
+		"skrouterd.json": skrouterdJson,
+	}
+	volumesFiles["skupper-console-users"] = map[string]string{
+		"admin": "admin",
+	}
+	volumesFiles["skupper-services"] = map[string]string{
+		"skupper-services.json": skupperServicesJson,
+	}
+
+	// defining skupper-services configmap
+	return volumes, volumesFiles
 }

--- a/pkg/domain/podman/site_test.go
+++ b/pkg/domain/podman/site_test.go
@@ -364,21 +364,25 @@ func mockContainers() []*container.Container {
 func mockVolumes() (map[string]*container.Volume, map[string]map[string]string) {
 	var volumes = map[string]*container.Volume{}
 	var volumesFiles = map[string]map[string]string{}
-	addSkupperVolume := func(name string) {
-		volumes[name] = &container.Volume{Name: name, Labels: map[string]string{"application": "skupper"}}
+	addSkupperVolume := func(name string, typeLabel ...string) {
+		labels := map[string]string{"application": "skupper"}
+		if len(typeLabel) == 1 {
+			labels[types.SkupperTypeQualifier] = typeLabel[0]
+		}
+		volumes[name] = &container.Volume{Name: name, Labels: labels}
 	}
-	addSkupperVolume("skupper-console-certs")
+	addSkupperVolume("skupper-console-certs", "Credential")
 	addSkupperVolume("skupper-console-users")
 	addSkupperVolume("skupper-internal")
-	addSkupperVolume("skupper-local-ca")
-	addSkupperVolume("skupper-local-client")
-	addSkupperVolume("skupper-local-server")
+	addSkupperVolume("skupper-local-ca", "CertAuthority")
+	addSkupperVolume("skupper-local-client", "Credential")
+	addSkupperVolume("skupper-local-server", "Credential")
 	addSkupperVolume("skupper-router-certs")
-	addSkupperVolume("skupper-service-ca")
-	addSkupperVolume("skupper-service-client")
+	addSkupperVolume("skupper-service-ca", "CertAuthority")
+	addSkupperVolume("skupper-service-client", "Credential")
 	addSkupperVolume("skupper-services")
-	addSkupperVolume("skupper-site-ca")
-	addSkupperVolume("skupper-site-server")
+	addSkupperVolume("skupper-site-ca", "CertAuthority")
+	addSkupperVolume("skupper-site-server", "Credential")
 
 	// volumes content
 	volumesFiles["skupper-internal"] = map[string]string{

--- a/pkg/domain/podman/update/common_test.go
+++ b/pkg/domain/podman/update/common_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/client/container"
 	"github.com/skupperproject/skupper/client/podman"
 	domainpodman "github.com/skupperproject/skupper/pkg/domain/podman"
@@ -273,21 +274,25 @@ func mockContainers() []*container.Container {
 func mockVolumes() (map[string]*container.Volume, map[string]map[string]string) {
 	var volumes = map[string]*container.Volume{}
 	var volumesFiles = map[string]map[string]string{}
-	addSkupperVolume := func(name string) {
-		volumes[name] = &container.Volume{Name: name, Labels: map[string]string{"application": "skupper"}}
+	addSkupperVolume := func(name string, typeLabel ...string) {
+		labels := map[string]string{"application": "skupper"}
+		if len(typeLabel) == 1 {
+			labels[types.SkupperTypeQualifier] = typeLabel[0]
+		}
+		volumes[name] = &container.Volume{Name: name, Labels: labels}
 	}
-	addSkupperVolume("skupper-console-certs")
+	addSkupperVolume("skupper-console-certs", "Credential")
 	addSkupperVolume("skupper-console-users")
 	addSkupperVolume("skupper-internal")
-	addSkupperVolume("skupper-local-ca")
-	addSkupperVolume("skupper-local-client")
-	addSkupperVolume("skupper-local-server")
+	addSkupperVolume("skupper-local-ca", "CertAuthority")
+	addSkupperVolume("skupper-local-client", "Credential")
+	addSkupperVolume("skupper-local-server", "Credential")
 	addSkupperVolume("skupper-router-certs")
-	addSkupperVolume("skupper-service-ca")
-	addSkupperVolume("skupper-service-client")
+	addSkupperVolume("skupper-service-ca", "CertAuthority")
+	addSkupperVolume("skupper-service-client", "Credential")
 	addSkupperVolume("skupper-services")
-	addSkupperVolume("skupper-site-ca")
-	addSkupperVolume("skupper-site-server")
+	addSkupperVolume("skupper-site-ca", "CertAuthority")
+	addSkupperVolume("skupper-site-server", "Credential")
 
 	// volumes content
 	volumesFiles["skupper-internal"] = map[string]string{


### PR DESCRIPTION
* Improves skupper delete command to remove resources left from a bad initialization or a broken site
* It also improves the initialization process to get rid of all created resources in case of an initialization failure (preventing sites to be in a broken state)