### PR TITLE
Default ingress to route on openshift

### DIFF
--- a/cmd/skupper/skupper_kube_site.go
+++ b/cmd/skupper/skupper_kube_site.go
@@ -36,7 +36,7 @@ func (s *SkupperKubeSite) Create(cmd *cobra.Command, args []string) error {
 	routerIngressFlag := cmd.Flag("ingress")
 	routerCreateOpts.Platform = s.kube.Platform()
 
-	if !routerIngressFlag.Changed {
+	if !routerIngressFlag.Changed || routerCreateOpts.Ingress == "" {
 		routerCreateOpts.Ingress = cli.GetIngressDefault()
 	}
 	if routerCreateOpts.Ingress == types.IngressNodePortString && routerCreateOpts.IngressHost == "" && routerCreateOpts.Router.IngressHost == "" {


### PR DESCRIPTION
On openshift, if skupper init is called with ingress='' or with no ingress param specified, default ingress to route.

Fixes #1424