### PR TITLE
Fix broken go mod cache restore in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -449,6 +449,7 @@ jobs:
       name: go_cimg
     steps:
       - checkout
+      - go/mod-download-cached
       - run:
           name: "Enforce Go Formatted Code"
           command: >
@@ -457,7 +458,6 @@ jobs:
                 echo "Bad formatting! execute \"\$make format\" locally and push again!"
                 exit 1
               fi
-      - go/mod-download-cached
       - run: make generate-client
       - run:
           name: Creating artifacts directory


### PR DESCRIPTION
Running `go fmt` triggers a go build (and go mod download), which was pre-populating the go mod cache. The presence of these files conflicts with how the cache is restored in the following step and causes a minute long delay unarchiving the cache.

Last one for now, I promise :smile:. Should fix this issue:
![image](https://github.com/skupperproject/skupper/assets/33990804/f5cd721e-8a6f-4b0c-858d-8c7fce61c0f2)
