### PR TITLE
Skupper version manifest subcommand

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,12 @@ executors:
 
   local_cluster_test_executor:
     machine:
-      image: ubuntu-2204:2022.10.2
+      image: ubuntu-2204:2023.10.1
     resource_class: large
 
   local_cluster_policy_test_executor:
     machine:
-      image: ubuntu-2204:2022.10.2
+      image: ubuntu-2204:2023.10.1
     # Policy tests run all in sequence.  So, there is no benefit in adding more
     # CPU or memory.  Within the tests, there is paralellism, but on goroutines,
     # so they'd not use the additional CPUs.  The only thing a running policy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,12 @@ executors:
 
   local_cluster_test_executor:
     machine:
-      image: ubuntu-2204:2023.10.1
+      image: ubuntu-2204:2022.10.2
     resource_class: large
 
   local_cluster_policy_test_executor:
     machine:
-      image: ubuntu-2204:2023.10.1
+      image: ubuntu-2204:2022.10.2
     # Policy tests run all in sequence.  So, there is no benefit in adding more
     # CPU or memory.  Within the tests, there is paralellism, but on goroutines,
     # so they'd not use the additional CPUs.  The only thing a running policy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,6 +322,10 @@ commands:
             sudo apt-get update -qq
             sudo apt-get -qq -y install podman
             podman version
+            
+            # temporary fix for https://github.com/containers/podman/issues/21024
+            wget https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/amd64/conmon_2.1.2~0_amd64.deb -O /tmp/conmon_2.1.2.deb
+            sudo apt install /tmp/conmon_2.1.2.deb
 
             # Bypassing CircleCI issue with user session (see: https://github.com/containers/podman/issues/16529)
             mkdir -p ~/.config/containers/containers.conf.d

--- a/cmd/manifest/manifest.go
+++ b/cmd/manifest/manifest.go
@@ -1,88 +1,12 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/skupperproject/skupper/pkg/utils/configs"
 	"os"
 
-	"github.com/skupperproject/skupper/pkg/images"
 	"github.com/spf13/cobra"
 )
-
-type SkupperImage struct {
-	Name       string `yaml:"name"`
-	SHA        string `yaml:"sha"`
-	Repository string `yaml:"repository,omitempty"`
-}
-
-func generateManifestFile() error {
-	// Define a struct for the manifest file.
-	manifest := struct {
-		Images []SkupperImage `json:"images"`
-	}{
-		Images: []SkupperImage{
-			{
-				Name:       images.GetRouterImageName(),
-				SHA:        images.GetSha(images.GetRouterImageName()),
-				Repository: "https://github.com/skupperproject/skupper-router",
-			},
-			{
-				Name:       images.GetServiceControllerImageName(),
-				SHA:        images.GetSha(images.GetServiceControllerImageName()),
-				Repository: "https://github.com/skupperproject/skupper",
-			},
-			{
-				Name:       images.GetControllerPodmanImageName(),
-				SHA:        images.GetSha(images.GetControllerPodmanImageName()),
-				Repository: "https://github.com/skupperproject/skupper",
-			},
-			{
-				Name:       images.GetConfigSyncImageName(),
-				SHA:        images.GetSha(images.GetConfigSyncImageName()),
-				Repository: "https://github.com/skupperproject/skupper",
-			},
-			{
-				Name:       images.GetFlowCollectorImageName(),
-				SHA:        images.GetSha(images.GetFlowCollectorImageName()),
-				Repository: "https://github.com/skupperproject/skupper",
-			},
-			{
-				Name:       images.GetSiteControllerImageName(),
-				SHA:        images.GetSha(images.GetSiteControllerImageName()),
-				Repository: "https://github.com/skupperproject/skupper",
-			},
-			{
-				Name: images.GetPrometheusServerImageName(),
-				SHA:  images.GetSha(images.GetPrometheusServerImageName()),
-			},
-			{
-				Name: images.GetOauthProxyImageName(),
-				SHA:  images.GetSha(images.GetOauthProxyImageName()),
-			},
-		},
-	}
-
-	// Encode the manifest image list as JSON.
-	manifestListJSON, err := json.MarshalIndent(manifest, "", "   ")
-	if err != nil {
-		return fmt.Errorf("Error encoding manifest image list: %v\n", err)
-
-	}
-
-	// Create a new file.
-	file, err := os.Create("manifest.json")
-	if err != nil {
-		return fmt.Errorf("Error creating file: %v\n", err)
-	}
-
-	// Write the JSON data to the file.
-	_, err = file.Write(manifestListJSON)
-	if err != nil {
-		return fmt.Errorf("Error writing to file: %v\n", err)
-	}
-
-	return nil
-}
 
 func main() {
 
@@ -93,7 +17,9 @@ func main() {
 		Short: "generates a manifest.json file",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return generateManifestFile()
+			manifestManager := configs.ManifestManager{EnableSHA: true}
+			return manifestManager.CreateFile(manifestManager.GetConfiguredManifest())
+
 		},
 	}
 

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/skupperproject/skupper/pkg/utils/configs"
 	"os"
 	"reflect"
 	"strconv"
@@ -866,6 +867,21 @@ func NewCmdVersion(skupperClient SkupperSiteClient) *cobra.Command {
 	return cmd
 }
 
+func NewCmdVersionManifest() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "manifest",
+		Short: "Report the version of the Skupper images by default and the value of the environment variables",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+
+			manifestManager := configs.ManifestManager{}
+			return manifestManager.CreateFile(manifestManager.GetDefaultManifestWithEnv())
+		},
+	}
+	return cmd
+}
+
 func NewCmdDebug() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "debug dump <file>, debug events or debug service <service-name>",
@@ -1040,7 +1056,10 @@ func init() {
 	cmdStatusService := NewCmdServiceStatus(skupperCli.Service())
 	cmdLabelsService := NewCmdServiceLabel(skupperCli.Service())
 
+	cmdVersionManifest := NewCmdVersionManifest()
 	cmdVersion := NewCmdVersion(skupperCli.Site())
+	cmdVersion.AddCommand(cmdVersionManifest)
+
 	cmdDebugDump := NewCmdDebugDump(skupperCli.Debug())
 	cmdDebugEvents := NewCmdDebugEvents(skupperCli.Debug())
 	cmdDebugService := NewCmdDebugService(skupperCli.Debug())

--- a/pkg/utils/configs/manifest.go
+++ b/pkg/utils/configs/manifest.go
@@ -1,0 +1,208 @@
+package configs
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/skupperproject/skupper/pkg/images"
+	"os"
+	"strings"
+)
+
+type SkupperImage struct {
+	Name       string `yaml:"name"`
+	SHA        string `yaml:"sha,omitempty"`
+	Repository string `yaml:"repository,omitempty"`
+}
+
+type Manifest struct {
+	Images    []SkupperImage     `json:"images"`
+	Variables *map[string]string `json:"variables,omitempty"`
+}
+
+type ManifestManager struct {
+	EnableSHA bool
+}
+
+type ManifestGenerator interface {
+	GetConfiguredManifest() Manifest
+	GetDefaultManifestWithEnv() Manifest
+	CreateFile(m Manifest) error
+}
+
+func (manager *ManifestManager) GetConfiguredManifest() Manifest {
+	return Manifest{
+		Images: getSkupperConfiguredImages(manager.EnableSHA),
+	}
+}
+
+func (manager *ManifestManager) GetDefaultManifestWithEnv() Manifest {
+	return Manifest{
+		Images:    getSkupperDefaultImages(),
+		Variables: getEnvironmentVariableMap(),
+	}
+}
+
+func (manager *ManifestManager) CreateFile(m Manifest) error {
+	// Encode the manifest image list as JSON.
+	manifestListJSON, err := json.MarshalIndent(m, "", "   ")
+	if err != nil {
+		return fmt.Errorf("Error encoding manifest image list: %v\n", err)
+
+	}
+
+	// Create a new file.
+	file, err := os.Create("manifest.json")
+	if err != nil {
+		return fmt.Errorf("Error creating file: %v\n", err)
+	}
+
+	// Write the JSON data to the file.
+	_, err = file.Write(manifestListJSON)
+	if err != nil {
+		return fmt.Errorf("Error writing to file: %v\n", err)
+	}
+
+	return nil
+}
+
+func getSkupperConfiguredImages(enableSHA bool) []SkupperImage {
+	return []SkupperImage{
+		{
+			Name:       images.GetRouterImageName(),
+			SHA:        getSHAIfEnabled(enableSHA, images.GetRouterImageName()),
+			Repository: "https://github.com/skupperproject/skupper-router",
+		},
+		{
+			Name:       images.GetServiceControllerImageName(),
+			SHA:        getSHAIfEnabled(enableSHA, images.GetServiceControllerImageName()),
+			Repository: "https://github.com/skupperproject/skupper",
+		},
+		{
+			Name:       images.GetControllerPodmanImageName(),
+			SHA:        getSHAIfEnabled(enableSHA, images.GetControllerPodmanImageName()),
+			Repository: "https://github.com/skupperproject/skupper",
+		},
+		{
+			Name:       images.GetConfigSyncImageName(),
+			SHA:        getSHAIfEnabled(enableSHA, images.GetConfigSyncImageName()),
+			Repository: "https://github.com/skupperproject/skupper",
+		},
+		{
+			Name:       images.GetFlowCollectorImageName(),
+			SHA:        getSHAIfEnabled(enableSHA, images.GetFlowCollectorImageName()),
+			Repository: "https://github.com/skupperproject/skupper",
+		},
+		{
+			Name:       images.GetSiteControllerImageName(),
+			SHA:        getSHAIfEnabled(enableSHA, images.GetSiteControllerImageName()),
+			Repository: "https://github.com/skupperproject/skupper",
+		},
+		{
+			Name: images.GetPrometheusServerImageName(),
+			SHA:  getSHAIfEnabled(enableSHA, images.GetPrometheusServerImageName()),
+		},
+		{
+			Name: images.GetOauthProxyImageName(),
+			SHA:  getSHAIfEnabled(enableSHA, images.GetOauthProxyImageName()),
+		},
+	}
+}
+
+func getSkupperDefaultImages() []SkupperImage {
+	return []SkupperImage{
+		{
+			Name:       strings.Join([]string{images.DefaultImageRegistry, images.RouterImageName}, "/"),
+			Repository: "https://github.com/skupperproject/skupper-router",
+		},
+		{
+			Name:       strings.Join([]string{images.DefaultImageRegistry, images.ServiceControllerImageName}, "/"),
+			Repository: "https://github.com/skupperproject/skupper",
+		},
+		{
+			Name:       strings.Join([]string{images.DefaultImageRegistry, images.ControllerPodmanImageName}, "/"),
+			Repository: "https://github.com/skupperproject/skupper",
+		},
+		{
+			Name:       strings.Join([]string{images.DefaultImageRegistry, images.ConfigSyncImageName}, "/"),
+			Repository: "https://github.com/skupperproject/skupper",
+		},
+		{
+			Name:       strings.Join([]string{images.DefaultImageRegistry, images.FlowCollectorImageName}, "/"),
+			Repository: "https://github.com/skupperproject/skupper",
+		},
+		{
+			Name:       strings.Join([]string{images.DefaultImageRegistry, images.SiteControllerImageName}, "/"),
+			Repository: "https://github.com/skupperproject/skupper",
+		},
+		{
+			Name: strings.Join([]string{images.PrometheusImageRegistry, images.PrometheusServerImageName}, "/"),
+		},
+		{
+			Name: strings.Join([]string{images.OauthProxyImageRegistry, images.OauthProxyImageName}, "/"),
+		},
+	}
+}
+
+func getEnvironmentVariableMap() *map[string]string {
+
+	envVariables := make(map[string]string)
+
+	skupperImageRegistry := os.Getenv(images.SkupperImageRegistryEnvKey)
+	if skupperImageRegistry != "" {
+		envVariables[images.SkupperImageRegistryEnvKey] = skupperImageRegistry
+	}
+
+	prometheusImageRegistry := os.Getenv(images.PrometheusImageRegistryEnvKey)
+	if prometheusImageRegistry != "" {
+		envVariables[images.PrometheusImageRegistry] = prometheusImageRegistry
+	}
+
+	oauthImageRegistry := os.Getenv(images.OauthProxyImageRegistry)
+	if oauthImageRegistry != "" {
+		envVariables[images.OauthProxyImageRegistry] = oauthImageRegistry
+	}
+
+	routerImage := os.Getenv(images.RouterImageEnvKey)
+	if routerImage != "" {
+		envVariables[images.RouterImageEnvKey] = routerImage
+	}
+
+	serviceControllerImage := os.Getenv(images.ServiceControllerImageEnvKey)
+	if serviceControllerImage != "" {
+		envVariables[images.ServiceControllerImageEnvKey] = serviceControllerImage
+	}
+
+	controllerPodmanImage := os.Getenv(images.ControllerPodmanImageEnvKey)
+	if controllerPodmanImage != "" {
+		envVariables[images.ControllerPodmanImageEnvKey] = controllerPodmanImage
+	}
+
+	configSyncImage := os.Getenv(images.ConfigSyncImageEnvKey)
+	if configSyncImage != "" {
+		envVariables[images.ConfigSyncImageEnvKey] = configSyncImage
+	}
+
+	flowCollectorImage := os.Getenv(images.FlowCollectorImageEnvKey)
+	if flowCollectorImage != "" {
+		envVariables[images.FlowCollectorImageEnvKey] = flowCollectorImage
+	}
+
+	prometheusImage := os.Getenv(images.PrometheusServerImageEnvKey)
+	if prometheusImage != "" {
+		envVariables[images.PrometheusServerImageEnvKey] = prometheusImage
+	}
+
+	oauthImage := os.Getenv(images.OauthProxyImageEnvKey)
+	if oauthImage != "" {
+		envVariables[images.OauthProxyImageEnvKey] = oauthImage
+	}
+
+	return &envVariables
+}
+
+func getSHAIfEnabled(enableSHA bool, imageName string) string {
+	if !enableSHA {
+		return ""
+	}
+	return images.GetSha(imageName)
+}

--- a/pkg/utils/configs/manifest.go
+++ b/pkg/utils/configs/manifest.go
@@ -9,9 +9,9 @@ import (
 )
 
 type SkupperImage struct {
-	Name       string `yaml:"name"`
-	SHA        string `yaml:"sha,omitempty"`
-	Repository string `yaml:"repository,omitempty"`
+	Name       string `json:"name"`
+	SHA        string `json:"sha,omitempty"`
+	Repository string `json:"repository,omitempty"`
 }
 
 type Manifest struct {

--- a/pkg/utils/configs/manifest_test.go
+++ b/pkg/utils/configs/manifest_test.go
@@ -1,0 +1,137 @@
+package configs
+
+import (
+	"fmt"
+	"github.com/skupperproject/skupper/pkg/images"
+	"gotest.tools/assert"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestManifestManager(t *testing.T) {
+	testcases := []struct {
+		title                          string
+		envVariablesWithValue          []string
+		expectedConfiguredManifest     Manifest
+		expectedDefaultManifestWithEnv Manifest
+	}{
+		{
+			title: "configured manifest has different images that the default manifest",
+			envVariablesWithValue: []string{
+				images.SkupperImageRegistryEnvKey,
+				images.ConfigSyncImageEnvKey,
+				images.RouterImageEnvKey},
+			expectedConfiguredManifest: Manifest{
+				Images: []SkupperImage{
+					{
+						Name: "SKUPPER_CONFIG_SYNC_IMAGE_TESTING",
+					},
+					{
+						Name: "QDROUTERD_IMAGE_TESTING"},
+				},
+			},
+			expectedDefaultManifestWithEnv: Manifest{
+				Images: []SkupperImage{
+					{
+						Name: strings.Join([]string{images.DefaultImageRegistry, images.ConfigSyncImageName}, "/"),
+					},
+					{
+						Name: strings.Join([]string{images.DefaultImageRegistry, images.RouterImageName}, "/"),
+					},
+				},
+				Variables: &map[string]string{
+					images.SkupperImageRegistryEnvKey: "SKUPPER_IMAGE_REGISTRY_TESTING",
+					images.ConfigSyncImageEnvKey:      "SKUPPER_CONFIG_SYNC_IMAGE_TESTING",
+					images.RouterImageEnvKey:          "QDROUTERD_IMAGE_TESTING",
+				},
+			},
+		},
+		{
+			title:                 "configured manifest the same images that the default manifest",
+			envVariablesWithValue: []string{},
+			expectedConfiguredManifest: Manifest{
+				Images: []SkupperImage{
+					{
+						Name: strings.Join([]string{images.DefaultImageRegistry, images.ConfigSyncImageName}, "/"),
+					},
+					{
+						Name: strings.Join([]string{images.DefaultImageRegistry, images.RouterImageName}, "/"),
+					},
+				},
+			},
+			expectedDefaultManifestWithEnv: Manifest{
+				Images: []SkupperImage{
+					{
+						Name: strings.Join([]string{images.DefaultImageRegistry, images.ConfigSyncImageName}, "/"),
+					},
+					{
+						Name: strings.Join([]string{images.DefaultImageRegistry, images.RouterImageName}, "/"),
+					},
+				},
+				Variables: &map[string]string{},
+			},
+		},
+	}
+
+	for _, c := range testcases {
+
+		setUpEnvVariables(c.envVariablesWithValue)
+
+		manifestManager := ManifestManager{EnableSHA: false}
+		configuredManifest := manifestManager.GetConfiguredManifest()
+		defaultManifest := manifestManager.GetDefaultManifestWithEnv()
+
+		for _, expectedImage := range c.expectedConfiguredManifest.Images {
+
+			configuredImage := getSkupperImageFromManifest(&configuredManifest, expectedImage.Name)
+
+			assert.Check(t, configuredImage != nil)
+		}
+
+		assert.Check(t, configuredManifest.Variables == nil)
+
+		for _, expectedImage := range c.expectedDefaultManifestWithEnv.Images {
+
+			defaultImage := getSkupperImageFromManifest(&defaultManifest, expectedImage.Name)
+
+			assert.Check(t, defaultImage != nil)
+		}
+
+		assert.DeepEqual(t, c.expectedDefaultManifestWithEnv.Variables, defaultManifest.Variables)
+
+		clearEnvVariables(c.envVariablesWithValue)
+	}
+}
+
+func setUpEnvVariables(variables []string) {
+	for _, variable := range variables {
+		err := os.Setenv(variable, strings.Join([]string{variable, "TESTING"}, "_"))
+		if err != nil {
+			fmt.Printf("error while setting %s", variable)
+			return
+		}
+	}
+}
+
+func clearEnvVariables(variables []string) {
+	for _, variable := range variables {
+		err := os.Unsetenv(variable)
+		if err != nil {
+			fmt.Printf("error while unssetting %s", variable)
+			return
+		}
+	}
+}
+
+func getSkupperImageFromManifest(m *Manifest, name string) *SkupperImage {
+
+	for _, skImage := range m.Images {
+
+		if skImage.Name == name {
+			return &skImage
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fixes #1303 

**Changes:**

- New skupper subcommand included in the version command:  `skupper version manifest`
- It generates a `manifest.json` file with all the images that skupper uses by default and the value of the environment variables for the images if there is any of them. Example:
```
{
   "images": [
      {
         "Name": "quay.io/skupper/skupper-router:main",
         "SHA": "",
         "Repository": "https://github.com/skupperproject/skupper-router"
      },
      {
         "Name": "quay.io/skupper/service-controller:main",
         "SHA": "",
         "Repository": "https://github.com/skupperproject/skupper"
      },
      {
         "Name": "quay.io/skupper/controller-podman:main",
         "SHA": "",
         "Repository": "https://github.com/skupperproject/skupper"
      },
      {
         "Name": "quay.io/skupper/config-sync:main",
         "SHA": "",
         "Repository": "https://github.com/skupperproject/skupper"
      },
      {
         "Name": "quay.io/skupper/flow-collector:main",
         "SHA": "",
         "Repository": "https://github.com/skupperproject/skupper"
      },
      {
         "Name": "quay.io/skupper/site-controller:main",
         "SHA": "",
         "Repository": "https://github.com/skupperproject/skupper"
      },
      {
         "Name": "quay.io/prometheus/prometheus:v2.42.0",
         "SHA": "",
         "Repository": ""
      },
      {
         "Name": "quay.io/openshift/origin-oauth-proxy:4.14.0",
         "SHA": "",
         "Repository": ""
      }
   ],
   "variables": {
      "QDROUTERD_IMAGE": "quay.io/skupper/skupper-router:latest"
   }
}
```
- There are no changes for the manifest command (external to skupper) that is being used in the release build.