### PR TITLE
skupper init fixes for rootful podman

### DIFF
--- a/pkg/config/local.go
+++ b/pkg/config/local.go
@@ -142,6 +142,9 @@ func GetPlatform() types.Platform {
 }
 
 func GetDataHome() string {
+	if os.Getuid() == 0 {
+		return "/usr/local/bin"
+	}
 	dataHome, ok := os.LookupEnv("XDG_DATA_HOME")
 	if !ok {
 		homeDir, _ := os.UserHomeDir()


### PR DESCRIPTION
When a skupper site (podman) is initialized, the Skupper CLI checks whether user is root before it creates a systemd service as user level only.

Fixes #1465