### PR TITLE
display switch command on skupper help

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -1127,7 +1127,6 @@ func init() {
 	cmdNetwork.AddCommand(NewCmdNetworkStatus(skupperCli.Network()))
 
 	cmdSwitch := NewCmdSwitch()
-	cmdSwitch.Hidden = true
 
 	addCommands(skupperCli, rootCmd,
 		cmdInit,


### PR DESCRIPTION
The command switch is not been displayed on Skupper help.
Should we display it once podman is not tech-preview on 1.5.3 ?
Related to https://github.com/skupperproject/skupper/issues/1278