### PR TITLE
Assorted fixes on -use-cluster tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
       - run:
           command: >-
             curl -Lo minikube
-            https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 &&
+            https://storage.googleapis.com/minikube/releases/v1.32.0/minikube-linux-amd64 &&
             chmod +x minikube && sudo
             mv minikube /usr/local/bin/
           name: Install Minikube Executable
@@ -322,7 +322,7 @@ commands:
             sudo apt-get update -qq
             sudo apt-get -qq -y install podman
             podman version
-            
+
             # temporary fix for https://github.com/containers/podman/issues/21024
             wget https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/amd64/conmon_2.1.2~0_amd64.deb -O /tmp/conmon_2.1.2.deb
             sudo apt install /tmp/conmon_2.1.2.deb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
       - run:
           command: >-
             curl -Lo minikube
-            https://storage.googleapis.com/minikube/releases/v1.32.0/minikube-linux-amd64 &&
+            https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 &&
             chmod +x minikube && sudo
             mv minikube /usr/local/bin/
           name: Install Minikube Executable
@@ -322,7 +322,7 @@ commands:
             sudo apt-get update -qq
             sudo apt-get -qq -y install podman
             podman version
-
+            
             # temporary fix for https://github.com/containers/podman/issues/21024
             wget https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/amd64/conmon_2.1.2~0_amd64.deb -O /tmp/conmon_2.1.2.deb
             sudo apt install /tmp/conmon_2.1.2.deb

--- a/client/router_create_test.go
+++ b/client/router_create_test.go
@@ -393,17 +393,16 @@ func TestRouterCreateDefaults(t *testing.T) {
 				svcAccountsFound = append(svcAccountsFound, svcAccount.Name)
 			},
 		})
-		iterationCtx, iterationCancel := context.WithCancel(ctx)
-		clusterRoleInformerFactory.Start(iterationCtx.Done())
-		informerFactory.Start(iterationCtx.Done())
-		cache.WaitForCacheSync(iterationCtx.Done(), depInformer.HasSynced)
-		cache.WaitForCacheSync(iterationCtx.Done(), cmInformer.HasSynced)
-		cache.WaitForCacheSync(iterationCtx.Done(), roleInformer.HasSynced)
-		cache.WaitForCacheSync(iterationCtx.Done(), roleBindingInformer.HasSynced)
-		cache.WaitForCacheSync(iterationCtx.Done(), secretInformer.HasSynced)
-		cache.WaitForCacheSync(iterationCtx.Done(), svcInformer.HasSynced)
-		cache.WaitForCacheSync(iterationCtx.Done(), svcAccountInformer.HasSynced)
-		cache.WaitForCacheSync(iterationCtx.Done(), clusterRoleInformer.HasSynced)
+		clusterRoleInformerFactory.Start(ctx.Done())
+		informerFactory.Start(ctx.Done())
+		cache.WaitForCacheSync(ctx.Done(), depInformer.HasSynced)
+		cache.WaitForCacheSync(ctx.Done(), cmInformer.HasSynced)
+		cache.WaitForCacheSync(ctx.Done(), roleInformer.HasSynced)
+		cache.WaitForCacheSync(ctx.Done(), roleBindingInformer.HasSynced)
+		cache.WaitForCacheSync(ctx.Done(), secretInformer.HasSynced)
+		cache.WaitForCacheSync(ctx.Done(), svcInformer.HasSynced)
+		cache.WaitForCacheSync(ctx.Done(), svcAccountInformer.HasSynced)
+		cache.WaitForCacheSync(ctx.Done(), clusterRoleInformer.HasSynced)
 
 		getIngress := func() string {
 			if c.clusterLocal || !isCluster {
@@ -487,7 +486,7 @@ func TestRouterCreateDefaults(t *testing.T) {
 		}
 
 		// Close informers
-		iterationCancel()
+		cancel()
 	}
 }
 

--- a/client/router_create_test.go
+++ b/client/router_create_test.go
@@ -345,14 +345,22 @@ func TestRouterCreateDefaults(t *testing.T) {
 			},
 		})
 
+		expectedClusterRoles := sets.NewString(c.clusterRolesExpected...)
 		clusterRoleInformer := clusterRoleInformerFactory.Rbac().V1().ClusterRoles().Informer()
 		clusterRoleInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				clusterRole := obj.(*rbacv1.ClusterRole)
 				if strings.HasPrefix(clusterRole.Name, "skupper") {
-					clusterRolesFound = append(clusterRolesFound, clusterRole.Name)
-					for _, p := range clusterRole.Rules {
-						clusterRolesResourcesFound = clusterRolesResourcesFound.Insert(p.Resources...)
+					if isCluster && !expectedClusterRoles.Has(clusterRole.Name) {
+						// A real cluster may have pre-existing clusterroles that would
+						// make this test flaky, so we ignore clusterroles not listed
+						// on the test.
+						fmt.Printf("clusterrole %q ignored due to -use-cluster\n", clusterRole.Name)
+					} else {
+						clusterRolesFound = append(clusterRolesFound, clusterRole.Name)
+						for _, p := range clusterRole.Rules {
+							clusterRolesResourcesFound = clusterRolesResourcesFound.Insert(p.Resources...)
+						}
 					}
 				}
 			},
@@ -455,17 +463,7 @@ func TestRouterCreateDefaults(t *testing.T) {
 			t.Errorf("TestRouterCreateDefaults "+c.doc+" roles mismatch (-want +got):\n%s", diff)
 		}
 		if diff := cmp.Diff(c.clusterRolesExpected, clusterRolesFound, c.opts...); diff != "" {
-			// On a cluster that's not been created exclusivelly for this test, there may be pre-existing
-			// cluster roles.  For that reason, we only log the differences, and then check specifically
-			// that the cluster roles we expected _are_ present, ignoring any additional cluster roles.
-			t.Logf("TestRouterCreateDefaults "+c.doc+" cluster roles mismatch (-want +got):\n%s", diff)
-			t.Logf("Checking specifically for expected cluster roles")
-			expectedClusterRoles := sets.NewString(c.clusterRolesExpected...)
-			for _, cr := range c.clusterRolesExpected {
-				if !expectedClusterRoles.Has(cr) {
-					t.Errorf("TestRouterCreateDefaults "+c.doc+" expected cluster role not found: %q", cr)
-				}
-			}
+			t.Errorf("TestRouterCreateDefaults "+c.doc+" cluster roles mismatch (-want +got):\n%s", diff)
 		}
 		if diff := cmp.Diff(c.clusterRoleResources, clusterRolesResourcesFound, c.opts...); diff != "" {
 			t.Errorf("TestRouterCreateDefaults "+c.doc+" cluster roles policy resources mismatch (-want +got):\n%s", diff)

--- a/client/router_create_test.go
+++ b/client/router_create_test.go
@@ -455,15 +455,19 @@ func TestRouterCreateDefaults(t *testing.T) {
 			t.Errorf("TestRouterCreateDefaults "+c.doc+" roles mismatch (-want +got):\n%s", diff)
 		}
 		if diff := cmp.Diff(c.clusterRolesExpected, clusterRolesFound, c.opts...); diff != "" {
-			// On a cluster that's not been created exclusivelly for this test, there may be pre-existing
-			// cluster roles.  For that reason, we only log the differences, and then check specifically
-			// that the cluster roles we expected _are_ present, ignoring any additional cluster roles.
-			t.Logf("TestRouterCreateDefaults "+c.doc+" cluster roles mismatch (-want +got):\n%s", diff)
-			t.Logf("Checking specifically for expected cluster roles")
-			expectedClusterRoles := sets.NewString(c.clusterRolesExpected...)
-			for _, cr := range c.clusterRolesExpected {
-				if !expectedClusterRoles.Has(cr) {
-					t.Errorf("TestRouterCreateDefaults "+c.doc+" expected cluster role not found: %q", cr)
+			if !isCluster {
+				t.Errorf("TestRouterCreateDefaults "+c.doc+" cluster roles mismatch (-want +got):\n%s", diff)
+			} else {
+				// On a cluster that's not been created exclusivelly for this test, there may be pre-existing
+				// cluster roles.  For that reason, we only log the differences, and then check specifically
+				// that the cluster roles we expected _are_ present, ignoring any additional cluster roles.
+				t.Logf("TestRouterCreateDefaults "+c.doc+" cluster roles mismatch (-want +got):\n%s", diff)
+				t.Logf("Checking specifically for expected cluster roles, as we're running on a cluster...")
+				expectedClusterRoles := sets.NewString(c.clusterRolesExpected...)
+				for _, cr := range c.clusterRolesExpected {
+					if !expectedClusterRoles.Has(cr) {
+						t.Errorf("TestRouterCreateDefaults "+c.doc+" expected cluster role not found: %q", cr)
+					}
 				}
 			}
 		}

--- a/client/router_create_test.go
+++ b/client/router_create_test.go
@@ -455,19 +455,15 @@ func TestRouterCreateDefaults(t *testing.T) {
 			t.Errorf("TestRouterCreateDefaults "+c.doc+" roles mismatch (-want +got):\n%s", diff)
 		}
 		if diff := cmp.Diff(c.clusterRolesExpected, clusterRolesFound, c.opts...); diff != "" {
-			if !isCluster {
-				t.Errorf("TestRouterCreateDefaults "+c.doc+" cluster roles mismatch (-want +got):\n%s", diff)
-			} else {
-				// On a cluster that's not been created exclusivelly for this test, there may be pre-existing
-				// cluster roles.  For that reason, we only log the differences, and then check specifically
-				// that the cluster roles we expected _are_ present, ignoring any additional cluster roles.
-				t.Logf("TestRouterCreateDefaults "+c.doc+" cluster roles mismatch (-want +got):\n%s", diff)
-				t.Logf("Checking specifically for expected cluster roles, as we're running on a cluster...")
-				expectedClusterRoles := sets.NewString(c.clusterRolesExpected...)
-				for _, cr := range c.clusterRolesExpected {
-					if !expectedClusterRoles.Has(cr) {
-						t.Errorf("TestRouterCreateDefaults "+c.doc+" expected cluster role not found: %q", cr)
-					}
+			// On a cluster that's not been created exclusivelly for this test, there may be pre-existing
+			// cluster roles.  For that reason, we only log the differences, and then check specifically
+			// that the cluster roles we expected _are_ present, ignoring any additional cluster roles.
+			t.Logf("TestRouterCreateDefaults "+c.doc+" cluster roles mismatch (-want +got):\n%s", diff)
+			t.Logf("Checking specifically for expected cluster roles")
+			expectedClusterRoles := sets.NewString(c.clusterRolesExpected...)
+			for _, cr := range c.clusterRolesExpected {
+				if !expectedClusterRoles.Has(cr) {
+					t.Errorf("TestRouterCreateDefaults "+c.doc+" expected cluster role not found: %q", cr)
 				}
 			}
 		}

--- a/client/serviceinterface_create_test.go
+++ b/client/serviceinterface_create_test.go
@@ -32,6 +32,9 @@ func check_result(t *testing.T, name string, timeoutSeconds float64, resultType 
 	if len(expected) <= 0 {
 		return
 	}
+
+	fmt.Printf("Checking %q results for test %q on %q\n", resultType, doc, name)
+
 	// Sometimes it requires a little time for the requested entities to be
 	// created and for the informers to tell us about them.
 	// So -- count down by tenths of a second until the allotted timeout expires,
@@ -227,7 +230,8 @@ func TestServiceInterfaceCreate(t *testing.T) {
 		cmInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				cm := obj.(*corev1.ConfigMap)
-				if cm.Name != "kube-root-ca.crt" { // seems to be something added in more recent kubernetes?
+				if cm.Name != "kube-root-ca.crt" && // auto-created, introduced in K8S 1.20
+					cm.Name != "openshift-service-ca.crt" { // auto-created, OCP 4.7
 					cmsFound = append(cmsFound, cm.Name)
 				}
 			},

--- a/pkg/domain/podman/main_test.go
+++ b/pkg/domain/podman/main_test.go
@@ -110,10 +110,16 @@ func teardownKube() {
 }
 
 func configureSiteAndCreateRouter(ctx context.Context, cli *client.VanClient, name string) error {
+	var ingressType string
+	if cli.GetRouteClient() != nil {
+		// Like the product, we default to routes on OpenShift
+		ingressType = types.IngressRouteString
+	}
 	routerCreateOpts := types.SiteConfigSpec{
 		SkupperName:      "skupper",
 		RouterMode:       string(types.TransportModeInterior),
 		EnableController: true,
+		Ingress:          ingressType,
 	}
 	siteConfig, err := cli.SiteConfigCreate(ctx, routerCreateOpts)
 	if err != nil {


### PR DESCRIPTION
- Use routes as ingress, when available
- Ignore unexpected additional clusterroles, when running as `-use-cluster`
- Shutdown previous informers between iterations
- Ignore additional cm `openshift-service-ca.crt`, along with `kube-root-ca.crt`
- Cherry pick Fernando's #1386 into 1.5