### PR TITLE
status commands with podman collector lite

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/skupperproject/skupper/pkg/network"
 	"github.com/skupperproject/skupper/pkg/utils/configs"
 	"os"
 	"reflect"
@@ -85,7 +86,8 @@ type SkupperTokenClient interface {
 }
 
 type SkupperNetworkClient interface {
-	Status(cmd *cobra.Command, args []string) error
+	GetCurrentSite(ctx context.Context) (string, error)
+	Status(cmd *cobra.Command, args []string, ctx context.Context) (*network.NetworkStatusInfo, error)
 	StatusFlags(cmd *cobra.Command)
 	SkupperClientCommon
 }

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -86,7 +86,7 @@ type SkupperTokenClient interface {
 }
 
 type SkupperNetworkClient interface {
-	GetCurrentSite(ctx context.Context) (string, error)
+	GetCurrentSiteId(ctx context.Context) (string, error)
 	Status(cmd *cobra.Command, args []string, ctx context.Context) (*network.NetworkStatusInfo, error)
 	StatusFlags(cmd *cobra.Command)
 	SkupperClientCommon

--- a/cmd/skupper/skupper_kube_network.go
+++ b/cmd/skupper/skupper_kube_network.go
@@ -13,7 +13,7 @@ type SkupperKubeNetwork struct {
 	kube *SkupperKube
 }
 
-func (s *SkupperKubeNetwork) GetCurrentSite(ctx context.Context) (string, error) {
+func (s *SkupperKubeNetwork) GetCurrentSiteId(ctx context.Context) (string, error) {
 
 	siteConfig, err := s.kube.Cli.SiteConfigInspect(ctx, nil)
 	if err != nil || siteConfig == nil {

--- a/cmd/skupper/skupper_kube_network.go
+++ b/cmd/skupper/skupper_kube_network.go
@@ -6,14 +6,22 @@ import (
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/pkg/network"
 	"github.com/skupperproject/skupper/pkg/utils"
-	"github.com/skupperproject/skupper/pkg/utils/formatter"
 	"github.com/spf13/cobra"
-	"strconv"
-	"strings"
 )
 
 type SkupperKubeNetwork struct {
 	kube *SkupperKube
+}
+
+func (s *SkupperKubeNetwork) GetCurrentSite(ctx context.Context) (string, error) {
+
+	siteConfig, err := s.kube.Cli.SiteConfigInspect(ctx, nil)
+	if err != nil || siteConfig == nil {
+
+		return "", fmt.Errorf("Skupper is not enabled in namespace: %s", s.kube.Cli.GetNamespace())
+	}
+
+	return siteConfig.Reference.UID, nil
 }
 
 func (s *SkupperKubeNetwork) NewClient(cmd *cobra.Command, args []string) {
@@ -24,123 +32,15 @@ func (s *SkupperKubeNetwork) Platform() types.Platform {
 	return s.kube.Platform()
 }
 
-func (s *SkupperKubeNetwork) Status(cmd *cobra.Command, args []string) error {
-
-	silenceCobra(cmd)
-
-	ctx, cancel := context.WithTimeout(context.Background(), types.DefaultTimeoutDuration)
-	defer cancel()
-
-	siteConfig, err := s.kube.Cli.SiteConfigInspect(ctx, nil)
-	if err != nil || siteConfig == nil {
-		fmt.Printf("Skupper is not enabled in namespace: %s", s.kube.Cli.GetNamespace())
-		fmt.Println()
-		return nil
-	}
+func (s *SkupperKubeNetwork) Status(cmd *cobra.Command, args []string, ctx context.Context) (*network.NetworkStatusInfo, error) {
 
 	configSyncVersion := utils.GetVersionTag(s.kube.Cli.GetVersion(types.TransportContainerName, types.ConfigSyncContainerName))
 	if configSyncVersion != "" && !utils.IsValidFor(configSyncVersion, network.MINIMUM_VERSION) {
-		fmt.Printf(network.MINIMUM_VERSION_MESSAGE, configSyncVersion, network.MINIMUM_VERSION)
-		fmt.Println()
-		return nil
+		return nil, fmt.Errorf(network.MINIMUM_VERSION_MESSAGE, configSyncVersion, network.MINIMUM_VERSION)
 	}
 
-	currentSite := siteConfig.Reference.UID
+	return s.kube.Cli.NetworkStatus(ctx)
 
-	currentNetworkStatus, errStatus := s.kube.Cli.NetworkStatus(ctx)
-	if errStatus != nil && errStatus.Error() == "status not ready" {
-		fmt.Println("Status pending...")
-		return nil
-	} else if errStatus != nil {
-		return errStatus
-	}
-
-	sitesStatus := currentNetworkStatus.SiteStatus
-	statusManager := network.SkupperStatus{NetworkStatus: currentNetworkStatus}
-
-	if sitesStatus != nil && len(sitesStatus) > 0 {
-
-		networkList := formatter.NewList()
-		networkList.Item("Sites:")
-
-		for _, siteStatus := range sitesStatus {
-			if len(siteNetworkStatus) == 0 || siteNetworkStatus == siteStatus.Site.Name {
-
-				siteVersion := "-"
-				if len(siteStatus.Site.Version) > 0 {
-					siteVersion = siteStatus.Site.Version
-				}
-
-				if len(siteStatus.Site.MinimumVersion) > 0 {
-					siteVersion = fmt.Sprintf("%s (minimum version required %s)", siteStatus.Site.Version, siteStatus.Site.MinimumVersion)
-				}
-
-				detailsMap := map[string]string{"site name": siteStatus.Site.Name, "namespace": siteStatus.Site.Namespace, "version": siteVersion}
-
-				location := "[remote]"
-				if siteStatus.Site.Identity == currentSite {
-					location = "[local]"
-				} else if strings.HasPrefix(siteStatus.Site.Identity, "gateway") {
-					location = ""
-				}
-
-				newItem := fmt.Sprintf("%s %s(%s) ", location, siteStatus.Site.Identity, siteStatus.Site.Namespace)
-				newItem = newItem + fmt.Sprintln()
-
-				siteLevel := networkList.NewChildWithDetail(newItem, detailsMap)
-
-				if len(siteStatus.RouterStatus) > 0 {
-
-					err, index := statusManager.GetRouterIndex(&siteStatus)
-					if err != nil {
-						return err
-					}
-
-					mapSiteLink := statusManager.GetSiteLinkMapPerRouter(&siteStatus.RouterStatus[index], &siteStatus.Site)
-
-					if len(mapSiteLink) > 0 {
-						siteLinks := siteLevel.NewChild("Linked sites:")
-						for key, value := range mapSiteLink {
-							siteLinks.NewChildWithDetail(fmt.Sprintln(key), map[string]string{"direction": value.Direction})
-						}
-					}
-
-					if verboseNetworkStatus {
-						routers := siteLevel.NewChild("Routers:")
-						for _, routerStatus := range siteStatus.RouterStatus {
-							routerId := strings.Split(routerStatus.Router.Name, "/")
-
-							// skip routers that belong to headless services
-							if network.PrintableRouter(routerStatus, siteStatus.Site.Name) {
-								routerItem := fmt.Sprintf("name: %s\n", routerId[1])
-								detailsRouter := map[string]string{"image name": routerStatus.Router.ImageName, "image version": routerStatus.Router.ImageVersion}
-
-								routerLevel := routers.NewChildWithDetail(routerItem, detailsRouter)
-
-								printableLinks := statusManager.RemoveLinksFromSameSite(routerStatus, siteStatus.Site)
-
-								if len(printableLinks) > 0 {
-									links := routerLevel.NewChild("Links:")
-									for _, link := range printableLinks {
-										linkItem := fmt.Sprintf("name:  %s\n", link.Name)
-										detailsLink := map[string]string{"direction": link.Direction}
-										if link.LinkCost > 0 {
-											detailsLink["cost"] = strconv.FormatUint(link.LinkCost, 10)
-										}
-										links.NewChildWithDetail(linkItem, detailsLink)
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-
-		networkList.Print()
-	}
-
-	return nil
 }
 
 func (s *SkupperKubeNetwork) StatusFlags(cmd *cobra.Command) {}

--- a/cmd/skupper/skupper_network.go
+++ b/cmd/skupper/skupper_network.go
@@ -1,7 +1,14 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/pkg/network"
+	"github.com/skupperproject/skupper/pkg/utils/formatter"
 	"github.com/spf13/cobra"
+	"strconv"
+	"strings"
 )
 
 func NewCmdNetwork() *cobra.Command {
@@ -21,11 +28,124 @@ func NewCmdNetworkStatus(skupperClient SkupperNetworkClient) *cobra.Command {
 		Short:  "Shows information about the current site, and connected sites.",
 		Args:   cobra.MaximumNArgs(1),
 		PreRun: skupperClient.NewClient,
-		RunE:   skupperClient.Status,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			silenceCobra(cmd)
+
+			ctx, cancel := context.WithTimeout(context.Background(), types.DefaultTimeoutDuration)
+			defer cancel()
+
+			currentSiteId, err := skupperClient.GetCurrentSite(ctx)
+			if err != nil && strings.HasPrefix(err.Error(), "Skupper is not enabled") {
+				fmt.Println(err.Error())
+				return nil
+			} else if err != nil {
+				return err
+			}
+			currentNetworkStatus, errStatus := skupperClient.Status(cmd, args, ctx)
+			if errStatus != nil && errStatus.Error() == "status not ready" {
+				fmt.Println("Status pending...")
+				return nil
+			} else if errStatus != nil && strings.HasPrefix(errStatus.Error(), "Version incompatibility:") {
+				fmt.Println(errStatus.Error())
+				return nil
+			} else if errStatus != nil {
+				return errStatus
+			}
+
+			return printNetworkStatus(currentSiteId, currentNetworkStatus)
+		},
 	}
 
 	cmd.Flags().BoolVarP(&verboseNetworkStatus, "verbose", "v", false, "More detailed output about the network topology")
 	cmd.Flags().StringVarP(&siteNetworkStatus, "site", "s", "", "Filter by a specific site name")
 	return cmd
 
+}
+
+func printNetworkStatus(currentSite string, currentNetworkStatus *network.NetworkStatusInfo) error {
+	sitesStatus := currentNetworkStatus.SiteStatus
+	statusManager := network.SkupperStatus{NetworkStatus: currentNetworkStatus}
+
+	if sitesStatus != nil && len(sitesStatus) > 0 {
+
+		networkList := formatter.NewList()
+		networkList.Item("Sites:")
+
+		for _, siteStatus := range sitesStatus {
+			if len(siteNetworkStatus) == 0 || siteNetworkStatus == siteStatus.Site.Name {
+
+				siteVersion := "-"
+				if len(siteStatus.Site.Version) > 0 {
+					siteVersion = siteStatus.Site.Version
+				}
+
+				if len(siteStatus.Site.MinimumVersion) > 0 {
+					siteVersion = fmt.Sprintf("%s (minimum version required %s)", siteStatus.Site.Version, siteStatus.Site.MinimumVersion)
+				}
+
+				detailsMap := map[string]string{"site name": siteStatus.Site.Name, "namespace": siteStatus.Site.Namespace, "version": siteVersion}
+
+				location := "[remote]"
+				if siteStatus.Site.Identity == currentSite {
+					location = "[local]"
+				} else if strings.HasPrefix(siteStatus.Site.Identity, "gateway") {
+					location = ""
+				}
+
+				newItem := fmt.Sprintf("%s %s(%s) ", location, siteStatus.Site.Identity, siteStatus.Site.Namespace)
+				newItem = newItem + fmt.Sprintln()
+
+				siteLevel := networkList.NewChildWithDetail(newItem, detailsMap)
+
+				if len(siteStatus.RouterStatus) > 0 {
+
+					err, index := statusManager.GetRouterIndex(&siteStatus)
+					if err != nil {
+						return err
+					}
+
+					mapSiteLink := statusManager.GetSiteLinkMapPerRouter(&siteStatus.RouterStatus[index], &siteStatus.Site)
+
+					if len(mapSiteLink) > 0 {
+						siteLinks := siteLevel.NewChild("Linked sites:")
+						for key, value := range mapSiteLink {
+							siteLinks.NewChildWithDetail(fmt.Sprintln(key), map[string]string{"direction": value.Direction})
+						}
+					}
+
+					if verboseNetworkStatus {
+						routers := siteLevel.NewChild("Routers:")
+						for _, routerStatus := range siteStatus.RouterStatus {
+							routerId := strings.Split(routerStatus.Router.Name, "/")
+
+							// skip routers that belong to headless services
+							if network.PrintableRouter(routerStatus, siteStatus.Site.Name) {
+								routerItem := fmt.Sprintf("name: %s\n", routerId[1])
+								detailsRouter := map[string]string{"image name": routerStatus.Router.ImageName, "image version": routerStatus.Router.ImageVersion}
+
+								routerLevel := routers.NewChildWithDetail(routerItem, detailsRouter)
+
+								printableLinks := statusManager.RemoveLinksFromSameSite(routerStatus, siteStatus.Site)
+
+								if len(printableLinks) > 0 {
+									links := routerLevel.NewChild("Links:")
+									for _, link := range printableLinks {
+										linkItem := fmt.Sprintf("name:  %s\n", link.Name)
+										detailsLink := map[string]string{"direction": link.Direction}
+										if link.LinkCost > 0 {
+											detailsLink["cost"] = strconv.FormatUint(link.LinkCost, 10)
+										}
+										links.NewChildWithDetail(linkItem, detailsLink)
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		networkList.Print()
+	}
+	return nil
 }

--- a/cmd/skupper/skupper_network.go
+++ b/cmd/skupper/skupper_network.go
@@ -34,7 +34,7 @@ func NewCmdNetworkStatus(skupperClient SkupperNetworkClient) *cobra.Command {
 			ctx, cancel := context.WithTimeout(context.Background(), types.DefaultTimeoutDuration)
 			defer cancel()
 
-			currentSiteId, err := skupperClient.GetCurrentSite(ctx)
+			currentSiteId, err := skupperClient.GetCurrentSiteId(ctx)
 			if err != nil && strings.HasPrefix(err.Error(), "Skupper is not enabled") {
 				fmt.Println(err.Error())
 				return nil

--- a/cmd/skupper/skupper_network.go
+++ b/cmd/skupper/skupper_network.go
@@ -119,7 +119,7 @@ func printNetworkStatus(currentSite string, currentNetworkStatus *network.Networ
 							routerId := strings.Split(routerStatus.Router.Name, "/")
 
 							// skip routers that belong to headless services
-							if network.PrintableRouter(routerStatus, siteStatus.Site.Name) {
+							if network.PrintableRouter(routerStatus, &siteStatus) {
 								routerItem := fmt.Sprintf("name: %s\n", routerId[1])
 								detailsRouter := map[string]string{"image name": routerStatus.Router.ImageName, "image version": routerStatus.Router.ImageVersion}
 

--- a/cmd/skupper/skupper_podman.go
+++ b/cmd/skupper/skupper_podman.go
@@ -16,7 +16,7 @@ var notImplementedErr = fmt.Errorf("Not implemented")
 
 var SkupperPodmanCommands = []string{
 	"switch", "init", "delete", "status", "version", "token", "link",
-	"service", "expose", "unexpose", "revoke-access", "update",
+	"service", "expose", "unexpose", "revoke-access", "update", "network",
 }
 
 type SkupperPodman struct {
@@ -28,6 +28,7 @@ type SkupperPodman struct {
 	token              *SkupperPodmanToken
 	link               *SkupperPodmanLink
 	service            *SkupperPodmanService
+	network            *SkupperPodmanNetwork
 	exit               exitHandler
 	output             io.Writer
 }
@@ -79,12 +80,13 @@ func (s *SkupperPodman) Token() SkupperTokenClient {
 }
 
 func (s *SkupperPodman) Network() SkupperNetworkClient {
-	return &SkupperPodmanNetwork{}
-}
-
-func notImplementedExit() {
-	fmt.Println("Not implemented")
-	os.Exit(1)
+	if s.network != nil {
+		return s.network
+	}
+	s.network = &SkupperPodmanNetwork{
+		podman: s,
+	}
+	return s.network
 }
 
 func (s *SkupperPodman) NewClient(cmd *cobra.Command, args []string) {

--- a/cmd/skupper/skupper_podman_network.go
+++ b/cmd/skupper/skupper_podman_network.go
@@ -27,7 +27,7 @@ func (s *SkupperPodmanNetwork) GetCurrentSite(ctx context.Context) (string, erro
 func (s *SkupperPodmanNetwork) Status(cmd *cobra.Command, args []string, ctx context.Context) (*network.NetworkStatusInfo, error) {
 	podmanSiteVersion := s.podman.currentSite.Version
 	if podmanSiteVersion != "" && !utils.IsValidFor(podmanSiteVersion, network.MINIMUM_PODMAN_VERSION) {
-		return nil, fmt.Errorf(network.MINIMUM_VERSION_MESSAGE, podmanSiteVersion, network.MINIMUM_VERSION)
+		return nil, fmt.Errorf(network.MINIMUM_VERSION_MESSAGE, podmanSiteVersion, network.MINIMUM_PODMAN_VERSION)
 	}
 
 	return s.NetworkStatusHandler().Get()

--- a/cmd/skupper/skupper_podman_network.go
+++ b/cmd/skupper/skupper_podman_network.go
@@ -1,21 +1,55 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/pkg/domain/podman"
+	"github.com/skupperproject/skupper/pkg/network"
+	"github.com/skupperproject/skupper/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
 type SkupperPodmanNetwork struct {
+	podman               *SkupperPodman
+	networkStatusHandler *podman.NetworkStatusHandler
 }
 
-func (s *SkupperPodmanNetwork) Status(cmd *cobra.Command, args []string) error {
-	return notImplementedErr
+func (s *SkupperPodmanNetwork) GetCurrentSite(ctx context.Context) (string, error) {
+
+	if s.podman.currentSite == nil {
+		return "", fmt.Errorf("Skupper is not enabled")
+	}
+	return s.podman.currentSite.Id, nil
+
+}
+
+func (s *SkupperPodmanNetwork) Status(cmd *cobra.Command, args []string, ctx context.Context) (*network.NetworkStatusInfo, error) {
+	podmanSiteVersion := s.podman.currentSite.Version
+	if podmanSiteVersion != "" && !utils.IsValidFor(podmanSiteVersion, network.MINIMUM_PODMAN_VERSION) {
+		return nil, fmt.Errorf(network.MINIMUM_VERSION_MESSAGE, podmanSiteVersion, network.MINIMUM_VERSION)
+	}
+
+	return s.NetworkStatusHandler().Get()
 }
 
 func (s *SkupperPodmanNetwork) StatusFlags(cmd *cobra.Command) {}
 
-func (s *SkupperPodmanNetwork) NewClient(cmd *cobra.Command, args []string) {}
+func (s *SkupperPodmanNetwork) NewClient(cmd *cobra.Command, args []string) {
+	s.podman.NewClient(cmd, args)
+}
 
 func (s *SkupperPodmanNetwork) Platform() types.Platform {
 	return types.PlatformPodman
+}
+
+func (s *SkupperPodmanNetwork) NetworkStatusHandler() *podman.NetworkStatusHandler {
+	if s.networkStatusHandler != nil {
+		return s.networkStatusHandler
+	}
+	if s.podman.currentSite == nil {
+		return nil
+	}
+	s.networkStatusHandler = new(podman.NetworkStatusHandler).WithClient(s.podman.cli)
+	return s.networkStatusHandler
 }

--- a/cmd/skupper/skupper_podman_network.go
+++ b/cmd/skupper/skupper_podman_network.go
@@ -15,7 +15,7 @@ type SkupperPodmanNetwork struct {
 	networkStatusHandler *podman.NetworkStatusHandler
 }
 
-func (s *SkupperPodmanNetwork) GetCurrentSite(ctx context.Context) (string, error) {
+func (s *SkupperPodmanNetwork) GetCurrentSiteId(ctx context.Context) (string, error) {
 
 	if s.podman.currentSite == nil {
 		return "", fmt.Errorf("Skupper is not enabled")

--- a/cmd/skupper/skupper_podman_service.go
+++ b/cmd/skupper/skupper_podman_service.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/skupperproject/skupper/pkg/network"
 	"net"
 	"net/url"
 	"strconv"
@@ -11,7 +12,6 @@ import (
 	"github.com/skupperproject/skupper/pkg/domain"
 	"github.com/skupperproject/skupper/pkg/domain/podman"
 	"github.com/skupperproject/skupper/pkg/utils"
-	"github.com/skupperproject/skupper/pkg/utils/formatter"
 	"github.com/spf13/cobra"
 )
 
@@ -78,11 +78,12 @@ func (p *PodmanServiceCreateFlags) ToPortMapping(service podman.Service) (map[in
 }
 
 type SkupperPodmanService struct {
-	podman          *SkupperPodman
-	svcHandler      *podman.ServiceHandler
-	svcIfaceHandler *podman.ServiceInterfaceHandler
-	createFlags     PodmanServiceCreateFlags
-	exposeFlags     PodmanExposeFlags
+	podman               *SkupperPodman
+	svcHandler           *podman.ServiceHandler
+	svcIfaceHandler      *podman.ServiceInterfaceHandler
+	createFlags          PodmanServiceCreateFlags
+	exposeFlags          PodmanExposeFlags
+	networkStatusHandler *podman.NetworkStatusHandler
 }
 
 func (s *SkupperPodmanService) Create(cmd *cobra.Command, args []string) error {
@@ -137,57 +138,36 @@ func (s *SkupperPodmanService) List(cmd *cobra.Command, args []string) error {
 func (s *SkupperPodmanService) ListFlags(cmd *cobra.Command) {}
 
 func (s *SkupperPodmanService) Status(cmd *cobra.Command, args []string) error {
+
+	podmanSiteVersion := s.podman.currentSite.Version
+	if podmanSiteVersion != "" && !utils.IsValidFor(podmanSiteVersion, network.MINIMUM_PODMAN_VERSION) {
+		fmt.Printf(network.MINIMUM_VERSION_MESSAGE, podmanSiteVersion, network.MINIMUM_PODMAN_VERSION)
+		fmt.Println()
+		return nil
+	}
 	services, err := s.svcHandler.List()
 	if err == nil {
 		if len(services) == 0 {
 			fmt.Println("No services defined")
 		} else {
-			l := formatter.NewList()
-			l.Item("Services exposed through Skupper:")
-			addresses := []string{}
-			for _, si := range services {
-				addresses = append(addresses, si.GetAddress())
+
+			currentStatus, errStatus := s.NetworkStatusHandler().Get()
+			if errStatus != nil && strings.HasPrefix(errStatus.Error(), "Skupper is not installed") {
+				fmt.Printf("Skupper is not enabled\n")
+				return nil
+			} else if errStatus != nil && errStatus.Error() == "status not ready" {
+				fmt.Println("Status pending...")
+				return nil
+			} else if errStatus != nil {
+				return errStatus
 			}
 
-			for _, svc := range services {
-				svcPodman := svc.(*podman.Service)
+			mapServiceLabels := getPodmanServiceLabelsMap(services)
 
-				for _, port := range svcPodman.GetPorts() {
-					portStr := strconv.Itoa(port)
-
-					svc := l.NewChild(fmt.Sprintf("%s:%s (%s)", svcPodman.GetAddress(), portStr, svcPodman.GetProtocol()))
-					// ingressInfo := ""
-					containerPorts := svcPodman.ContainerPorts()
-					if len(containerPorts) > 0 {
-						ingress := svc.NewChild("Host ports:")
-						ingressInfo := fmt.Sprintf("ip: %s - ports: ", utils.DefaultStr(svcPodman.Ingress.GetHost(), "*"))
-						for i, portInfo := range containerPorts {
-							if i > 0 {
-								ingressInfo += ", "
-							}
-							ingressInfo += fmt.Sprintf("%s -> %s", portInfo.Host, portInfo.Target)
-						}
-						ingress.NewChild(ingressInfo)
-					}
-					if len(svcPodman.GetEgressResolvers()) > 0 {
-						targets := svc.NewChild("Targets:")
-						for _, t := range svcPodman.GetEgressResolvers() {
-							targetInfo := ""
-							if resolverHost, ok := t.(*domain.EgressResolverHost); ok {
-								targetInfo = fmt.Sprintf("host: %s - ports: %v", resolverHost.Host, resolverHost.Ports)
-							}
-							targets.NewChild(targetInfo)
-						}
-					}
-					if showLabels && len(svcPodman.GetLabels()) > 0 {
-						labels := svc.NewChild("Labels:")
-						for k, v := range svcPodman.GetLabels() {
-							labels.NewChild(fmt.Sprintf("%s=%s", k, v))
-						}
-					}
-				}
+			err = network.PrintServiceStatus(currentStatus, mapServiceLabels, verboseServiceStatus, showLabels)
+			if err != nil {
+				return err
 			}
-			l.Print()
 		}
 	} else {
 		return fmt.Errorf("Could not retrieve services: %w", err)
@@ -195,7 +175,9 @@ func (s *SkupperPodmanService) Status(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (s *SkupperPodmanService) StatusFlags(cmd *cobra.Command) {}
+func (s *SkupperPodmanService) StatusFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(&verboseServiceStatus, "verbose", "v", false, "more detailed output")
+}
 
 func (s *SkupperPodmanService) NewClient(cmd *cobra.Command, args []string) {
 	s.podman.NewClient(cmd, args)
@@ -449,4 +431,32 @@ func (s *SkupperPodmanService) checkCommonExposeArgs(cmd *cobra.Command, args []
 		}
 	}
 	return nil
+}
+
+func (s *SkupperPodmanService) NetworkStatusHandler() *podman.NetworkStatusHandler {
+	if s.networkStatusHandler != nil {
+		return s.networkStatusHandler
+	}
+	if s.podman.cli == nil {
+		return nil
+	}
+	s.networkStatusHandler = new(podman.NetworkStatusHandler).WithClient(s.podman.cli)
+	return s.networkStatusHandler
+}
+
+func getPodmanServiceLabelsMap(services []domain.Service) map[string]map[string]string {
+
+	mapServiceLabels := make(map[string]map[string]string)
+
+	for _, svc := range services {
+		if svc.GetLabels() != nil {
+			for _, port := range svc.GetPorts() {
+				serviceName := svc.GetAddress() + ":" + strconv.Itoa(port)
+				mapServiceLabels[serviceName] = svc.GetLabels()
+			}
+		}
+
+	}
+
+	return mapServiceLabels
 }

--- a/pkg/domain/podman/site.go
+++ b/pkg/domain/podman/site.go
@@ -64,9 +64,10 @@ func (s *Site) GetConsoleUrl() string {
 }
 
 type SiteHandler struct {
-	cli      *podman.PodmanRestClient
-	endpoint string
-	up       *domain.UpdateProcessor
+	cli                  *podman.PodmanRestClient
+	endpoint             string
+	up                   *domain.UpdateProcessor
+	networkStatusHandler *NetworkStatusHandler
 }
 
 func NewSitePodmanHandlerFromCli(cli *podman.PodmanRestClient) *SiteHandler {
@@ -98,6 +99,17 @@ func NewSitePodmanHandler(endpoint string) (*SiteHandler, error) {
 		cli:      c,
 		endpoint: endpoint,
 	}, nil
+}
+
+func (s *SiteHandler) NetworkStatusHandler() *NetworkStatusHandler {
+	if s.networkStatusHandler != nil {
+		return s.networkStatusHandler
+	}
+	if s.cli == nil {
+		return nil
+	}
+	s.networkStatusHandler = new(NetworkStatusHandler).WithClient(s.cli)
+	return s.networkStatusHandler
 }
 
 func (s *SiteHandler) prepare(ctx context.Context, site domain.Site) (domain.Site, error) {

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -164,11 +164,10 @@ func PrintableRouter(router RouterStatusInfo, siteName string) bool {
 	// Ignore routers that belong to statefulsets for headless services and any other router
 	routerId := strings.Split(router.Router.Name, "/")
 
-	isARegularSite := len(routerId) > 1 && strings.HasPrefix(routerId[1], siteName)
+	isARegularSite := len(routerId) > 1 && strings.HasPrefix(routerId[1], siteName) && router.Router.ImageName == "skupper-router"
 	isAGateway := len(routerId) > 1 && strings.HasPrefix(routerId[1], "skupper-gateway")
-	isNotAnAdditionalPodmanRouter := router.Router.ImageName == "skupper-router"
 
-	return (isARegularSite || isAGateway) && isNotAnAdditionalPodmanRouter
+	return isARegularSite || isAGateway
 }
 
 func sliceContainsSite(sites []SiteStatusInfo, site SiteStatusInfo) bool {

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -166,8 +166,9 @@ func PrintableRouter(router RouterStatusInfo, siteName string) bool {
 
 	isARegularSite := len(routerId) > 1 && strings.HasPrefix(routerId[1], siteName)
 	isAGateway := len(routerId) > 1 && strings.HasPrefix(routerId[1], "skupper-gateway")
+	isNotAnAdditionalPodmanRouter := router.Router.ImageName == "skupper-router"
 
-	return isARegularSite || isAGateway
+	return (isARegularSite || isAGateway) && isNotAnAdditionalPodmanRouter
 }
 
 func sliceContainsSite(sites []SiteStatusInfo, site SiteStatusInfo) bool {

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -7,7 +7,8 @@ import (
 )
 
 const MINIMUM_VERSION string = "1.5.0"
-const MINIMUM_VERSION_MESSAGE string = "Detected that the skupper version installed in the namespace is version %s. The CLI requires version %s. To update the installation, please follow the instructions found here: https://skupper.io/docs/index.html"
+const MINIMUM_PODMAN_VERSION string = "1.6.0"
+const MINIMUM_VERSION_MESSAGE string = "Version incompatibility:\n \tDetected that the skupper version installed in the namespace is version %s. The CLI requires at least version %s. To update the installation, please follow the instructions found here: https://skupper.io/install/index.html"
 
 type SkupperStatus struct {
 	NetworkStatus *NetworkStatusInfo

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -46,9 +46,9 @@ func (s *SkupperStatus) GetServiceSitesMap() map[string][]SiteStatusInfo {
 	return mapServiceSites
 }
 
-func (s *SkupperStatus) GetSiteTargetMap() map[string]map[string]ConnectorInfo {
+func (s *SkupperStatus) GetSiteTargetMap() map[string]map[string][]ConnectorInfo {
 
-	mapSiteTarget := make(map[string]map[string]ConnectorInfo)
+	mapSiteTarget := make(map[string]map[string][]ConnectorInfo)
 
 	for _, site := range s.NetworkStatus.SiteStatus {
 
@@ -56,9 +56,9 @@ func (s *SkupperStatus) GetSiteTargetMap() map[string]map[string]ConnectorInfo {
 			for _, router := range site.RouterStatus {
 				for _, connector := range router.Connectors {
 					if mapSiteTarget[site.Site.Identity] == nil {
-						mapSiteTarget[site.Site.Identity] = make(map[string]ConnectorInfo)
+						mapSiteTarget[site.Site.Identity] = make(map[string][]ConnectorInfo)
 					}
-					mapSiteTarget[site.Site.Identity][connector.Address] = connector
+					mapSiteTarget[site.Site.Identity][connector.Address] = append(mapSiteTarget[site.Site.Identity][connector.Address], connector)
 				}
 			}
 		}
@@ -211,16 +211,21 @@ func PrintServiceStatus(currentNetworkStatus *NetworkStatusInfo, mapServiceLabel
 						theSite := sites.NewChildWithDetail(item, map[string]string{"policy": policy})
 
 						if si.ConnectorCount > 0 {
-							t := mapSiteTarget[site.Site.Identity][si.Name]
+							serviceTargets := mapSiteTarget[site.Site.Identity][si.Name]
 
-							if len(t.Address) > 0 {
+							if len(serviceTargets) > 0 {
 								targets := theSite.NewChild("Targets:")
-								var name string
-								if t.Target != "" {
-									name = fmt.Sprintf("name=%s", t.Target)
+
+								for _, t := range serviceTargets {
+									if len(t.Address) > 0 {
+										var name string
+										if t.Target != "" {
+											name = fmt.Sprintf("name=%s", t.Target)
+										}
+										targetInfo := fmt.Sprintf("%s %s", t.Address, name)
+										targets.NewChild(targetInfo)
+									}
 								}
-								targetInfo := fmt.Sprintf("%s %s", t.Address, name)
-								targets.NewChild(targetInfo)
 							}
 						}
 					}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -125,7 +125,7 @@ func (s *SkupperStatus) LinkBelongsToSameSite(linkName string, siteId string, ro
 func (s *SkupperStatus) GetRouterIndex(site *SiteStatusInfo) (error, int) {
 
 	for index, router := range site.RouterStatus {
-		if PrintableRouter(router, site.Site.Name) {
+		if PrintableRouter(router, site) {
 			return nil, index
 
 		}
@@ -160,14 +160,15 @@ func UnmarshalSkupperStatus(data map[string]string) (*NetworkStatusInfo, error) 
 	return networkStatusInfo, nil
 }
 
-func PrintableRouter(router RouterStatusInfo, siteName string) bool {
+func PrintableRouter(router RouterStatusInfo, site *SiteStatusInfo) bool {
 	// Ignore routers that belong to statefulsets for headless services and any other router
 	routerId := strings.Split(router.Router.Name, "/")
 
-	isARegularSite := len(routerId) > 1 && strings.HasPrefix(routerId[1], siteName) && router.Router.ImageName == "skupper-router"
+	isAKubernetesSite := len(routerId) > 1 && strings.HasPrefix(routerId[1], site.Site.Name) && site.Site.Platform == "kubernetes"
+	isAPodmanSite := len(routerId) > 1 && routerId[1] == site.Site.Name && site.Site.Platform == "podman"
 	isAGateway := len(routerId) > 1 && strings.HasPrefix(routerId[1], "skupper-gateway")
 
-	return isARegularSite || isAGateway
+	return isAKubernetesSite || isAPodmanSite || isAGateway
 }
 
 func sliceContainsSite(sites []SiteStatusInfo, site SiteStatusInfo) bool {

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -56,7 +56,7 @@ func TestGetSiteTargetsMap(t *testing.T) {
 	result := skupperStatus.GetSiteTargetMap()
 
 	assert.Check(t, result[expectedSite2] == nil)
-	assert.Check(t, result[expectedSite1][expectedService].Address == expectedService)
+	assert.Check(t, result[expectedSite1][expectedService][0].Address == expectedService)
 
 }
 

--- a/test/integration/examples/custom/helloworld/helloworld_podman_test.go
+++ b/test/integration/examples/custom/helloworld/helloworld_podman_test.go
@@ -341,15 +341,6 @@ func TestHelloWorldCLIOnPodman(t *testing.T) {
 						TargetName:  "hello-world-frontend",
 						TargetPort:  8080,
 					},
-					// skupper service status - validate status expecting frontend now has a target
-					&service.StatusTester{
-						ServiceInterfaces: []types.ServiceInterface{
-							{Address: "hello-world-frontend", Protocol: "tcp", Ports: []int{8080}, Targets: []types.ServiceInterfaceTarget{
-								{Name: "hello-world-frontend", TargetPorts: map[int]int{8080: 8080}, Service: "hello-world-frontend"},
-							}},
-							{Address: "hello-world-backend", Protocol: "tcp", Ports: []int{8080}},
-						},
-					},
 				}},
 				{Platform: types.PlatformPodman, Commands: []cli.SkupperCommandTester{
 					// skupper service bind - bind service to deployment and validate target has been defined
@@ -363,10 +354,7 @@ func TestHelloWorldCLIOnPodman(t *testing.T) {
 					&service.StatusTester{
 						ServiceInterfaces: []types.ServiceInterface{
 							{Address: "hello-world-frontend", Protocol: "tcp", Ports: []int{8080}},
-							{Address: "hello-world-backend", Protocol: "tcp", Ports: []int{8080}, Targets: []types.ServiceInterfaceTarget{
-								{Name: `*domain.EgressResolverHost={"host":"hello-world-backend","ports":{"8080":8080}}`,
-									TargetPorts: map[int]int{8080: 8080}, Service: "hello-world-backend"},
-							}},
+							{Address: "hello-world-backend", Protocol: "tcp", Ports: []int{8080}},
 						},
 						Podman: service.StatusPodman{
 							ServiceHostPort: map[string]service.HostPortBinding{

--- a/test/utils/skupper/cli/service/status.go
+++ b/test/utils/skupper/cli/service/status.go
@@ -110,16 +110,6 @@ func (s *StatusTester) run(platform types.Platform, cluster *base.ClusterContext
 	// Iterating through provided service interfaces to validate stdout matches
 	for _, svc := range s.ServiceInterfaces {
 		serviceEntry := fmt.Sprintf(`.*%s:%d \(%s\)`, svc.Address, svc.Ports[0], svc.Protocol)
-		if hostPortBinding, ok := s.Podman.GetHostPortBinding(svc.Address); ok {
-			hostIp := utils.DefaultStr(hostPortBinding.HostIp, `\*`)
-			var portMapping string
-			var portMappingPrefix string
-			for svcPort, hostPort := range hostPortBinding.HostPorts {
-				portMapping += fmt.Sprintf("%s%d -> %d", portMappingPrefix, hostPort, svcPort)
-				portMappingPrefix = ", "
-			}
-			serviceEntry += fmt.Sprintf(`\n.*Host ports:\n.*ip: %s - ports: %s`, hostIp, portMapping)
-		}
 
 		r := regexp.MustCompile(serviceEntry)
 		if r.MatchString(stdout) == s.Absent {


### PR DESCRIPTION
Status commands adapted to the podman collector lite: 
- skupper network status 
- skupper init
- skupper status
- skupper link status
- skupper service status

I did some refactoring to avoid code duplication. I plan to move all the `print` functions in a common package in further pull requests.