### PR TITLE
Prevent the flow collector from updating skupper-network-status

### DIFF
--- a/cmd/config-sync/collector.go
+++ b/cmd/config-sync/collector.go
@@ -56,11 +56,13 @@ func siteCollector(stopCh <-chan struct{}, cli *client.VanClient) {
 	}
 
 	fc = flow.NewFlowCollector(flow.FlowCollectorSpec{
-		Mode:              flow.RecordStatus,
-		Namespace:         cli.Namespace,
-		PromReg:           nil,
-		ConnectionFactory: qdr.NewConnectionFactory("amqp://localhost:5672", nil),
-		FlowRecordTtl:     time.Minute * 15})
+		Mode:                flow.RecordStatus,
+		Namespace:           cli.Namespace,
+		PromReg:             nil,
+		ConnectionFactory:   qdr.NewConnectionFactory("amqp://localhost:5672", nil),
+		FlowRecordTtl:       time.Minute * 15,
+		NetworkStatusClient: cli.KubeClient,
+	})
 
 	go primeBeacons(fc, cli)
 	log.Println("COLLECTOR: Starting flow collector")

--- a/pkg/flow/collector.go
+++ b/pkg/flow/collector.go
@@ -14,6 +14,7 @@ import (
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/pkg/messaging"
 	"github.com/skupperproject/skupper/pkg/version"
+	"k8s.io/client-go/kubernetes"
 )
 
 type senderDirect struct {
@@ -153,15 +154,17 @@ const (
 )
 
 type FlowCollectorSpec struct {
-	Mode              CollectorMode
-	Namespace         string
-	Origin            string
-	PromReg           prometheus.Registerer
-	ConnectionFactory messaging.ConnectionFactory
-	FlowRecordTtl     time.Duration
+	Mode                CollectorMode
+	Namespace           string
+	Origin              string
+	PromReg             prometheus.Registerer
+	ConnectionFactory   messaging.ConnectionFactory
+	FlowRecordTtl       time.Duration
+	NetworkStatusClient kubernetes.Interface
 }
 
 type FlowCollector struct {
+	kubeclient              kubernetes.Interface
 	mode                    CollectorMode
 	origin                  string
 	namespace               string
@@ -215,6 +218,7 @@ func getTtl(ttl time.Duration) time.Duration {
 
 func NewFlowCollector(spec FlowCollectorSpec) *FlowCollector {
 	fc := &FlowCollector{
+		kubeclient:              spec.NetworkStatusClient,
 		mode:                    spec.Mode,
 		namespace:               spec.Namespace,
 		origin:                  spec.Origin,

--- a/pkg/flow/controller_test.go
+++ b/pkg/flow/controller_test.go
@@ -63,6 +63,8 @@ func TestUpdateHost(t *testing.T) {
 func TestUpdateBeaconAndHeartbeats(t *testing.T) {
 	_ = os.Setenv("SKUPPER_SITE_ID", "mySite")
 	fc := NewFlowController("mySite", "X.Y.Z", uint64(time.Now().UnixNano())/uint64(time.Microsecond), nil, WithPolicyDisabled)
+	fc.beaconInterval = 10 * time.Millisecond
+	fc.heartbeatInterval = 2 * time.Millisecond
 	assert.Assert(t, fc != nil)
 	stopCh := make(chan struct{})
 	go fc.updateBeacon(stopCh)

--- a/pkg/flow/flow_mem_driver.go
+++ b/pkg/flow/flow_mem_driver.go
@@ -531,7 +531,7 @@ func (fc *FlowCollector) updateNetworkStatus() {
 
 	if platform == "" || platform == types.PlatformKubernetes {
 		if fc.kubeclient == nil { // errant configuration - means there is a bug in FlowCollector or how it was configured
-			panic("FlowCollector was not configured with a kuberentes client")
+			panic("FlowCollector was not configured with a kubernetes client")
 		}
 		err = func() error {
 			err = retry.RetryOnConflict(defaultRetry, func() error {

--- a/pkg/flow/flow_mem_driver.go
+++ b/pkg/flow/flow_mem_driver.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/skupperproject/skupper/api/types"
-	"github.com/skupperproject/skupper/client"
 	"github.com/skupperproject/skupper/pkg/config"
 	"github.com/skupperproject/skupper/pkg/domain/podman"
 	"github.com/skupperproject/skupper/pkg/kube"
@@ -490,7 +489,7 @@ var defaultRetry = wait.Backoff{
 
 var netUpdateCt int
 
-func (fc *FlowCollector) updateNetworkStatus() error {
+func (fc *FlowCollector) updateNetworkStatus() {
 	var err error
 	networkData := map[string]string{}
 	platform := config.GetPlatform()
@@ -531,36 +530,40 @@ func (fc *FlowCollector) updateNetworkStatus() error {
 	networkData["NetworkStatus"] = prettyPrint(networkStatus)
 
 	if platform == "" || platform == types.PlatformKubernetes {
-		cli, err := client.NewClient(fc.namespace, "", "")
-		if err != nil {
-			return err
+		if fc.kubeclient == nil { // errant configuration - means there is a bug in FlowCollector or how it was configured
+			panic("FlowCollector was not configured with a kuberentes client")
 		}
+		err = func() error {
+			err = retry.RetryOnConflict(defaultRetry, func() error {
+				configMap, err := kube.GetConfigMap(types.NetworkStatusConfigMapName, fc.namespace, fc.kubeclient)
+				if err != nil {
+					return err
+				}
 
-		err = retry.RetryOnConflict(defaultRetry, func() error {
-			configMap, err := kube.GetConfigMap(types.NetworkStatusConfigMapName, cli.Namespace, cli.KubeClient)
-			if err != nil {
-				return err
+				configMap.Data = networkData
+
+				_, err = fc.kubeclient.CoreV1().ConfigMaps(fc.namespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
+				if err != nil {
+					return err
+				} else {
+					netUpdateCt++
+					return nil
+				}
+			})
+			if !fc.networkStatusUp && len(networkStatus.Sites) > 0 && len(networkStatus.Sites[0].RouterStatus) > 0 {
+				fc.networkStatusUp = true
+				log.Printf("COLLECTOR: First functional network status update written after %s and %d updates\n", time.Since(fc.begin), netUpdateCt)
 			}
-
-			configMap.Data = networkData
-
-			_, err = cli.KubeClient.CoreV1().ConfigMaps(cli.Namespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
-			if err != nil {
-				return err
-			} else {
-				netUpdateCt++
-				return nil
-			}
-		})
-		if !fc.networkStatusUp && len(networkStatus.Sites) > 0 && len(networkStatus.Sites[0].RouterStatus) > 0 {
-			fc.networkStatusUp = true
-			log.Printf("COLLECTOR: First functional network status update written after %s and %d updates\n", time.Since(fc.begin), netUpdateCt)
-		}
+			return nil
+		}()
 	} else if platform == types.PlatformPodman {
 		networkStatusHandler := &podman.NetworkStatusHandler{}
 		err = networkStatusHandler.Update(networkData["NetworkStatus"])
 	}
-	return err
+
+	if err != nil {
+		log.Printf("COLLECTOR: Error writing network status update: %v", err)
+	}
 }
 
 func (fc *FlowCollector) addRecord(record interface{}) error {
@@ -2469,7 +2472,9 @@ func (fc *FlowCollector) reconcileConnectorRecords() error {
 							connector.Target = process.Name
 							process.connector = &connector.Identity
 							process.ProcessBinding = &Bound
-							fc.updateNetworkStatus()
+							if fc.mode == RecordStatus {
+								fc.updateNetworkStatus()
+							}
 							log.Printf("COLLECTOR: Connector %s/%s associated to process %s\n", connector.Identity, *connector.Address, *process.Name)
 							delete(fc.connectorsToReconcile, connId)
 							break


### PR DESCRIPTION
A bug in the FlowCollector allows it to write to the skupper-network when configured in mode RecordMetrics - which is not intended. Because of this, sites with --enable-flow-collector set have competing processes updating the status. This change fixes that bug and mitigates the likelyhood of similar bugs appearing in the future.

Closes https://github.com/skupperproject/skupper/issues/1406