### PR TITLE
update wording around upgrades

### DIFF
--- a/cmd/skupper/skupper_kube_site.go
+++ b/cmd/skupper/skupper_kube_site.go
@@ -341,7 +341,7 @@ func (s *SkupperKubeSite) Update(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if updated {
-		fmt.Println("Skupper is now updated in '" + cli.GetNamespace() + "'.")
+		fmt.Println("Skupper update in progress for '" + cli.GetNamespace() + "'.")
 	} else {
 		fmt.Println("No update required in '" + cli.GetNamespace() + "'.")
 	}


### PR DESCRIPTION
```
[paulwright@p1 ~]$ skupper update

Skupper is now updated in 'pwright-dev'.

# expecting the components to now be at 1.5.3, but the upgrade takes time

[paulwright@p1 ~]$ skupper version
client version                 1.5.3
transport version              quay.io/skupper/skupper-router:2.5.1 (sha256:4f44d5a5d08f)
controller version             quay.io/skupper/service-controller:1.5.2 (sha256:c3326888b661)
config-sync version            quay.io/skupper/config-sync:1.5.2 (sha256:167d1657404c)
flow-collector version         quay.io/skupper/flow-collector:1.5.2 (sha256:052ddbc7373d)

```