### PR TITLE
Include http server TLS and timeout configuration

### DIFF
--- a/cmd/flow-collector/main.go
+++ b/cmd/flow-collector/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/skupperproject/skupper/pkg/config"
 	"github.com/skupperproject/skupper/pkg/domain/podman"
 	"github.com/skupperproject/skupper/pkg/utils"
+	"github.com/skupperproject/skupper/pkg/utils/tlscfg"
 
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/client"
@@ -575,8 +576,11 @@ func main() {
 	}
 	log.Printf("COLLECTOR: server listening on %s", addr)
 	s := &http.Server{
-		Addr:    addr,
-		Handler: handlers.CompressHandler(mux),
+		Addr:         addr,
+		Handler:      handlers.CompressHandler(mux),
+		ReadTimeout:  60 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		TLSConfig:    tlscfg.Default(),
 	}
 
 	go func() {

--- a/cmd/service-controller/console_server.go
+++ b/cmd/service-controller/console_server.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/skupperproject/skupper/pkg/utils"
+	"github.com/skupperproject/skupper/pkg/utils/tlscfg"
 	"github.com/skupperproject/skupper/pkg/version"
 
 	"github.com/skupperproject/skupper/api/types"
@@ -426,11 +427,18 @@ func (server *ConsoleServer) listen() {
 	if os.Getenv("USE_CORS") != "" {
 		r.Use(cors)
 	}
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      r,
+		ReadTimeout:  60 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		TLSConfig:    tlscfg.Default(),
+	}
 	_, err := os.Stat("/etc/service-controller/console/tls.crt")
 	if err == nil {
-		log.Fatal(http.ListenAndServeTLS(addr, "/etc/service-controller/console/tls.crt", "/etc/service-controller/console/tls.key", r))
+		log.Fatal(srv.ListenAndServeTLS("/etc/service-controller/console/tls.crt", "/etc/service-controller/console/tls.key"))
 	} else {
-		log.Fatal(http.ListenAndServe(addr, r))
+		log.Fatal(srv.ListenAndServe())
 	}
 }
 

--- a/pkg/kube/claims/claim_verifier.go
+++ b/pkg/kube/claims/claim_verifier.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/pkg/utils/tlscfg"
 )
 
 const (
@@ -198,8 +199,15 @@ func enableClaimVerifier() bool {
 
 func (server *ClaimVerifier) listen() {
 	addr := fmt.Sprintf(":%d", types.ClaimRedemptionPort)
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      server,
+		TLSConfig:    tlscfg.Modern(),
+		ReadTimeout:  60 * time.Second,
+		WriteTimeout: 60 * time.Second,
+	}
 	log.Printf("Claim verifier listening on %s", addr)
-	log.Fatal(http.ListenAndServeTLS(addr, cert, key, server))
+	log.Fatal(srv.ListenAndServeTLS(cert, key))
 }
 
 func StartClaimVerifier(client kubernetes.Interface, namespace string, generator TokenGenerator, siteChecker SiteChecker) bool {

--- a/pkg/utils/tlscfg/tls.go
+++ b/pkg/utils/tlscfg/tls.go
@@ -22,7 +22,7 @@ func Modern() *tls.Config {
 }
 
 // Default TLS Configuration excludes cipher suites implemented in crypto/tls
-// that have not been marked insecure.
+// that have been marked insecure.
 func Default() *tls.Config {
 	suites := make([]uint16, len(tlsCiphers))
 	copy(suites, tlsCiphers)

--- a/pkg/utils/tlscfg/tls.go
+++ b/pkg/utils/tlscfg/tls.go
@@ -1,0 +1,32 @@
+package tlscfg
+
+import "crypto/tls"
+
+var (
+	tlsCiphers []uint16
+)
+
+func init() {
+	tlsCiphers = make([]uint16, len(tls.CipherSuites()))
+	for i, suite := range tls.CipherSuites() {
+		tlsCiphers[i] = suite.ID
+	}
+}
+
+// Modern TLS Configuration for when TLSv1.3 can be assumed (e.g. when only
+// internal clients are expected.)
+func Modern() *tls.Config {
+	return &tls.Config{
+		MinVersion: tls.VersionTLS13,
+	}
+}
+
+// Default TLS Configuration excludes cipher suites implemented in crypto/tls
+// that have not been marked insecure.
+func Default() *tls.Config {
+	suites := make([]uint16, len(tlsCiphers))
+	copy(suites, tlsCiphers)
+	return &tls.Config{
+		CipherSuites: suites,
+	}
+}


### PR DESCRIPTION
Introduces a `tlscfg.Default()` configuration that is backwards compatible with as many older clients as possible while still excluding ciphers marked as insecure in the go standard library. Also includes a TLSv1.3 only configuration `tlscfg.Modern()` that I suggest we use for skupper-to-skupper APIs (e.g. claims service.)

Also introduces server read and write timeouts to help mitigate the risk of stalled clients tying up resources. Values chosen conservatively to avoid impacting any desired traffic.