### PR TITLE
use cache when building container images

### DIFF
--- a/Dockerfile.flow-collector
+++ b/Dockerfile.flow-collector
@@ -2,7 +2,6 @@ FROM --platform=$BUILDPLATFORM golang:1.20 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG BUILDARCH
 
 WORKDIR /go/src/app
 
@@ -14,9 +13,7 @@ COPY . .
 
 RUN make GOOS=$TARGETOS GOARCH=$TARGETARCH
 
-FROM --platform=$BUILDPLATFORM $BUILDARCH/node:18.18.2 AS console-builder
-
-ARG BUILDARCH
+FROM --platform=$BUILDPLATFORM node:18.18.2 AS console-builder
 
 WORKDIR /skupper-console/
 ADD https://github.com/skupperproject/skupper-console/archive/main.tar.gz .

--- a/Makefile
+++ b/Makefile
@@ -50,19 +50,19 @@ build-manifest:
 	go build -ldflags="${LDFLAGS}"  -o manifest ./cmd/manifest
 
 docker-build-test-image:
-	${DOCKER} buildx build --no-cache --platform ${PLATFORMS} -t ${TEST_IMAGE} -f Dockerfile.ci-test .
+	${DOCKER} buildx build --platform ${PLATFORMS} -t ${TEST_IMAGE} -f Dockerfile.ci-test .
 	${DOCKER} buildx build --load -t ${TEST_IMAGE} -f Dockerfile.ci-test .
 
 docker-build: generate-client docker-build-test-image
-	${DOCKER} buildx build --no-cache --platform ${PLATFORMS} -t ${SERVICE_CONTROLLER_IMAGE} -f Dockerfile.service-controller .
+	${DOCKER} buildx build --platform ${PLATFORMS} -t ${SERVICE_CONTROLLER_IMAGE} -f Dockerfile.service-controller .
 	${DOCKER} buildx build --load  -t ${SERVICE_CONTROLLER_IMAGE} -f Dockerfile.service-controller .
-	${DOCKER} buildx build --no-cache --platform ${PLATFORMS} -t ${CONTROLLER_PODMAN_IMAGE} -f Dockerfile.controller-podman .
+	${DOCKER} buildx build --platform ${PLATFORMS} -t ${CONTROLLER_PODMAN_IMAGE} -f Dockerfile.controller-podman .
 	${DOCKER} buildx build --load  -t ${CONTROLLER_PODMAN_IMAGE} -f Dockerfile.controller-podman .
-	${DOCKER} buildx build --no-cache --platform ${PLATFORMS} -t ${SITE_CONTROLLER_IMAGE} -f Dockerfile.site-controller .
+	${DOCKER} buildx build --platform ${PLATFORMS} -t ${SITE_CONTROLLER_IMAGE} -f Dockerfile.site-controller .
 	${DOCKER} buildx build --load  -t ${SITE_CONTROLLER_IMAGE} -f Dockerfile.site-controller .
-	${DOCKER} buildx build --no-cache --platform ${PLATFORMS} -t ${CONFIG_SYNC_IMAGE} -f Dockerfile.config-sync .
+	${DOCKER} buildx build --platform ${PLATFORMS} -t ${CONFIG_SYNC_IMAGE} -f Dockerfile.config-sync .
 	${DOCKER} buildx build --load  -t ${CONFIG_SYNC_IMAGE} -f Dockerfile.config-sync .
-	${DOCKER} buildx build --no-cache --platform ${PLATFORMS} -t ${FLOW_COLLECTOR_IMAGE} -f Dockerfile.flow-collector .
+	${DOCKER} buildx build --platform ${PLATFORMS} -t ${FLOW_COLLECTOR_IMAGE} -f Dockerfile.flow-collector .
 	${DOCKER} buildx build --load  -t ${FLOW_COLLECTOR_IMAGE} -f Dockerfile.flow-collector .
 
 docker-push-test-image:


### PR DESCRIPTION
Reduces CI `build_and_save_test_images` time from 20+ minutes to ~7.

Instead of forcing docker to re-run everything in the builder step for each image produced (together `go mod download` and `make` seem to take around 3 minutes a pop in CI), allow docker layer caching.

~~Locally podman buildx build doesn't seem quite as clever about caching layers, still trying to sort that all out.~~ Local builds with podman are not totally insane for me now 3-4 minutes (though it's still very easy to work against yourself if you keep editing while the build is running - `COPY . .` means just about anything will break the cache. e.g. `time make docker-build` is ~3m. `time make docker-build | tee docker-build.log` is ~20m.)