### PR TITLE
Check if site version is compatible with CLI version

### DIFF
--- a/cmd/skupper/skupper_kube_network.go
+++ b/cmd/skupper/skupper_kube_network.go
@@ -40,7 +40,7 @@ func (s *SkupperKubeNetwork) Status(cmd *cobra.Command, args []string) error {
 
 	configSyncVersion := utils.GetVersionTag(s.kube.Cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
 	if configSyncVersion != "" && !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
-		fmt.Printf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
+		fmt.Printf(network.MINIMUM_VERSION_MESSAGE, configSyncVersion, network.MINIMUM_VERSION)
 		fmt.Println()
 		return nil
 	}

--- a/cmd/skupper/skupper_kube_network.go
+++ b/cmd/skupper/skupper_kube_network.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/pkg/network"
+	"github.com/skupperproject/skupper/pkg/utils"
 	"github.com/skupperproject/skupper/pkg/utils/formatter"
 	"github.com/spf13/cobra"
 	"strconv"
@@ -36,6 +37,14 @@ func (s *SkupperKubeNetwork) Status(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 		return nil
 	}
+
+	configSyncVersion := utils.GetVersionFromImageTag(s.kube.Cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
+	if !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
+		fmt.Printf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
+		fmt.Println()
+		return nil
+	}
+
 	currentSite := siteConfig.Reference.UID
 
 	currentNetworkStatus, errStatus := s.kube.Cli.NetworkStatus(ctx)

--- a/cmd/skupper/skupper_kube_network.go
+++ b/cmd/skupper/skupper_kube_network.go
@@ -39,7 +39,7 @@ func (s *SkupperKubeNetwork) Status(cmd *cobra.Command, args []string) error {
 	}
 
 	configSyncVersion := utils.GetVersionFromImageTag(s.kube.Cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
-	if !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
+	if configSyncVersion != "" && !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
 		fmt.Printf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
 		fmt.Println()
 		return nil

--- a/cmd/skupper/skupper_kube_network.go
+++ b/cmd/skupper/skupper_kube_network.go
@@ -38,7 +38,7 @@ func (s *SkupperKubeNetwork) Status(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	configSyncVersion := utils.GetVersionFromImageTag(s.kube.Cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
+	configSyncVersion := utils.GetVersionTag(s.kube.Cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
 	if configSyncVersion != "" && !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
 		fmt.Printf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
 		fmt.Println()

--- a/cmd/skupper/skupper_kube_service.go
+++ b/cmd/skupper/skupper_kube_service.go
@@ -55,7 +55,7 @@ func (s *SkupperKubeService) Status(cmd *cobra.Command, args []string) error {
 	cli := s.kube.Cli
 
 	configSyncVersion := utils.GetVersionFromImageTag(cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
-	if !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
+	if configSyncVersion != "" && !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
 		fmt.Printf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
 		fmt.Println()
 		return nil

--- a/cmd/skupper/skupper_kube_service.go
+++ b/cmd/skupper/skupper_kube_service.go
@@ -54,7 +54,7 @@ func (s *SkupperKubeService) ListFlags(cmd *cobra.Command) {}
 func (s *SkupperKubeService) Status(cmd *cobra.Command, args []string) error {
 	cli := s.kube.Cli
 
-	configSyncVersion := utils.GetVersionFromImageTag(cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
+	configSyncVersion := utils.GetVersionTag(cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
 	if configSyncVersion != "" && !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
 		fmt.Printf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
 		fmt.Println()

--- a/cmd/skupper/skupper_kube_service.go
+++ b/cmd/skupper/skupper_kube_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/skupperproject/skupper/pkg/network"
+	"github.com/skupperproject/skupper/pkg/utils"
 	"strconv"
 	"strings"
 
@@ -52,10 +53,19 @@ func (s *SkupperKubeService) ListFlags(cmd *cobra.Command) {}
 
 func (s *SkupperKubeService) Status(cmd *cobra.Command, args []string) error {
 	cli := s.kube.Cli
+
+	configSyncVersion := utils.GetVersionFromImageTag(cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
+	if !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
+		fmt.Printf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
+		fmt.Println()
+		return nil
+	}
+
 	currentNetworkStatus, err := cli.NetworkStatus(context.Background())
 	if err != nil {
 		return fmt.Errorf("Could not retrieve services: %w", err)
 	}
+
 	vsis, err := s.kube.Cli.ServiceInterfaceList(context.Background())
 	statusManager := network.SkupperStatus{
 		NetworkStatus: currentNetworkStatus,

--- a/cmd/skupper/skupper_kube_service.go
+++ b/cmd/skupper/skupper_kube_service.go
@@ -56,7 +56,7 @@ func (s *SkupperKubeService) Status(cmd *cobra.Command, args []string) error {
 
 	configSyncVersion := utils.GetVersionTag(cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
 	if configSyncVersion != "" && !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
-		fmt.Printf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
+		fmt.Printf(network.MINIMUM_VERSION_MESSAGE, configSyncVersion, network.MINIMUM_VERSION)
 		fmt.Println()
 		return nil
 	}

--- a/cmd/skupper/skupper_kube_site.go
+++ b/cmd/skupper/skupper_kube_site.go
@@ -237,7 +237,7 @@ func (s *SkupperKubeSite) Status(cmd *cobra.Command, args []string) error {
 
 	configSyncVersion := utils.GetVersionTag(cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
 	if configSyncVersion != "" && !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
-		fmt.Printf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
+		fmt.Printf(network.MINIMUM_VERSION_MESSAGE, configSyncVersion, network.MINIMUM_VERSION)
 		fmt.Println()
 		return nil
 	}

--- a/cmd/skupper/skupper_kube_site.go
+++ b/cmd/skupper/skupper_kube_site.go
@@ -235,7 +235,7 @@ func (s *SkupperKubeSite) Status(cmd *cobra.Command, args []string) error {
 	silenceCobra(cmd)
 	cli := s.kube.Cli
 
-	configSyncVersion := utils.GetVersionFromImageTag(cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
+	configSyncVersion := utils.GetVersionTag(cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
 	if configSyncVersion != "" && !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
 		fmt.Printf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
 		fmt.Println()

--- a/cmd/skupper/skupper_kube_site.go
+++ b/cmd/skupper/skupper_kube_site.go
@@ -235,6 +235,13 @@ func (s *SkupperKubeSite) Status(cmd *cobra.Command, args []string) error {
 	silenceCobra(cmd)
 	cli := s.kube.Cli
 
+	configSyncVersion := utils.GetVersionFromImageTag(cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
+	if !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
+		fmt.Printf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
+		fmt.Println()
+		return nil
+	}
+
 	currentStatus, errStatus := cli.NetworkStatus(context.Background())
 	if errStatus != nil && strings.HasPrefix(errStatus.Error(), "Skupper is not installed") {
 		fmt.Printf("Skupper is not enabled in namespace '%s'", cli.GetNamespace())
@@ -253,6 +260,7 @@ func (s *SkupperKubeSite) Status(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 		return nil
 	}
+
 	var currentSite = statusManager.GetSiteById(siteConfig.Reference.UID)
 
 	if currentSite != nil {

--- a/cmd/skupper/skupper_kube_site.go
+++ b/cmd/skupper/skupper_kube_site.go
@@ -236,7 +236,7 @@ func (s *SkupperKubeSite) Status(cmd *cobra.Command, args []string) error {
 	cli := s.kube.Cli
 
 	configSyncVersion := utils.GetVersionFromImageTag(cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
-	if !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
+	if configSyncVersion != "" && !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
 		fmt.Printf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
 		fmt.Println()
 		return nil

--- a/pkg/domain/kube/link_kube.go
+++ b/pkg/domain/kube/link_kube.go
@@ -111,7 +111,7 @@ func (l *LinkHandlerKube) RemoteLinks(ctx context.Context) ([]*network.RemoteLin
 
 	configSyncVersion := utils.GetVersionTag(k8s.GetComponentVersion(l.namespace, l.cli, types.TransportContainerName, types.ConfigSyncContainerName))
 	if configSyncVersion != "" && !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
-		return nil, fmt.Errorf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
+		return nil, fmt.Errorf(network.MINIMUM_VERSION_MESSAGE, configSyncVersion, network.MINIMUM_VERSION)
 	}
 
 	currentSiteId := l.site.Reference.UID

--- a/pkg/domain/kube/link_kube.go
+++ b/pkg/domain/kube/link_kube.go
@@ -109,7 +109,7 @@ func (l *LinkHandlerKube) RemoteLinks(ctx context.Context) ([]*network.RemoteLin
 		return nil, fmt.Errorf("skupper is not installed: %s", err)
 	}
 
-	configSyncVersion := utils.GetVersionFromImageTag(k8s.GetComponentVersion(l.namespace, l.cli, types.TransportContainerName, types.ConfigSyncContainerName))
+	configSyncVersion := utils.GetVersionTag(k8s.GetComponentVersion(l.namespace, l.cli, types.TransportContainerName, types.ConfigSyncContainerName))
 	if configSyncVersion != "" && !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
 		return nil, fmt.Errorf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
 	}

--- a/pkg/domain/kube/link_kube.go
+++ b/pkg/domain/kube/link_kube.go
@@ -8,6 +8,7 @@ import (
 	kubeqdr "github.com/skupperproject/skupper/pkg/kube/qdr"
 	"github.com/skupperproject/skupper/pkg/network"
 	"github.com/skupperproject/skupper/pkg/qdr"
+	"github.com/skupperproject/skupper/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -106,6 +107,11 @@ func (l *LinkHandlerKube) RemoteLinks(ctx context.Context) ([]*network.RemoteLin
 	_, err := k8s.GetDeployment(types.TransportDeploymentName, l.namespace, l.cli)
 	if err != nil {
 		return nil, fmt.Errorf("skupper is not installed: %s", err)
+	}
+
+	configSyncVersion := utils.GetVersionFromImageTag(k8s.GetComponentVersion(l.namespace, l.cli, types.TransportContainerName, types.ConfigSyncContainerName))
+	if !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
+		return nil, fmt.Errorf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
 	}
 
 	currentSiteId := l.site.Reference.UID

--- a/pkg/domain/kube/link_kube.go
+++ b/pkg/domain/kube/link_kube.go
@@ -110,7 +110,7 @@ func (l *LinkHandlerKube) RemoteLinks(ctx context.Context) ([]*network.RemoteLin
 	}
 
 	configSyncVersion := utils.GetVersionFromImageTag(k8s.GetComponentVersion(l.namespace, l.cli, types.TransportContainerName, types.ConfigSyncContainerName))
-	if !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
+	if configSyncVersion != "" && !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
 		return nil, fmt.Errorf("Site version is %s, but CLI requires %s", configSyncVersion, network.MINIMUM_VERSION)
 	}
 

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -7,6 +7,7 @@ import (
 )
 
 const MINIMUM_VERSION string = "1.5.0"
+const MINIMUM_VERSION_MESSAGE string = "Detected that the skupper version installed in the namespace is version %s. The CLI requires version %s. To update the installation, please follow the instructions found here: https://skupper.io/docs/index.html"
 
 type SkupperStatus struct {
 	NetworkStatus *NetworkStatusInfo

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+const MINIMUM_VERSION string = "1.5.0"
+
 type SkupperStatus struct {
 	NetworkStatus *NetworkStatusInfo
 }

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 type Version struct {
@@ -96,4 +97,20 @@ func IsValidFor(actual string, minimum string) bool {
 	va := ParseVersion(actual)
 	vb := ParseVersion(minimum)
 	return va.IsUndefined() || !va.LessRecentThan(vb)
+}
+
+func GetVersionFromImageTag(imageTag string) string {
+	versionTag := ""
+
+	imageTagSlices := strings.Split(imageTag, " ")
+
+	if len(imageTagSlices) > 0 {
+		tagSlices := strings.Split(imageTagSlices[0], ":")
+
+		if len(tagSlices) > 1 {
+			versionTag = tagSlices[1]
+		}
+	}
+
+	return versionTag
 }

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -99,16 +99,15 @@ func IsValidFor(actual string, minimum string) bool {
 	return va.IsUndefined() || !va.LessRecentThan(vb)
 }
 
-func GetVersionFromImageTag(imageTag string) string {
+func GetVersionTag(imageDescriptor string) string {
 	versionTag := ""
+	imageDescriptorSlices := strings.Split(imageDescriptor, " ")
 
-	imageTagSlices := strings.Split(imageTag, " ")
+	if len(imageDescriptorSlices) > 0 {
+		imageSlices := strings.Split(imageDescriptorSlices[0], ":")
 
-	if len(imageTagSlices) > 0 {
-		tagSlices := strings.Split(imageTagSlices[0], ":")
-
-		if len(tagSlices) > 1 {
-			versionTag = tagSlices[1]
+		if len(imageSlices) > 1 {
+			versionTag = imageSlices[1]
 		}
 	}
 

--- a/pkg/utils/version_test.go
+++ b/pkg/utils/version_test.go
@@ -171,3 +171,22 @@ func TestIsValidFor(t *testing.T) {
 		}
 	}
 }
+
+func TestGetVersionFromImageTag(t *testing.T) {
+	var tests = []struct {
+		imageTag string
+		expected string
+	}{
+		{"quay.io/skupper/config-sync:1.4.4 (sha256:3b7e81fc45bd)", "1.4.4"},
+		{"quay.io/skupper/config-sync:1.4.4", "1.4.4"},
+		{"quay.io/skupper/config-sync (sha256:3b7e81fc45bd)", ""},
+		{"", ""},
+		{"quay.io/skupper/config-sync:1.4.4-prerelease", "1.4.4-prerelease"},
+		{"1.5.1", ""},
+	}
+	for _, test := range tests {
+		if actual := GetVersionFromImageTag(test.imageTag); actual != test.expected {
+			t.Errorf("Expected GetVersionFromImageTag(%s) to be %s, got %s", test.imageTag, test.expected, actual)
+		}
+	}
+}

--- a/pkg/utils/version_test.go
+++ b/pkg/utils/version_test.go
@@ -185,8 +185,8 @@ func TestGetVersionFromImageTag(t *testing.T) {
 		{"1.5.1", ""},
 	}
 	for _, test := range tests {
-		if actual := GetVersionFromImageTag(test.imageTag); actual != test.expected {
-			t.Errorf("Expected GetVersionFromImageTag(%s) to be %s, got %s", test.imageTag, test.expected, actual)
+		if actual := GetVersionTag(test.imageTag); actual != test.expected {
+			t.Errorf("Expected GetVersionTag(%s) to be %s, got %s", test.imageTag, test.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1281 

### What has changed: 

The following status commands check if the config-sync component (that is the one that contains the flow-collector lite process running) has the minimum version required (1.5.0) to work:
* skupper status
* skupper network status
* skupper link status
* skupper service status

When the site version is prior to 1.5.0, the message will be: 

~~Site version is 1.4.4, but CLI requires 1.5.0~~

EDIT: 
> Detected that the skupper version installed in the namespace is version 1.4.4. The CLI requires version 1.5.0. To update the installation, please follow the instructions found here: https://skupper.io/docs/index.html


### Testing:
 
- Installed last version of OLM: https://github.com/operator-framework/operator-lifecycle-manager/releases
- Installed skupper operator version 1.4.4 : https://github.com/skupperproject/skupper-operator/tree/1.4
- Executed all the status commands