### PR TITLE
token create: allow writing to standard output

### DIFF
--- a/cmd/controller/example/README.md
+++ b/cmd/controller/example/README.md
@@ -68,6 +68,12 @@ skupper token create --token-type=cert -n west token.yaml
 kubectl apply -n east -f token.yaml
 ```
 
+or, combined
+
+```
+skupper token create --token-type=cert -n west - | kubectl apply -n east -f -
+```
+
 # Test connectivity
 
 ```


### PR DESCRIPTION
This enables piping the token to kubectl apply. Since errors go to standard error, they remain visible, and a failed token creation doesn't produce any adverse effects in the cluster (kubectl fails because of the empty input).

The "Connection token written" is only output if the token output went to a file.