### PR TITLE
Updated format transformation to schema 2

### DIFF
--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -79,7 +79,7 @@ SKOPEO = skopeo
 # The options below create or transform the images into the docker format.
 # That is required for their use with Openshift 3.11
 FORMAT_OPTIONS = --format docker
-TRANSFORM_OPTIONS = --format v2s1
+TRANSFORM_OPTIONS = --format v2s2
 
 # Repositories
 MAIN_REPO = quay.io/skupper


### PR DESCRIPTION
Docker manifest format v2 schema 1 is deprecated [1], and will be removed from  Docker 27; it is already disabled on Docker 26 by default, and that version is used by the latest Minikube (1.33).

That was causing issues with the upstream CI runs.  The images have been updated on Quay, and the Makefile updated to ensure future image updates are consistent.

[1] https://docs.docker.com/engine/deprecated/#pushing-and-pulling-with-image-manifest-v2-schema-1