### PR TITLE
Incorrect podman version recommendation

### DIFF
--- a/client/podman/rest.go
+++ b/client/podman/rest.go
@@ -23,9 +23,10 @@ import (
 )
 
 const (
-	ENV_PODMAN_ENDPOINT  = "PODMAN_ENDPOINT"
-	DEFAULT_BASE_PATH    = "/v4.0.0"
-	DefaultNetworkDriver = "bridge"
+	ENV_PODMAN_ENDPOINT         = "PODMAN_ENDPOINT"
+	DEFAULT_BASE_PATH           = "/v4.0.0"
+	DefaultNetworkDriver        = "bridge"
+	podmanVersionRecommendation = "Please update your podman installation."
 )
 
 var (
@@ -388,7 +389,10 @@ func (p *PodmanRestClient) Validate() error {
 	}
 	apiVersion := utils.ParseVersion(version.Server.APIVersion)
 	if apiVersion.Major < 4 {
-		return fmt.Errorf("podman version must be 4.0.0 or greater, found: %s", version.Server.APIVersion)
+		return &Error{
+			Err:            fmt.Errorf("podman version must be 4.0.0 or greater, found: %s", version.Server.APIVersion),
+			Recommendation: podmanVersionRecommendation,
+		}
 	}
 	return nil
 }

--- a/cmd/skupper/skupper_podman.go
+++ b/cmd/skupper/skupper_podman.go
@@ -124,10 +124,14 @@ func (s *SkupperPodman) NewClient(cmd *cobra.Command, args []string) {
 	c, err := s.cliFactory(endpoint, "")
 	if err != nil {
 		if exitOnError {
-			fmt.Fprintf(out, "Podman endpoint is not available: %s",
-				utils.DefaultStr(endpoint, clientpodman.GetDefaultPodmanEndpoint()))
-			fmt.Fprintln(out)
-			recommendation := `
+			var recommendation string
+			if podmanErr, ok := err.(*clientpodman.Error); ok {
+				fmt.Println(podmanErr)
+			} else {
+				fmt.Fprintf(out, "Podman endpoint is not available: %s",
+					utils.DefaultStr(endpoint, clientpodman.GetDefaultPodmanEndpoint()))
+				fmt.Fprintln(out)
+				recommendation = `
 Recommendation:
 
 	Make sure you have an active podman endpoint available.
@@ -142,7 +146,8 @@ Recommendation:
 	You can get concrete examples through:
 
 		podman help system service`
-			fmt.Fprintln(out, recommendation)
+				fmt.Fprintln(out, recommendation)
+			}
 			s.exit(1)
 		}
 		return


### PR DESCRIPTION
Recommends updating podman to v4 when older version found. Previously it was reporting the endpoint as down.

Fixes #1448