### PR TITLE
Add timeout params to Connector and Listener structs

### DIFF
--- a/pkg/qdr/qdr.go
+++ b/pkg/qdr/qdr.go
@@ -432,23 +432,25 @@ type LogConfig struct {
 }
 
 type Listener struct {
-	Name             string `json:"name,omitempty" yaml:"name,omitempty"`
-	Role             Role   `json:"role,omitempty" yaml:"role,omitempty"`
-	Host             string `json:"host,omitempty" yaml:"host,omitempty"`
-	Port             int32  `json:"port" yaml:"port,omitempty"`
-	RouteContainer   bool   `json:"routeContainer,omitempty" yaml:"route-container,omitempty"`
-	Http             bool   `json:"http,omitempty" yaml:"http,omitempty"`
-	Cost             int32  `json:"cost,omitempty" yaml:"cost,omitempty"`
-	SslProfile       string `json:"sslProfile,omitempty" yaml:"ssl-profile,omitempty"`
-	SaslMechanisms   string `json:"saslMechanisms,omitempty" yaml:"sasl-mechanisms,omitempty"`
-	AuthenticatePeer bool   `json:"authenticatePeer,omitempty" yaml:"authenticate-peer,omitempty"`
-	LinkCapacity     int32  `json:"linkCapacity,omitempty" yaml:"link-capacity,omitempty"`
-	HttpRootDir      string `json:"httpRootDir,omitempty" yaml:"http-rootdir,omitempty"`
-	Websockets       bool   `json:"websockets,omitempty" yaml:"web-sockets,omitempty"`
-	Healthz          bool   `json:"healthz,omitempty" yaml:"healthz,omitempty"`
-	Metrics          bool   `json:"metrics,omitempty" yaml:"metrics,omitempty"`
-	MaxFrameSize     int    `json:"maxFrameSize,omitempty" yaml:"max-frame-size,omitempty"`
-	MaxSessionFrames int    `json:"maxSessionFrames,omitempty" yaml:"max-session-frames,omitempty"`
+	Name                           string `json:"name,omitempty" yaml:"name,omitempty"`
+	Role                           Role   `json:"role,omitempty" yaml:"role,omitempty"`
+	Host                           string `json:"host,omitempty" yaml:"host,omitempty"`
+	Port                           int32  `json:"port" yaml:"port,omitempty"`
+	RouteContainer                 bool   `json:"routeContainer,omitempty" yaml:"route-container,omitempty"`
+	Http                           bool   `json:"http,omitempty" yaml:"http,omitempty"`
+	Cost                           int32  `json:"cost,omitempty" yaml:"cost,omitempty"`
+	SslProfile                     string `json:"sslProfile,omitempty" yaml:"ssl-profile,omitempty"`
+	SaslMechanisms                 string `json:"saslMechanisms,omitempty" yaml:"sasl-mechanisms,omitempty"`
+	AuthenticatePeer               bool   `json:"authenticatePeer,omitempty" yaml:"authenticate-peer,omitempty"`
+	LinkCapacity                   int32  `json:"linkCapacity,omitempty" yaml:"link-capacity,omitempty"`
+	HttpRootDir                    string `json:"httpRootDir,omitempty" yaml:"http-rootdir,omitempty"`
+	Websockets                     bool   `json:"websockets,omitempty" yaml:"web-sockets,omitempty"`
+	Healthz                        bool   `json:"healthz,omitempty" yaml:"healthz,omitempty"`
+	Metrics                        bool   `json:"metrics,omitempty" yaml:"metrics,omitempty"`
+	MaxFrameSize                   int    `json:"maxFrameSize,omitempty" yaml:"max-frame-size,omitempty"`
+	MaxSessionFrames               int    `json:"maxSessionFrames,omitempty" yaml:"max-session-frames,omitempty"`
+	IdleTimeoutSeconds             int    `json:"idleTimeoutSeconds,omitempty" yaml:"idle-timeout-seconds",omitempty"`
+	InitialHandshakeTimeoutSeconds int    `json:"initialHandshakeTimeoutSeconds,omitempty" yaml:"Initial-handshake-timeout-seconds",omitempty"`
 }
 
 func (l *Listener) SetMaxFrameSize(value int) {
@@ -460,17 +462,18 @@ func (l *Listener) SetMaxSessionFrames(value int) {
 }
 
 type Connector struct {
-	Name             string `json:"name,omitempty"`
-	Role             Role   `json:"role,omitempty"`
-	Host             string `json:"host"`
-	Port             string `json:"port"`
-	RouteContainer   bool   `json:"routeContainer,omitempty"`
-	Cost             int32  `json:"cost,omitempty"`
-	VerifyHostname   bool   `json:"verifyHostname,omitempty"`
-	SslProfile       string `json:"sslProfile,omitempty"`
-	LinkCapacity     int32  `json:"linkCapacity,omitempty"`
-	MaxFrameSize     int    `json:"maxFrameSize,omitempty"`
-	MaxSessionFrames int    `json:"maxSessionFrames,omitempty"`
+	Name               string `json:"name,omitempty"`
+	Role               Role   `json:"role,omitempty"`
+	Host               string `json:"host"`
+	Port               string `json:"port"`
+	RouteContainer     bool   `json:"routeContainer,omitempty"`
+	Cost               int32  `json:"cost,omitempty"`
+	VerifyHostname     bool   `json:"verifyHostname,omitempty"`
+	SslProfile         string `json:"sslProfile,omitempty"`
+	LinkCapacity       int32  `json:"linkCapacity,omitempty"`
+	MaxFrameSize       int    `json:"maxFrameSize,omitempty"`
+	MaxSessionFrames   int    `json:"maxSessionFrames,omitempty"`
+	IdleTimeoutSeconds int    `json:"idleTimeoutSeconds,omitempty" yaml:"idle-timeout-seconds",omitempty"`
 }
 
 func (c *Connector) SetMaxFrameSize(value int) {


### PR DESCRIPTION
 The `Listener` and `Connector` structs are missing the connection timeout parameters so those just get ignored when the `skupper-internal` config map is read or written by `config-sync`. This prevents the user from overwriting the default timeout values for any connection (as it is reported in https://github.com/skupperproject/skupper-router/issues/1132)

Fixes skupperproject/skupper-router#1132