### PR TITLE
Add Source and Destination Site IDs to ConsoleAPI Links

### DIFF
--- a/pkg/flow/record.go
+++ b/pkg/flow/record.go
@@ -278,6 +278,12 @@ type LinkRecord struct {
 	Direction *string `json:"direction,omitempty"`
 }
 
+type linkRecordResponse struct {
+	LinkRecord
+	SourceSiteId      string `json:"sourceSiteId"`
+	DestinationSiteId string `json:"destinationSiteId"`
+}
+
 type ListenerRecord struct {
 	Base
 	Name        *string `json:"name,omitempty"`


### PR DESCRIPTION
Decorates the /api/v1alpha1/links/ and related endpoints to include source and destination site IDs.