### PR TITLE
skupper init for rootful podman should try /run/podman/podman.sock

### DIFF
--- a/pkg/config/local.go
+++ b/pkg/config/local.go
@@ -161,6 +161,9 @@ func GetConfigHome() string {
 }
 
 func GetRuntimeDir() string {
+	if os.Getuid() == 0 {
+		return "/run"
+	}
 	runtimeDir, ok := os.LookupEnv("XDG_RUNTIME_DIR")
 	if !ok {
 		runtimeDir = fmt.Sprintf("/run/user/%d", os.Getuid())


### PR DESCRIPTION
Rouine GetRuntimeDir returns path based on whether os.Getuid() is root.

Fixes #1401