### PR TITLE
Proper handling of job removal on TestGateway subtests

### DIFF
--- a/test/integration/acceptance/gateway_test.go
+++ b/test/integration/acceptance/gateway_test.go
@@ -37,9 +37,9 @@ func TestGateway(t *testing.T) {
 		t.Errorf("error deploying gateway resources before creating the skupper network")
 	}
 	defer gateway.TearDown(testRunner)
+	t.Run("local-gateway-service", testLocalGatewayService)
 	t.Run("local-gateway-docker", testLocalGatewayDocker)
 	t.Run("local-gateway-podman", testLocalGatewayPodman)
-	t.Run("local-gateway-service", testLocalGatewayService)
 }
 
 // testLocalGateway uses localhost to run a TCP Echo server
@@ -156,14 +156,12 @@ func testServices(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		defer cluster.VanClient.KubeClient.BatchV1().Jobs(cluster.Namespace).Delete(context.TODO(), job.Name, v12.DeleteOptions{})
+
 		_, err = k8s.WaitForJob(cluster.Namespace, cluster.VanClient.KubeClient, name, time.Minute)
 		if err != nil {
 			_, _ = cluster.KubectlExec("logs job/" + name)
 			testRunner.DumpTestInfo(name)
-			return err
-		}
-		err = cluster.VanClient.KubeClient.BatchV1().Jobs(cluster.Namespace).Delete(context.TODO(), job.Name, v12.DeleteOptions{})
-		if err != nil {
 			return err
 		}
 		return nil

--- a/test/integration/acceptance/gateway_test.go
+++ b/test/integration/acceptance/gateway_test.go
@@ -37,9 +37,9 @@ func TestGateway(t *testing.T) {
 		t.Errorf("error deploying gateway resources before creating the skupper network")
 	}
 	defer gateway.TearDown(testRunner)
-	t.Run("local-gateway-service", testLocalGatewayService)
 	t.Run("local-gateway-docker", testLocalGatewayDocker)
 	t.Run("local-gateway-podman", testLocalGatewayPodman)
+	t.Run("local-gateway-service", testLocalGatewayService)
 }
 
 // testLocalGateway uses localhost to run a TCP Echo server


### PR DESCRIPTION
Today, if one of the TestGateway subtests fail, the following ones will fail, as well, with the following error:

    === RUN   TestGateway/local-gateway-docker/tcp-echo-host/client-cluster-public
    TCP handler for connection 2 exiting.
        gateway_test.go:177: assertion failed: error is not nil: jobs.batch "tcp-echo-host" already exists

This happens because `testServices` returns in case of error, before executing the job deletion.

This PR fixes that by moving the job deletion to a `defer` call.