### PR TITLE
Conditionally add routes custom-host resource

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -158,7 +158,7 @@ var ControllerPolicyRule = []rbacv1.PolicyRule{
 	{
 		Verbs:     []string{"get", "list", "watch"},
 		APIGroups: []string{"route.openshift.io"},
-		Resources: []string{"routes", "routes/custom-host"},
+		Resources: []string{"routes"},
 	},
 	{
 		Verbs:     []string{"get", "list", "watch"},
@@ -169,6 +169,14 @@ var ControllerPolicyRule = []rbacv1.PolicyRule{
 		Verbs:     []string{"get", "list", "watch"},
 		APIGroups: []string{"networking.k8s.io"},
 		Resources: []string{"ingresses"},
+	},
+}
+
+var ControllerRouteIngressPolicyRule = []rbacv1.PolicyRule{
+	{
+		Verbs:     []string{"get", "list", "watch"},
+		APIGroups: []string{"route.openshift.io"},
+		Resources: []string{"routes/custom-host"},
 	},
 }
 

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -172,7 +172,7 @@ var ControllerPolicyRule = []rbacv1.PolicyRule{
 	},
 }
 
-var ControllerRouteIngressPolicyRule = []rbacv1.PolicyRule{
+var ControllerRoutesCustomHostPolicyRule = []rbacv1.PolicyRule{
 	{
 		Verbs:     []string{"get", "list", "watch"},
 		APIGroups: []string{"route.openshift.io"},

--- a/client/router_create.go
+++ b/client/router_create.go
@@ -84,7 +84,7 @@ func (cli *VanClient) adjustRules(options types.SiteConfigSpec, original []rbacv
 	if cli.RouteClient == nil {
 		apigroups = append(apigroups, "route.openshift.io")
 	} else if options.IsIngressRoute() && options.IngressHost != "" {
-		original = append(original, types.ControllerRouteIngressPolicyRule...)
+		original = append(original, types.ControllerRoutesCustomHostPolicyRule...)
 	}
 	if cli.OCAppsClient == nil {
 		apigroups = append(apigroups, "apps.openshift.io")


### PR DESCRIPTION
* This change ensures that the routes/custom-host resource is only included when the ingress-host is specified
* On OpenShift Local, using the developer account a new site cannot be created after 1.5.1 (still works until 1.5.0), so this gives an alternative to only include that extra rule when needed