### PR TITLE
Add expiry time to token.  

### DIFF
--- a/pkg/kube/claims/claim_create_test.go
+++ b/pkg/kube/claims/claim_create_test.go
@@ -196,6 +196,13 @@ func TestCreateTokenClaim(t *testing.T) {
 			assert.Equal(t, token.Annotations[types.SiteVersion], ctxt.siteVersion)
 			assert.Equal(t, token.Annotations[types.TokenGeneratedBy], ctxt.siteId)
 			assert.Assert(t, bytes.Equal(token.Data[types.ClaimPasswordDataKey], test.password))
+			// expect claim Expiration if expiry time is configured
+			_, ok := token.Annotations[types.ClaimExpiration]
+			if test.expiration != 0 {
+				assert.Assert(t, ok == true)
+			} else {
+				assert.Assert(t, ok == false)
+			}
 			if test.name != "" {
 				assert.Equal(t, token.Annotations[types.ClaimUrlAnnotationKey], fmt.Sprintf("https://%s:%d/%s", ctxt.claimsHostPort.Host, ctxt.claimsHostPort.Port, test.name))
 			} else {


### PR DESCRIPTION
Add expiry time to token.  When token is being used to create a link verify the token hasn't expired.  If it has log a warning but continue with trying to bring up link.

fixes #1415