### PR TITLE
Faster CI Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,6 +468,7 @@ jobs:
           coverpkg: "./api/...,./client/...,./cmd/...,./pkg/..."
           verbose: true
           coverprofile: "/tmp/artifacts/cover.out"
+          parallel: "3"
       - run:
           name: Generating HTML coverage report
           command: go tool cover -html /tmp/artifacts/cover.out -o /tmp/artifacts/cover.html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,8 +458,7 @@ jobs:
                 exit 1
               fi
       - go/mod-download-cached
-      - run: make
-      - run: make clean
+      - run: make generate-client
       - run:
           name: Creating artifacts directory
           command: mkdir /tmp/artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,7 +459,6 @@ jobs:
               fi
       - go/mod-download-cached
       - run: make
-      - run: make package
       - run: make clean
       - run:
           name: Creating artifacts directory


### PR DESCRIPTION
Tweaks to circleci to make the `test` job run faster. Results TBD, but should be ~8 minutes quicker.

* Stop running `make package`. That target doesn't appear to be used anywhere else, and we don't do anything with the output. 5 minutes burnt.
* Chooses a more appropriate default for `go test -p`. Many of our tests have sleeps in them. Without sorting that out the second best thing we can do is to allow the go test runner to run the test suite from multiple packages in parallel.