### PR TITLE
new spinner with context timeout

### DIFF
--- a/internal/cmd/skupper/utils/spinner.go
+++ b/internal/cmd/skupper/utils/spinner.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"github.com/briandowns/spinner"
 	"github.com/skupperproject/skupper/pkg/utils"
 	"time"
@@ -15,6 +16,28 @@ func NewSpinner(message string, maxRetries int, function func() error) error {
 	spin.Start()
 
 	err := utils.RetryError(time.Second, maxRetries, function)
+
+	spin.Stop()
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func NewSpinnerWithTimeout(message string, timeoutInSeconds int, function func() error) error {
+
+	spin := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	spin.Prefix = message
+	spin.FinalMSG = message + "\n"
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(timeoutInSeconds))
+	defer cancel()
+
+	spin.Start()
+
+	err := utils.RetryErrorWithContext(ctx, time.Second, function)
 
 	spin.Stop()
 


### PR DESCRIPTION
A new variant of the spinner constructor that works with a given timeout instead of a number of retries. This is going to be necessary for the commands that have the `--timeout` flag.