### PR TITLE
Fix lack of service_name and other info in legacy /DATA path

### DIFF
--- a/pkg/qdr/amqp_mgmt.go
+++ b/pkg/qdr/amqp_mgmt.go
@@ -578,6 +578,13 @@ func (a *Agent) BatchQuery(queries []Query) ([][]Record, error) {
 		response.Accept()
 		responseIndex, ok := response.Properties.CorrelationID.(uint64)
 		if !ok {
+			ri, ok2 := response.Properties.CorrelationID.(int32)
+			if ok2 {
+				responseIndex = uint64(ri)
+				ok = true
+			}
+		}
+		if !ok {
 			errors = append(errors, fmt.Sprintf("Could not get correct correlation id from response: %#v (%T)", response.Properties.CorrelationID, response.Properties.CorrelationID))
 		} else {
 			if status, ok := AsInt(response.ApplicationProperties["statusCode"]); ok && isOk(status) {


### PR DESCRIPTION
The router now appears to be replying to management queries with the wrong type

for the correlation id. This change checks for the new type and uses that if it can.

This prevents errors when handling /DATA in the rest-api, and ensures that the available information is included in the response.