### PR TITLE
Configure oauth proxy cookie secret

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -215,6 +215,7 @@ const (
 	SiteCaSecret             string = "skupper-site-ca"
 	ConsoleServerSecret      string = "skupper-console-certs"
 	ConsoleUsersSecret       string = "skupper-console-users"
+	ConsoleSessionSecret     string = "skupper-console-session"
 	PrometheusServerSecret   string = "skupper-prometheus-certs"
 	OauthRouterConsoleSecret string = "skupper-router-console-certs"
 	ServiceCaSecret          string = "skupper-service-ca"

--- a/client/router_create.go
+++ b/client/router_create.go
@@ -984,6 +984,7 @@ func (cli *VanClient) GetRouterSpecFromOpts(options types.SiteConfigSpec, siteId
 		if err != nil {
 			return van, fmt.Errorf("failed to generate console session credentials: %s", err)
 		}
+		sessionCreds.Labels = options.Labels
 		credentials = append(credentials, sessionCreds)
 	}
 

--- a/client/router_create_test.go
+++ b/client/router_create_test.go
@@ -195,6 +195,7 @@ func TestRouterCreateDefaults(t *testing.T) {
 				types.LocalClientSecret,
 				types.SiteServerSecret,
 				types.ConsoleServerSecret,
+				types.ConsoleSessionSecret,
 				types.ServiceCaSecret,
 				types.ServiceClientSecret},
 			svcsExpected:        []string{types.LocalTransportServiceName, types.TransportServiceName, types.ControllerServiceName, types.PrometheusServiceName},

--- a/client/router_update.go
+++ b/client/router_update.go
@@ -678,7 +678,7 @@ func (cli *VanClient) RouterUpdateVersionInNamespace(ctx context.Context, hup bo
 			if len(configmap.ObjectMeta.OwnerReferences) > 0 {
 				owner = &configmap.ObjectMeta.OwnerReferences[0]
 			}
-			changed, err := ensureOauthProxyConfig(cli, owner, controller)
+			changed, err := ensureOauthProxyConfig(cli, owner, siteConfig.Spec.Labels, controller)
 			if err != nil {
 				return false, err
 			}
@@ -1496,13 +1496,14 @@ func createFlowCollectorSidecar(ctx context.Context, cli *VanClient, controller 
 	return nil
 }
 
-func ensureOauthProxyConfig(cli *VanClient, owner *metav1.OwnerReference, controller *appsv1.Deployment) (bool, error) {
+func ensureOauthProxyConfig(cli *VanClient, owner *metav1.OwnerReference, labels map[string]string, controller *appsv1.Deployment) (bool, error) {
 	var edited bool
 	// ensure the console session credentials are present
 	sessionCreds, err := kube.GenerateConsoleSessionCredentials(nil)
 	if err != nil {
 		return false, err
 	}
+	sessionCreds.Labels = labels
 	edited = true
 	_, err = kube.NewSecret(sessionCreds, owner, cli.Namespace, cli.KubeClient)
 	if err != nil {

--- a/pkg/kube/secrets_test.go
+++ b/pkg/kube/secrets_test.go
@@ -1,0 +1,71 @@
+package kube
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/skupperproject/skupper/api/types"
+	"gotest.tools/assert"
+)
+
+func TestGenerateConsoleSessionCredentials(t *testing.T) {
+	zeros := bytes.NewReader(make([]byte, 128))
+	const zerosEncoded = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+	exampleText := "GenerateConsoleSessionCredentials"
+	exampleTextEncoded := "R2VuZXJhdGVDb25zb2xlU2Vzc2lvbkNyZWRlbnRpYWw="
+
+	testcases := []struct {
+		Input     io.Reader
+		CheckData func(map[string][]byte) error
+	}{
+		{
+			Input: zeros,
+			CheckData: func(data map[string][]byte) error {
+				if string(data["session_secret"]) != zerosEncoded {
+					return fmt.Errorf("session secret should have been %q but got %v", zerosEncoded, data)
+				}
+				return nil
+			},
+		},
+		{
+			Input: nil,
+			CheckData: func(data map[string][]byte) error {
+				if len(data["session_secret"]) != 44 {
+					return fmt.Errorf("session secret should have been 44 bytes long but got %v", data)
+				}
+				return nil
+			},
+		},
+		{
+			Input: rand.Reader,
+			CheckData: func(data map[string][]byte) error {
+				if len(data["session_secret"]) != 44 {
+					return fmt.Errorf("session secret should have been 44 bytes long but got %v", data)
+				}
+				return nil
+			},
+		},
+		{
+			Input: bytes.NewReader([]byte(exampleText)),
+			CheckData: func(data map[string][]byte) error {
+				if string(data["session_secret"]) != exampleTextEncoded {
+					return fmt.Errorf("session secret should have been %q but got %v", exampleTextEncoded, data)
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run("", func(t *testing.T) {
+			creds, err := GenerateConsoleSessionCredentials(tc.Input)
+			assert.Assert(t, err)
+			assert.Equal(t, creds.Name, types.ConsoleSessionSecret)
+			assert.Assert(t, tc.CheckData(creds.Data))
+		})
+	}
+}


### PR DESCRIPTION
The oauth-proxy uses the cookie secret as a key to sign and validate
session cookies. This change generates a random 32 byte key and stores
it in the skupper-console-session secret to be used by the proxy for
this purpose.

Signed-off-by: Christian Kruse <christian@c-kruse.com>