### PR TITLE
Include a profile option in the flow-collector

### DIFF
--- a/cmd/flow-collector/main.go
+++ b/cmd/flow-collector/main.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path"
@@ -207,9 +208,12 @@ func internalLogout(w http.ResponseWriter, r *http.Request, validNonces map[stri
 }
 
 func main() {
+	flags := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	// if -version used, report and exit
-	isVersion := flag.Bool("version", false, "Report the version of the Skupper Flow Collector")
-	flag.Parse()
+	isVersion := flags.Bool("version", false, "Report the version of the Skupper Flow Collector")
+	isProf := flags.Bool("profile", false, "Exposes the runtime profiling facilities from net/http/pprof on http://localhost:9970")
+
+	flags.Parse(os.Args[1:])
 	if *isVersion {
 		fmt.Println(version.Version)
 		os.Exit(0)
@@ -589,6 +593,12 @@ func main() {
 			}
 		}
 	}()
+	if *isProf {
+		// serve only over localhost loopback
+		go func() {
+			log.Fatalf("failure running default http server for net/http/pprof: %s", http.ListenAndServe("localhost:9970", nil))
+		}()
+	}
 
 	if err = c.Run(stopCh); err != nil {
 		log.Fatal("Error running Flow collector: ", err.Error())

--- a/cmd/flow-collector/main.go
+++ b/cmd/flow-collector/main.go
@@ -596,7 +596,9 @@ func main() {
 	if *isProf {
 		// serve only over localhost loopback
 		go func() {
-			log.Fatalf("failure running default http server for net/http/pprof: %s", http.ListenAndServe("localhost:9970", nil))
+			if err := http.ListenAndServe("localhost:9970", nil); err != nil {
+				log.Fatalf("failure running default http server for net/http/pprof: %s", err)
+			}
 		}()
 	}
 


### PR DESCRIPTION
adds a `-profile` flag to the flow-collector that when enabled will expose the routes from the net/http/pprof package over loopback to allow us to better understand the collector's resource utilization.


To use profiling data while running in k8s:

* edit the service controller deployment to run the flow collector with the `-profile` flag set: 
`kubectl patch deployment skupper-service-controller -p '{"spec":{"template":{"spec":{"containers":[{"name":"flow-collector","command":["/app/flow-collector"],"args":["-profile"]}]}}}}'`
* port-forward port 9970 from the deployment to your host: `kubectl port-forward deployments/skupper-service-controller 9970:9970`
* Open `http://localhost:9970/debug/pprof/` in your browser