### PR TITLE
Include Operational Metrics

### DIFF
--- a/pkg/flow/collector.go
+++ b/pkg/flow/collector.go
@@ -52,7 +52,7 @@ type collectorMetrics struct {
 	flowLatency     *prometheus.HistogramVec
 	activeReconcile *prometheus.GaugeVec
 	apiQueryLatency *prometheus.HistogramVec
-	activeLinks     prometheus.Gauge
+	activeLinks     *prometheus.GaugeVec
 	activeRouters   prometheus.Gauge
 	activeSites     prometheus.Gauge
 }
@@ -128,16 +128,16 @@ func (fc *FlowCollector) NewMetrics(reg prometheus.Registerer) *collectorMetrics
 				Buckets: []float64{10, 100, 1000, 2000, 5000, 10000, 100000, 1000000, 10000000},
 			},
 			[]string{"recordType", "handler"}),
-		activeLinks: prometheus.NewGauge(
+		activeLinks: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "active_links",
-				Help: "Number of active links",
-			},
+				Help: "Number of active links by site and direction",
+			}, []string{"sourceSite", "direction"},
 		),
 		activeRouters: prometheus.NewGauge(
 			prometheus.GaugeOpts{
 				Name: "active_routers",
-				Help: "Number of routers by site",
+				Help: "Number of routers",
 			},
 		),
 		activeSites: prometheus.NewGauge(

--- a/pkg/flow/collector.go
+++ b/pkg/flow/collector.go
@@ -52,6 +52,9 @@ type collectorMetrics struct {
 	flowLatency     *prometheus.HistogramVec
 	activeReconcile *prometheus.GaugeVec
 	apiQueryLatency *prometheus.HistogramVec
+	activeLinks     prometheus.Gauge
+	activeRouters   prometheus.Gauge
+	activeSites     prometheus.Gauge
 }
 
 func (fc *FlowCollector) NewMetrics(reg prometheus.Registerer) *collectorMetrics {
@@ -125,6 +128,24 @@ func (fc *FlowCollector) NewMetrics(reg prometheus.Registerer) *collectorMetrics
 				Buckets: []float64{10, 100, 1000, 2000, 5000, 10000, 100000, 1000000, 10000000},
 			},
 			[]string{"recordType", "handler"}),
+		activeLinks: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "active_links",
+				Help: "Number of active links",
+			},
+		),
+		activeRouters: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "active_routers",
+				Help: "Number of routers by site",
+			},
+		),
+		activeSites: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "active_sites",
+				Help: "Number of sites attached to the network",
+			},
+		),
 	}
 	reg.MustRegister(m.info)
 	reg.MustRegister(m.collectorOctets)
@@ -137,6 +158,9 @@ func (fc *FlowCollector) NewMetrics(reg prometheus.Registerer) *collectorMetrics
 	reg.MustRegister(m.flowLatency)
 	reg.MustRegister(m.activeReconcile)
 	reg.MustRegister(m.apiQueryLatency)
+	reg.MustRegister(m.activeLinks)
+	reg.MustRegister(m.activeRouters)
+	reg.MustRegister(m.activeSites)
 	return m
 
 }

--- a/pkg/flow/flow_mem_driver.go
+++ b/pkg/flow/flow_mem_driver.go
@@ -576,6 +576,9 @@ func (fc *FlowCollector) addRecord(record interface{}) error {
 	case *SiteRecord:
 		if site, ok := record.(*SiteRecord); ok {
 			fc.Sites[site.Identity] = site
+			if fc.mode == RecordMetrics {
+				fc.metrics.activeSites.Inc()
+			}
 		}
 	case *HostRecord:
 		if host, ok := record.(*HostRecord); ok {
@@ -584,10 +587,16 @@ func (fc *FlowCollector) addRecord(record interface{}) error {
 	case *RouterRecord:
 		if router, ok := record.(*RouterRecord); ok {
 			fc.Routers[router.Identity] = router
+			if fc.mode == RecordMetrics {
+				fc.metrics.activeRouters.Inc()
+			}
 		}
 	case *LinkRecord:
 		if link, ok := record.(*LinkRecord); ok {
 			fc.Links[link.Identity] = link
+			if fc.mode == RecordMetrics {
+				fc.metrics.activeLinks.Inc()
+			}
 		}
 	case *ListenerRecord:
 		if listener, ok := record.(*ListenerRecord); ok {
@@ -639,6 +648,9 @@ func (fc *FlowCollector) deleteRecord(record interface{}) error {
 	case *SiteRecord:
 		if site, ok := record.(*SiteRecord); ok {
 			delete(fc.Sites, site.Identity)
+			if fc.mode == RecordMetrics {
+				fc.metrics.activeSites.Dec()
+			}
 		}
 	case *HostRecord:
 		if host, ok := record.(*HostRecord); ok {
@@ -647,10 +659,16 @@ func (fc *FlowCollector) deleteRecord(record interface{}) error {
 	case *RouterRecord:
 		if router, ok := record.(*RouterRecord); ok {
 			delete(fc.Routers, router.Identity)
+			if fc.mode == RecordMetrics {
+				fc.metrics.activeRouters.Dec()
+			}
 		}
 	case *LinkRecord:
 		if link, ok := record.(*LinkRecord); ok {
 			delete(fc.Links, link.Identity)
+			if fc.mode == RecordMetrics {
+				fc.metrics.activeLinks.Dec()
+			}
 		}
 	case *ListenerRecord:
 		if listener, ok := record.(*ListenerRecord); ok {

--- a/pkg/flow/flow_mem_driver.go
+++ b/pkg/flow/flow_mem_driver.go
@@ -2868,7 +2868,9 @@ func (fc *FlowCollector) graph() (routers, sites map[string]*node) {
 					continue
 				}
 				rNode.Forward = append(rNode.Forward, peerRouter)
-				siteNode.Forward = append(siteNode.Forward, peerSite)
+				if site != peerSite {
+					siteNode.Forward = append(siteNode.Forward, peerSite)
+				}
 			default:
 				fallthrough
 			case "inter-router":
@@ -2887,9 +2889,11 @@ func (fc *FlowCollector) graph() (routers, sites map[string]*node) {
 				rNode, peerNode := routerNodes[router], routerNodes[peerRouter]
 				rNode.Forward = append(rNode.Forward, peerRouter)
 				peerNode.Backward = append(peerNode.Backward, router)
-				siteNode, peerSiteNode := siteNodes[site], siteNodes[peerSite]
-				siteNode.Forward = append(siteNode.Forward, peerSite)
-				peerSiteNode.Backward = append(peerSiteNode.Backward, site)
+				if site != peerSite {
+					siteNode, peerSiteNode := siteNodes[site], siteNodes[peerSite]
+					siteNode.Forward = append(siteNode.Forward, peerSite)
+					peerSiteNode.Backward = append(peerSiteNode.Backward, site)
+				}
 			}
 		}
 	}

--- a/pkg/flow/flow_mem_driver.go
+++ b/pkg/flow/flow_mem_driver.go
@@ -2794,10 +2794,10 @@ func (fc *FlowCollector) needForSiteProcess(flow *FlowRecord, siteId string, sta
 
 // graph relations between routers and sites using LinkRecords
 //
-// Collector state is falible, as such this graph is meant to be conservative
-// in the edges it includes between nodes. It deduplicates links (see
-// skupperproject/skupper-router issue #1456) and also for inter-router links
-// ensures both the listener and connector side links are present.
+// Collector state is fallible, as such this graph is meant to be conservative
+// in the edges it includes between nodes. It de-duplicates links (see
+// skupperproject/skupper-router issue #1456) and ensures both the listener and
+// connector sides of inter-router links are present representing either.
 func (fc *FlowCollector) graph() (routers, sites map[string]*node) {
 	siteByRouterID := make(map[string]string, len(fc.Routers))
 	routerIDByName := make(map[string]string, len(fc.Routers))

--- a/pkg/flow/flow_mem_driver_test.go
+++ b/pkg/flow/flow_mem_driver_test.go
@@ -1513,6 +1513,29 @@ func TestGraph(t *testing.T) {
 				"site:1": {ID: "site:1"},
 				"site:2": {ID: "site:2", Forward: []string{"site:0"}},
 			},
+		}, {
+			Name: "exclude intra-site links",
+			Sites: []*SiteRecord{
+				newSite("site:0"),
+			},
+			Routers: []*RouterRecord{
+				newRouter("router0", "site:0", "r0"),
+				newRouter("router1", "site:0", "r1"),
+				newRouter("router2", "site:0", "r2"),
+			},
+			Links: []*LinkRecord{
+				newLink(largs{ID: "link1", RouterID: "router0", PeerRouterName: "r1", Direction: Incoming, Role: "inter-router"}),
+				newLink(largs{ID: "link2", RouterID: "router1", PeerRouterName: "r0", Direction: Outgoing, Role: "inter-router"}),
+				newLink(largs{ID: "link3", RouterID: "router2", PeerRouterName: "r0", Direction: Outgoing, Role: "edge"}),
+			},
+			ExpectedRouterNodes: map[string]*node{
+				"router0": {ID: "router0", Backward: []string{"router1"}},
+				"router1": {ID: "router1", Forward: []string{"router0"}},
+				"router2": {ID: "router2", Forward: []string{"router0"}},
+			},
+			ExpectedSiteNodes: map[string]*node{
+				"site:0": {ID: "site:0"},
+			},
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/flow/flow_mem_driver_test.go
+++ b/pkg/flow/flow_mem_driver_test.go
@@ -1345,16 +1345,27 @@ func TestGraph(t *testing.T) {
 		}
 	}
 
-	newLink := func(id string, router string, peerRouterName string, direction string) *LinkRecord {
-		return &LinkRecord{
+	type largs struct {
+		ID             string
+		RouterID       string
+		PeerRouterName string
+		Direction      string
+		Role           string
+	}
+	newLink := func(a largs) *LinkRecord {
+		record := &LinkRecord{
 			Base: Base{
 				RecType:  recordNames[Router],
-				Identity: id,
-				Parent:   router,
+				Identity: a.ID,
+				Parent:   a.RouterID,
 			},
-			Name:      &peerRouterName,
-			Direction: &direction,
+			Name:      &a.PeerRouterName,
+			Direction: &a.Direction,
 		}
+		if a.Role != "" {
+			record.Mode = &a.Role
+		}
+		return record
 	}
 	tests := []struct {
 		Name                string
@@ -1369,12 +1380,12 @@ func TestGraph(t *testing.T) {
 		}, {
 			Name: "missing routers",
 			Sites: []*SiteRecord{
-				newSite("site:0"),
-				newSite("site:1"),
+				newSite("site:0"), newSite("site:1"),
 			},
 			Links: []*LinkRecord{
-				newLink("norouter:0", "router:0", "r1", Incoming),
-				newLink("norouter:1", "router:1", "r0", Outgoing),
+				newLink(largs{ID: "norouter:0", RouterID: "router:0", PeerRouterName: "r1", Direction: Incoming}),
+				newLink(largs{ID: "norouter:1", RouterID: "router:1", PeerRouterName: "r0", Direction: Outgoing}),
+				newLink(largs{ID: "norouter:2", RouterID: "router:2", PeerRouterName: "r0", Direction: Outgoing, Role: "edge"}),
 			},
 			ExpectedSiteNodes: map[string]*node{
 				"site:0": {ID: "site:0"},
@@ -1388,14 +1399,17 @@ func TestGraph(t *testing.T) {
 			Routers: []*RouterRecord{
 				newRouter("router0", "site:0", "r0"),
 				newRouter("router1", "site:1", "r1"),
+				newRouter("router2", "site:2", "r2"),
 			},
 			Links: []*LinkRecord{
-				newLink("link0", "router0", "r1", Incoming),
-				newLink("link1", "router1", "r0", Outgoing),
+				newLink(largs{ID: "link0", RouterID: "router0", PeerRouterName: "r1", Direction: Incoming}),
+				newLink(largs{ID: "link1", RouterID: "router1", PeerRouterName: "r0", Direction: Outgoing}),
+				newLink(largs{ID: "link2", RouterID: "router2", PeerRouterName: "r0", Direction: Outgoing, Role: "edge"}),
 			},
 			ExpectedRouterNodes: map[string]*node{
 				"router0": {ID: "router0"},
 				"router1": {ID: "router1"},
+				"router2": {ID: "router2"},
 			},
 			ExpectedSiteNodes: map[string]*node{
 				"site:0": {ID: "site:0"},
@@ -1403,16 +1417,15 @@ func TestGraph(t *testing.T) {
 		}, {
 			Name: "single link pair",
 			Sites: []*SiteRecord{
-				newSite("site:0"),
-				newSite("site:1"),
+				newSite("site:0"), newSite("site:1"),
 			},
 			Routers: []*RouterRecord{
 				newRouter("router0", "site:0", "r0"),
 				newRouter("router1", "site:1", "r1"),
 			},
 			Links: []*LinkRecord{
-				newLink("link0", "router0", "r1", Incoming),
-				newLink("link1", "router1", "r0", Outgoing),
+				newLink(largs{ID: "link0", RouterID: "router0", PeerRouterName: "r1", Direction: Incoming}),
+				newLink(largs{ID: "link1", RouterID: "router1", PeerRouterName: "r0", Direction: Outgoing}),
 			},
 			ExpectedRouterNodes: map[string]*node{
 				"router0": {ID: "router0", Backward: []string{"router1"}},
@@ -1425,20 +1438,19 @@ func TestGraph(t *testing.T) {
 		}, {
 			Name: "redundant links",
 			Sites: []*SiteRecord{
-				newSite("site:0"),
-				newSite("site:1"),
+				newSite("site:0"), newSite("site:1"),
 			},
 			Routers: []*RouterRecord{
 				newRouter("router0", "site:0", "r0"),
 				newRouter("router1", "site:1", "r1"),
 			},
 			Links: []*LinkRecord{
-				newLink("link0", "router0", "r1", Incoming),
-				newLink("link1", "router1", "r0", Outgoing),
-				newLink("link2", "router0", "r1", Incoming),
-				newLink("link3", "router1", "r0", Outgoing),
-				newLink("link80", "router0", "r1", Incoming),
-				newLink("link90", "router0", "r1", Incoming),
+				newLink(largs{ID: "link0", RouterID: "router0", PeerRouterName: "r1", Direction: Incoming}),
+				newLink(largs{ID: "link1", RouterID: "router1", PeerRouterName: "r0", Direction: Outgoing}),
+				newLink(largs{ID: "link2", RouterID: "router0", PeerRouterName: "r1", Direction: Incoming}),
+				newLink(largs{ID: "link3", RouterID: "router1", PeerRouterName: "r0", Direction: Outgoing}),
+				newLink(largs{ID: "link80", RouterID: "router0", PeerRouterName: "r1", Direction: Incoming}),
+				newLink(largs{ID: "link90", RouterID: "router0", PeerRouterName: "r1", Direction: Incoming}),
 			},
 			ExpectedRouterNodes: map[string]*node{
 				"router0": {ID: "router0", Backward: []string{"router1"}},
@@ -1451,9 +1463,7 @@ func TestGraph(t *testing.T) {
 		}, {
 			Name: "complex",
 			Sites: []*SiteRecord{
-				newSite("site:0"),
-				newSite("site:1"),
-				newSite("site:2"),
+				newSite("site:0"), newSite("site:1"), newSite("site:2"),
 			},
 			Routers: []*RouterRecord{
 				newRouter("router0", "site:0", "r0"),
@@ -1461,12 +1471,12 @@ func TestGraph(t *testing.T) {
 				newRouter("router2", "site:2", "r2"),
 			},
 			Links: []*LinkRecord{
-				newLink("link0", "router1", "r0", Outgoing), // half link to router1 -> router0
-				newLink("link1", "router1", "r2", Outgoing), // |
-				newLink("link2", "router2", "r1", Incoming), // | link pair router1,router2
-				newLink("link3", "router2", "r0", Incoming), // half link to router2 -> router0
-				newLink("bogus1", "router2", "rdne", Incoming),
-				newLink("bogus2", "routerdne", "r0", Incoming),
+				newLink(largs{ID: "link0", RouterID: "router1", PeerRouterName: "r0", Direction: Outgoing}), // half link to router1 -> router0
+				newLink(largs{ID: "link1", RouterID: "router1", PeerRouterName: "r2", Direction: Outgoing}), // |
+				newLink(largs{ID: "link2", RouterID: "router2", PeerRouterName: "r1", Direction: Incoming}), // | link pair router1,router2
+				newLink(largs{ID: "link3", RouterID: "router2", PeerRouterName: "r0", Direction: Incoming}), // half link to router2 -> router0
+				newLink(largs{ID: "bogus1", RouterID: "router2", PeerRouterName: "rdne", Direction: Incoming, Role: "edge"}),
+				newLink(largs{ID: "bogus2", RouterID: "routerdne", PeerRouterName: "r0", Direction: Incoming}),
 			},
 			ExpectedRouterNodes: map[string]*node{
 				"router0": {ID: "router0"},
@@ -1478,10 +1488,35 @@ func TestGraph(t *testing.T) {
 				"site:1": {ID: "site:1", Forward: []string{"site:2"}},
 				"site:2": {ID: "site:2", Backward: []string{"site:1"}},
 			},
+		}, {
+			Name: "edge links counted on connector side only",
+			Sites: []*SiteRecord{
+				newSite("site:0"), newSite("site:1"), newSite("site:2"),
+			},
+			Routers: []*RouterRecord{
+				newRouter("router0", "site:0", "r0"),
+				newRouter("router1", "site:1", "r1"),
+				newRouter("router2", "site:2", "r2"),
+			},
+			Links: []*LinkRecord{
+				newLink(largs{ID: "link1", RouterID: "router1", PeerRouterName: "r0", Direction: Outgoing, Role: "inter-router"}),
+				newLink(largs{ID: "link2", RouterID: "router2", PeerRouterName: "r0", Direction: Outgoing, Role: "edge"}),
+				newLink(largs{ID: "link-invalid", RouterID: "router0", PeerRouterName: "r2", Direction: Incoming, Role: "edge"}),
+			},
+			ExpectedRouterNodes: map[string]*node{
+				"router0": {ID: "router0"},
+				"router1": {ID: "router1"},
+				"router2": {ID: "router2", Forward: []string{"router0"}},
+			},
+			ExpectedSiteNodes: map[string]*node{
+				"site:0": {ID: "site:0"},
+				"site:1": {ID: "site:1"},
+				"site:2": {ID: "site:2", Forward: []string{"site:0"}},
+			},
 		},
 	}
 	for _, tc := range tests {
-		t.Run("", func(t *testing.T) {
+		t.Run(tc.Name, func(t *testing.T) {
 			fc := NewFlowCollector(FlowCollectorSpec{})
 			for _, site := range tc.Sites {
 				fc.Sites[site.Identity] = site


### PR DESCRIPTION
## What
Adds the following metrics:
```
# HELP active_links Number of active links by site and direction
# TYPE active_links gauge
active_links{ direction="incoming|outgoing", sourceSite="..." }

# HELP active_routers Number of routers
# TYPE active_routers gauge
active_routers

# HELP active_sites Number of sites attached to the network
# TYPE active_sites gauge
active_sites 2
```

## Caveats
I am still wavering on whether or not this is an acceptable solution. Without finding a way to really tackle some of the core issues that make tracking VAN state reliably in the collector, this was my best try to give closer to accurate operational metrics for active sites, routers and links.

active_sites and active_routers both lag (by 60s for vanflow source timeout) but I am otherwise confident in their accuracy.

The active Links metric is fallible in situations where multiple faults have occurred, but should in most cases be more responsive than active sites and routers the way I've implemented it (counting only full incoming/outgoing link pairs once per router pair.)

**Example: A fault occurs at 11:05**
![image](https://github.com/skupperproject/skupper/assets/33990804/0b49fb9d-d124-4f28-868b-827067e67420)

In this example, a VAN with two sites is disconnected at 11:05. The collector side observes immediately that the incoming link from the remote side's connection was closed. At 11:06 the collector has not heard from the remote site in 60 seconds, so it expires its router.

### When link metrics lie

An example of where the link metric is fallible would be in a configuration where three sites are linked in a triangle. If you segment the site with the collector, then quickly remove the link between the other two sites, then restore connectivity to the collector site it will still observe 3 total links even though there should only be 2.

**After** doing this maneuver, the console still shows the link that was removed, and the link metrics reflect the same.
![Screenshot from 2024-03-29 13-15-56](https://github.com/skupperproject/skupper/assets/33990804/3481e04a-b8be-4085-827a-1939cb3b7717)
![image](https://github.com/skupperproject/skupper/assets/33990804/b5870fb0-2e5d-494e-935d-c684706f6640)

**After restarting the collector** the glitch is fixed:
![image](https://github.com/skupperproject/skupper/assets/33990804/239e23d7-40a5-4230-aacf-b8490b4e355f)
![image](https://github.com/skupperproject/skupper/assets/33990804/4517cb4f-2473-49a9-add8-fac7e5b33349)



