### PR TITLE
Fixes displaying of podman sites recommandation

### DIFF
--- a/client/podman/rest.go
+++ b/client/podman/rest.go
@@ -37,6 +37,8 @@ type PodmanRestClient struct {
 	endpoint   string
 }
 
+type RestClientFactory func(endpoint, basePath string) (*PodmanRestClient, error)
+
 func NewPodmanClient(endpoint, basePath string) (*PodmanRestClient, error) {
 	var err error
 

--- a/cmd/skupper/skupper_podman_site.go
+++ b/cmd/skupper/skupper_podman_site.go
@@ -78,26 +78,10 @@ func (s *SkupperPodmanSite) Create(cmd *cobra.Command, args []string) error {
 	siteHandler, err := podman.NewSitePodmanHandler(site.PodmanEndpoint)
 	if err != nil {
 		initErr := fmt.Errorf("Unable to initialize Skupper - %w", err)
-		recommendation := `
-Recommendation:
-
-	Make sure you have an active podman endpoint available.
-	On most systems you can execute:
-
-		systemctl --user enable --now podman.socket
-
-	Alternatively you could also create your own service that runs:
-
-		podman system service --time=0 <URI>
-
-	You can get concrete examples through:
-
-		podman help system service`
 
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true
 		fmt.Println("Error:", initErr)
-		fmt.Println(recommendation)
 		return initErr
 	}
 

--- a/cmd/skupper/skupper_podman_test.go
+++ b/cmd/skupper/skupper_podman_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	clientpodman "github.com/skupperproject/skupper/client/podman"
+	"github.com/skupperproject/skupper/pkg/domain"
+	"github.com/skupperproject/skupper/pkg/domain/podman"
+	"github.com/spf13/cobra"
+	"gotest.tools/assert"
+)
+
+func TestNewClient(t *testing.T) {
+
+	const didNotExit = -99
+	tests := []struct {
+		scenario           string
+		command            string
+		args               []string
+		cliFactory         clientpodman.RestClientFactory
+		siteHandlerFactory podman.SiteHandlerFactory
+		currentSiteLoaded  bool
+		exitCode           int
+		stdoutContains     string
+	}{
+		{
+			scenario: "init-invalid-endpoint",
+			command:  "init",
+			args:     []string{"/invalid/podman/endpoint"},
+			cliFactory: func(endpoint, basePath string) (*clientpodman.PodmanRestClient, error) {
+				return nil, fmt.Errorf("Podman endpoint is not available: %s", endpoint)
+			},
+			exitCode:       1,
+			stdoutContains: "Recommendation:",
+		},
+		{
+			scenario: "init-sitehandler-factory-error",
+			command:  "init",
+			cliFactory: func(endpoint, basePath string) (*clientpodman.PodmanRestClient, error) {
+				return &clientpodman.PodmanRestClient{}, nil
+			},
+			siteHandlerFactory: func(endpoint string) (domain.SiteHandler, error) {
+				return nil, fmt.Errorf("unable to get sitehandler instance [mock]")
+			},
+			exitCode:       1,
+			stdoutContains: "error verifying existing skupper site",
+		},
+		{
+			scenario: "init-already-exists",
+			command:  "init",
+			cliFactory: func(endpoint, basePath string) (*clientpodman.PodmanRestClient, error) {
+				return &clientpodman.PodmanRestClient{}, nil
+			},
+			siteHandlerFactory: func(endpoint string) (domain.SiteHandler, error) {
+				siteHandler := &siteHandlerMock{
+					getHook: func() (domain.Site, error) {
+						return &podman.Site{}, nil
+					},
+				}
+				return siteHandler, nil
+			},
+			currentSiteLoaded: false,
+			exitCode:          0,
+			stdoutContains:    "Skupper has already been initialized for user",
+		},
+		{
+			scenario: "status-ok",
+			command:  "status",
+			cliFactory: func(endpoint, basePath string) (*clientpodman.PodmanRestClient, error) {
+				return &clientpodman.PodmanRestClient{}, nil
+			},
+			siteHandlerFactory: func(endpoint string) (domain.SiteHandler, error) {
+				siteHandler := &siteHandlerMock{
+					getHook: func() (domain.Site, error) {
+						return &podman.Site{}, nil
+					},
+				}
+				return siteHandler, nil
+			},
+			currentSiteLoaded: true,
+			exitCode:          didNotExit,
+		},
+		{
+			scenario: "status-not-enabled",
+			command:  "status",
+			cliFactory: func(endpoint, basePath string) (*clientpodman.PodmanRestClient, error) {
+				return &clientpodman.PodmanRestClient{}, nil
+			},
+			siteHandlerFactory: func(endpoint string) (domain.SiteHandler, error) {
+				siteHandler := &siteHandlerMock{
+					getHook: func() (domain.Site, error) {
+						return nil, fmt.Errorf("skupper is not enabled")
+					},
+				}
+				return siteHandler, nil
+			},
+			currentSiteLoaded: false,
+			stdoutContains:    "Skupper is not enabled for user",
+			exitCode:          0,
+		},
+		{
+			scenario: "version-not-enabled",
+			command:  "version",
+			cliFactory: func(endpoint, basePath string) (*clientpodman.PodmanRestClient, error) {
+				return &clientpodman.PodmanRestClient{}, nil
+			},
+			siteHandlerFactory: func(endpoint string) (domain.SiteHandler, error) {
+				siteHandler := &siteHandlerMock{
+					getHook: func() (domain.Site, error) {
+						return nil, fmt.Errorf("skupper is not enabled")
+					},
+				}
+				return siteHandler, nil
+			},
+			exitCode: didNotExit,
+		},
+	}
+
+	var s *SkupperPodman
+	var lastExitCode int
+	stdout := new(bytes.Buffer)
+	resetSkupperPodman := func() {
+		s = &SkupperPodman{}
+		s.exit = func(code int) {
+			lastExitCode = code
+		}
+		s.output = stdout
+		lastExitCode = didNotExit
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			// reset test status
+			resetSkupperPodman()
+			// set factories
+			s.cliFactory = test.cliFactory
+			s.siteHandlerFactory = test.siteHandlerFactory
+			s.NewClient(&cobra.Command{
+				Use: test.command,
+			}, test.args)
+			assert.Equal(t, lastExitCode, test.exitCode)
+			assert.Assert(t, strings.Contains(stdout.String(), test.stdoutContains))
+			siteLoaded := s.currentSite != nil
+			assert.Assert(t, siteLoaded == test.currentSiteLoaded, "expected site to be loaded? %v", test.currentSiteLoaded)
+		})
+	}
+}
+
+type siteHandlerMock struct {
+	getHook func() (domain.Site, error)
+}
+
+func (sh *siteHandlerMock) Create(s domain.Site) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (sh *siteHandlerMock) Get() (domain.Site, error) {
+	if sh.getHook == nil {
+		return nil, fmt.Errorf("not implemented")
+	}
+	return sh.getHook()
+}
+
+func (sh *siteHandlerMock) Delete() error {
+	return fmt.Errorf("not implemented")
+}
+
+func (sh *siteHandlerMock) Update() error {
+	return fmt.Errorf("not implemented")
+}
+
+func (sh *siteHandlerMock) RevokeAccess() error {
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/domain/podman/site.go
+++ b/pkg/domain/podman/site.go
@@ -74,6 +74,12 @@ func NewSitePodmanHandlerFromCli(cli *podman.PodmanRestClient) *SiteHandler {
 	}
 }
 
+type SiteHandlerFactory func(endpoint string) (domain.SiteHandler, error)
+
+func NewSiteHandler(endpoint string) (domain.SiteHandler, error) {
+	return NewSitePodmanHandler(endpoint)
+}
+
 func NewSitePodmanHandler(endpoint string) (*SiteHandler, error) {
 	if endpoint == "" {
 		podmanCfg, err := NewPodmanConfigFileHandler().GetConfig()


### PR DESCRIPTION
* A recommendation message has to be displayed when podman endpoint is not available
* Previously the recommendation message was just displayed during init
* Unit tests added to cover NewClient (for podman)