### PR TITLE
Prevent segfault when apps/v1 client not available

### DIFF
--- a/pkg/kube/misc.go
+++ b/pkg/kube/misc.go
@@ -87,6 +87,9 @@ func GetServiceInterfaceTarget(targetType string, targetName string, deducePort 
 		}
 		return &target, nil
 	} else if targetType == "deploymentconfig" {
+		if appscli == nil {
+			return nil, fmt.Errorf("can not read deploymentconfig without apps/v1 client")
+		}
 		depconfig, err := GetDeploymentConfig(targetName, namespace, appscli)
 		if err == nil {
 			target := types.ServiceInterfaceTarget{


### PR DESCRIPTION
Adds a nil check around the usage of the apps/v1 client to prevent a service-controller crash when it attempts to look for a DeploymentConfig matching a service target in a kubernetes environment without the DeploymentConfig resource installed.

Closes https://github.com/skupperproject/skupper/issues/1427