### PR TITLE
add support for routes

### DIFF
--- a/api/types/crds/skupper_site_crd.yaml
+++ b/api/types/crds/skupper_site_crd.yaml
@@ -17,6 +17,8 @@ spec:
               properties:
                 serviceAccount:
                   type: string
+                linkAccess:
+                  type: string
                 settings:
                   type: array
                   items:

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -123,7 +123,7 @@ func NewController(cli kube.Clients, watchNamespace string, currentNamespace str
 
 	controller.certMgr = certificates.NewCertificateManager(controller.controller)
 	controller.certMgr.Watch(watchNamespace)
-	controller.accessMgr = securedaccess.NewSecuredAccessManager(controller.controller, controller.certMgr)
+	controller.accessMgr = securedaccess.NewSecuredAccessManager(controller.controller, controller.certMgr, securedaccess.GetAccessTypeFromEnv())
 
 	controller.accessRecovery.serviceWatcher = controller.controller.WatchServices(coreSecuredAccess(), watchNamespace, controller.checkSecuredAccessService)
 	controller.accessRecovery.ingressWatcher = controller.controller.WatchIngresses(coreSecuredAccess(), watchNamespace, controller.checkSecuredAccessIngress)

--- a/cmd/controller/deploy_cluster_scope.yaml
+++ b/cmd/controller/deploy_cluster_scope.yaml
@@ -223,4 +223,3 @@ spec:
     port: 9090
   ca: skupper-grant-server-ca
   certificate: skupper-grant-server
-  accessType: loadbalancer

--- a/cmd/controller/example/site1.yaml
+++ b/cmd/controller/example/site1.yaml
@@ -2,3 +2,5 @@ apiVersion: skupper.io/v1alpha1
 kind: Site
 metadata:
   name: west
+spec:
+  linkAccess: default

--- a/pkg/apis/skupper/v1alpha1/types.go
+++ b/pkg/apis/skupper/v1alpha1/types.go
@@ -57,6 +57,7 @@ type SiteList struct {
 
 type SiteSpec struct {
 	ServiceAccount string            `json:"serviceAccount,omitempty"`
+	LinkAccess     string            `json:"linkAccess,omitempty"`
 	Settings       map[string]string `json:"settings,omitempty"`
 }
 

--- a/pkg/kube/securedaccess/route.go
+++ b/pkg/kube/securedaccess/route.go
@@ -95,6 +95,10 @@ func desiredRouteForPort(sa *skupperv1alpha1.SecuredAccess, port skupperv1alpha1
 				Kind: "Service",
 				Name: sa.Name,
 			},
+			TLS: &routev1.TLSConfig{
+				Termination:                   routev1.TLSTerminationPassthrough,
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
+			},
 		},
 	}
 	return route

--- a/pkg/kube/site/resources/skupper-router-deployment.yaml
+++ b/pkg/kube/site/resources/skupper-router-deployment.yaml
@@ -94,8 +94,6 @@ spec:
           name: skupper-local-server
         - mountPath: /etc/skupper-router/config/
           name: router-config
-        - mountPath: /etc/skupper-router-certs/skupper-internal/
-          name: skupper-site-server
         - mountPath: /etc/skupper-router-certs
           name: skupper-router-certs
       - env:
@@ -134,9 +132,5 @@ spec:
           defaultMode: 420
           name: skupper-internal
         name: router-config
-      - name: skupper-site-server
-        secret:
-          defaultMode: 420
-          secretName: skupper-site-server
       - emptyDir: {}
         name: skupper-router-certs


### PR DESCRIPTION
This also includes a change that requires linkAccess to be specified on a site in order to enable incoming link access. Valid values for the field are 'none' (meaning the controller will not enable any link access), 'default' meaning the controller will enable link access using the default access type, or an explicit access type 'loadbalancer', 'route' etc