### PR TITLE
Fix the early parsing of platform flag in init()

### DIFF
--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -1039,12 +1039,27 @@ func addCommands(skupperCli SkupperClient, rootCmd *cobra.Command, cmds ...*cobr
 	}
 }
 
+func parsePlatformFlagOnly(args []string) {
+	// This function is called when not every supported command flag is defined yet
+	for i, p := range args {
+		if p == "--platform" && i < len(args)-1 {
+			config.Platform = args[i+1]
+			break
+		} else if strings.HasPrefix(p, "--platform=") {
+			_, v, _ := strings.Cut(p, "=")
+			config.Platform = v
+			break
+		}
+	}
+}
+
 func init() {
 	rootCmd = &cobra.Command{Use: "skupper"}
 	routev1.AddToScheme(scheme.Scheme)
 
 	rootCmd.PersistentFlags().StringVarP(&config.Platform, "platform", "", "", "The platform type to use [kubernetes, podman]")
-	rootCmd.ParseFlags(os.Args)
+	// Only the "platform" flag is defined at this point so it is unsafe to call rootCmd.ParseFlags(os.Args) here
+	parsePlatformFlagOnly(os.Args)
 
 	var skupperCli SkupperClient
 	switch config.GetPlatform() {

--- a/cmd/skupper/skupper_test.go
+++ b/cmd/skupper/skupper_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/pkg/config"
 
 	"gotest.tools/assert"
 )
@@ -316,4 +317,32 @@ func TestSkupperInitFlowCollectorParseArgs(t *testing.T) {
 	assert.Equal(t, routerCreateOpts.FlowCollector.Memory, "2G")
 	assert.Equal(t, routerCreateOpts.FlowCollector.MemoryLimit, "3G")
 	assert.Equal(t, routerCreateOpts.FlowCollector.FlowRecordTtl, time.Minute*15)
+}
+
+func TestParsePlatformFlagOnly(t *testing.T) {
+	config.Platform = ""
+	args := []string{"skupper", "expose", "host", "10.0.0.1", "--address", "test-service", "--port", "8080", "--platform", "podman"}
+	parsePlatformFlagOnly(args)
+	assert.Equal(t, config.Platform, types.PlatformPodman)
+
+	config.Platform = ""
+	args = []string{"skupper", "expose", "host", "10.0.0.1", "--address", "test-service", "--port", "8080", "--platform=podman"}
+	parsePlatformFlagOnly(args)
+	assert.Equal(t, config.Platform, types.PlatformPodman)
+
+	config.Platform = ""
+	args = []string{"skupper", "--platform", "podman", "expose", "host", "10.0.0.1", "--address", "test-service", "--port", "8080"}
+	parsePlatformFlagOnly(args)
+	assert.Equal(t, config.Platform, types.PlatformPodman)
+
+	config.Platform = ""
+	args = []string{"skupper", "--platform=podman", "expose", "host", "10.0.0.1", "--address", "test-service", "--port", "8080"}
+	parsePlatformFlagOnly(args)
+	assert.Equal(t, config.Platform, types.PlatformPodman)
+
+	// Bad value
+	config.Platform = ""
+	args = []string{"skupper", "--platform=", "expose", "host", "10.0.0.1", "--address", "test-service", "--port", "8080"}
+	parsePlatformFlagOnly(args)
+	assert.Equal(t, config.Platform, "")
 }


### PR DESCRIPTION
The parsing of `--platform` happens very early in the `init()` in order to decide which type of client to instantiate. However, no other flags are defined yet at that point. This causes the parsing to fail if any other flag is encountered in the command line before the `--platform` one (and the code then falls back to the default Kubernetes platform). 

Fixes #1147