### PR TITLE
Deploy namespaced resources in the skupper namespace

### DIFF
--- a/cmd/controller/deploy_cluster_scope.yaml
+++ b/cmd/controller/deploy_cluster_scope.yaml
@@ -8,6 +8,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: skupper-controller
+  namespace: skupper
   labels:
     application: skupper-controller
 ---
@@ -156,6 +157,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: skupper-controller
+  namespace: skupper
 spec:
   replicas: 1
   selector:
@@ -206,6 +208,7 @@ apiVersion: skupper.io/v1alpha1
 kind: Certificate
 metadata:
   name: skupper-grant-server-ca
+  namespace: skupper
 spec:
   signing: true
   ca:      ""
@@ -215,6 +218,7 @@ apiVersion: skupper.io/v1alpha1
 kind: SecuredAccess
 metadata:
   name: skupper-grant-server
+  namespace: skupper
 spec:
   selector:
       application: skupper-controller


### PR DESCRIPTION
The ClusterRoleBinding applies to skupper/skupper-controller, so the Deployment and ServiceAccount should be there too. Since the Certificate and SecureAccess resources are namespaced, they probably should be in the skupper namespace as well.