### PR TITLE
Improves errors when pulling images on podman sites

### DIFF
--- a/client/podman/container.go
+++ b/client/podman/container.go
@@ -351,7 +351,7 @@ func (p *PodmanRestClient) ContainerExec(id string, command []string) (string, e
 	startParams := exec.NewExecStartLibpodParams()
 	startParams.ID = resp.ID
 
-	reader := &responseReaderByteStreamBody{}
+	reader := &multiplexedBodyReader{}
 	startOp := &runtime.ClientOperation{
 		ID:                 "ExecStartLibpod",
 		Method:             "POST",

--- a/client/podman/container.go
+++ b/client/podman/container.go
@@ -321,7 +321,7 @@ func (p *PodmanRestClient) ContainerExec(id string, command []string) (string, e
 	params := exec.NewContainerExecLibpodParams()
 	params.Name = id
 	params.Control = exec.ContainerExecLibpodBody{
-		AttachStderr: false,
+		AttachStderr: true,
 		AttachStdout: true,
 		Cmd:          command,
 	}
@@ -373,6 +373,7 @@ func (p *PodmanRestClient) ContainerExec(id string, command []string) (string, e
 	if err != nil {
 		return "", fmt.Errorf("error starting execution: %v", err)
 	}
+	// stdout and stderr are also available under reader.Stdout() and reader.Stderr()
 	out, ok := result.(string)
 	if !ok {
 		return "", fmt.Errorf("error parsing response")

--- a/client/podman/image.go
+++ b/client/podman/image.go
@@ -12,6 +12,17 @@ import (
 	"github.com/skupperproject/skupper/client/generated/libpod/client/images"
 )
 
+const (
+	imagePullRecommendation = `
+If the image is being pulled from an authenticated registry,
+make sure to log in first, using:
+
+    podman login <registry-url>
+
+In case you are using a custom authentication file, you should
+set the REGISTRY_AUTH_FILE environment variable.`
+)
+
 func (p *PodmanRestClient) ImageList() ([]*container.Image, error) {
 	cli := images.New(p.RestClient, formats)
 	param := images.NewImageListLibpodParams()
@@ -87,7 +98,10 @@ func (p *PodmanRestClient) ImagePull(id string) error {
 	}
 	res, err := p.RestClient.Submit(op)
 	if err != nil {
-		return fmt.Errorf("error pulling image %s: %v", id, err)
+		return &Error{
+			Err:            fmt.Errorf("error pulling image %s: %v", id, err),
+			Recommendation: imagePullRecommendation,
+		}
 	}
 	// eventually err is nil but auth problems are reported as json after a string msg
 	if resStr, ok := res.(string); ok {
@@ -100,7 +114,10 @@ func (p *PodmanRestClient) ImagePull(id string) error {
 		var jsonRes map[string]interface{}
 		if err = json.Unmarshal([]byte(resStrClean), &jsonRes); err == nil {
 			if errMsg, ok := jsonRes["error"]; ok && errMsg != "" {
-				return fmt.Errorf("unable to pull image %s: %v", id, errMsg)
+				return &Error{
+					Err:            fmt.Errorf("unable to pull image %s: %v", id, errMsg),
+					Recommendation: imagePullRecommendation,
+				}
 			}
 		}
 	}
@@ -160,4 +177,13 @@ func getXRegistryAuth(image string) *string {
 		}
 	}
 	return nil
+}
+
+type Error struct {
+	Recommendation string
+	Err            error
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s\n\nRecommendation: %s\n", e.Err, e.Recommendation)
 }

--- a/client/podman/image.go
+++ b/client/podman/image.go
@@ -84,6 +84,7 @@ func (p *PodmanRestClient) ImagePull(id string) error {
 	params.XRegistryAuth = getXRegistryAuth(id)
 
 	// Need to do that as the default response reader is being closed too soon
+	reader := &responseReaderJSONErrorBody{}
 	op := &runtime.ClientOperation{
 		ID:                 "ImagePullLibpod",
 		Method:             "POST",
@@ -92,7 +93,7 @@ func (p *PodmanRestClient) ImagePull(id string) error {
 		ConsumesMediaTypes: []string{"application/json", "application/x-tar"},
 		Schemes:            []string{"http", "https"},
 		Params:             params,
-		Reader:             &responseReaderBody{},
+		Reader:             reader,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
 	}

--- a/client/podman/rest.go
+++ b/client/podman/rest.go
@@ -195,29 +195,29 @@ func (r *responseReaderID) ReadResponse(response runtime.ClientResponse, consume
 	}
 }
 
-type responseReaderByteStreamBody struct {
+type multiplexedBodyReader struct {
 	output map[byte][]byte
 }
 
-func (r *responseReaderByteStreamBody) Stdout() string {
+func (r *multiplexedBodyReader) Stdout() string {
 	if r.output == nil {
 		return ""
 	}
 	return string(r.output[1])
 }
 
-func (r *responseReaderByteStreamBody) Stderr() string {
+func (r *multiplexedBodyReader) Stderr() string {
 	if r.output == nil {
 		return ""
 	}
 	return string(r.output[2])
 }
 
-func (r *responseReaderByteStreamBody) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+func (r *multiplexedBodyReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	return ReadResponse(response, r)
 }
 
-func (r *responseReaderByteStreamBody) readStreams(offset *uint64, data []byte) {
+func (r *multiplexedBodyReader) readStreams(offset *uint64, data []byte) {
 	if *offset == 0 {
 		r.output = map[byte][]byte{0: []byte{}, 1: []byte{}, 2: []byte{}}
 	}
@@ -238,7 +238,7 @@ func (r *responseReaderByteStreamBody) readStreams(offset *uint64, data []byte) 
 	r.readStreams(offset, data)
 }
 
-func (r *responseReaderByteStreamBody) Consume(reader io.Reader, i interface{}) error {
+func (r *multiplexedBodyReader) Consume(reader io.Reader, i interface{}) error {
 	consumeErr := runtime.TextConsumer().Consume(reader, i)
 	bodyStr, ok := i.(*string)
 	if !ok {

--- a/client/podman/rest.go
+++ b/client/podman/rest.go
@@ -206,14 +206,17 @@ func (r *responseReaderBody) Consume(reader io.Reader, i interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error reading response body: %v", err)
 	}
-
 	var dataClean []byte
-	for idx, v := range data {
-		// skip 8 first bytes every 8k chunk
-		if idx%(8192+8) < 8 {
-			continue
+	if data[0] != '{' {
+		for idx, v := range data {
+			// skip 8 first bytes every 8k chunk
+			if idx%(8192+8) < 8 {
+				continue
+			}
+			dataClean = append(dataClean, v)
 		}
-		dataClean = append(dataClean, v)
+	} else {
+		dataClean = data
 	}
 
 	for idx, v := range dataClean {


### PR DESCRIPTION
* Fixes libpod responses parsing (impacting proper error messages from being displayed)
* Adds a recommendation when skupper is unable to pull images (as well as display the error accordingly)
* Libpod responses for container exec and container logs are being parsed properly as well