### PR TITLE
add the protocol info to the addresses info in ProcessRecord

### DIFF
--- a/pkg/flow/flow_mem_driver.go
+++ b/pkg/flow/flow_mem_driver.go
@@ -1708,7 +1708,7 @@ func (fc *FlowCollector) retrieve(request ApiRequest) (*string, error) {
 						process.Addresses = nil
 						if connector, ok := fc.Connectors[*process.connector]; ok {
 							if connector.Address != nil && connector.AddressId != nil {
-								addrDetails := *connector.Address + "@" + *connector.AddressId
+								addrDetails := *connector.Address + "@" + *connector.AddressId + "@" + *connector.Protocol
 								process.Addresses = append(process.Addresses, &addrDetails)
 							}
 						}


### PR DESCRIPTION
The task involves enhancing the ProcessRecord structure to include protocol information along with the existing address details "addressName@addressId@addressProtocol.
 same UI links necessitate a unique selection based on a combination of name, ID, and protocol. This modification eliminates the need to invoke an AddressRecord within a process solely to retrieve the protocol.