### PR TITLE
exclude book info test from the CI build

### DIFF
--- a/test/integration/examples/bookinfo_test.go
+++ b/test/integration/examples/bookinfo_test.go
@@ -1,5 +1,5 @@
-//go:build integration || examples
-// +build integration examples
+//go:build examples
+// +build examples
 
 package examples
 


### PR DESCRIPTION
```
curl -ik docker.io/maistra/examples-bookinfo-productpage-v1:0.12.0                                                                                                                 
HTTP/1.1 301 Moved Permanently
content-length: 0
location: https://docker.io/maistra/examples-bookinfo-productpage-v1:0.12.0
```
The images needed for this example are not available in the docker hub.