### PR TITLE
Configures the router with tcpConnector processIds

### DIFF
--- a/pkg/kube/site/bindings.go
+++ b/pkg/kube/site/bindings.go
@@ -67,7 +67,7 @@ func (a *BindingAdaptor) ConnectorUpdated(connector *skupperv1alpha1.Connector, 
 				return true
 			}
 			// else create a new watcher below
- 		}
+		}
 	} else if connector.Spec.Selector == "" {
 		return true
 	}
@@ -112,8 +112,8 @@ func (a *BindingAdaptor) updateBridgeConfigForConnector(siteId string, connector
 		site.UpdateBridgeConfigForConnectorWithHost(siteId, connector, connector.Spec.Host, config)
 	} else if connector.Spec.Selector != "" {
 		if selector, ok := a.selectors[connector.Name]; ok {
-			for _, host := range selector.List() {
-				site.UpdateBridgeConfigForConnectorWithHost(siteId, connector, host, config)
+			for podUID, host := range selector.List() {
+				site.UpdateBridgeConfigForConnectorWithHostProccess(siteId, connector, host, podUID, config)
 			}
 		} else {
 			log.Printf("Error: not yet tracking pods for connector %s/%s with selector set", connector.Namespace, connector.Name)
@@ -145,15 +145,15 @@ func (w *TargetSelection) Close() {
 	close(w.stopCh)
 }
 
-func (w *TargetSelection) List() []string {
+func (w *TargetSelection) List() map[string]string {
 	pods := w.watcher.List()
-	var targets []string
+	targets := make(map[string]string, len(pods))
 
 	for _, pod := range pods {
 		if kube.IsPodReady(pod) || w.includeNotReady {
 			if kube.IsPodRunning(pod) && pod.DeletionTimestamp == nil {
 				log.Printf("Pod %s selected for connector %s in %s", pod.ObjectMeta.Name, w.name, w.namespace)
-				targets = append(targets, pod.Status.PodIP)
+				targets[string(pod.UID)] = pod.Status.PodIP
 			} else {
 				log.Printf("Pod %s not running for connector %s in %s", pod.ObjectMeta.Name, w.name, w.namespace)
 			}

--- a/pkg/kube/site/bindings.go
+++ b/pkg/kube/site/bindings.go
@@ -113,7 +113,7 @@ func (a *BindingAdaptor) updateBridgeConfigForConnector(siteId string, connector
 	} else if connector.Spec.Selector != "" {
 		if selector, ok := a.selectors[connector.Name]; ok {
 			for podUID, host := range selector.List() {
-				site.UpdateBridgeConfigForConnectorWithHostProccess(siteId, connector, host, podUID, config)
+				site.UpdateBridgeConfigForConnectorWithHostProcess(siteId, connector, host, podUID, config)
 			}
 		} else {
 			log.Printf("Error: not yet tracking pods for connector %s/%s with selector set", connector.Namespace, connector.Name)

--- a/pkg/qdr/amqp_mgmt.go
+++ b/pkg/qdr/amqp_mgmt.go
@@ -125,6 +125,7 @@ func asTcpEndpoint(record Record) TcpEndpoint {
 		Address:    record.AsString("address"),
 		SiteId:     record.AsString("siteId"),
 		SslProfile: record.AsString("sslProfile"),
+		ProcessID:  record.AsString("processId"),
 	}
 }
 

--- a/pkg/qdr/qdr.go
+++ b/pkg/qdr/qdr.go
@@ -570,6 +570,7 @@ type TcpEndpoint struct {
 	SiteId         string `json:"siteId,omitempty"`
 	SslProfile     string `json:"sslProfile,omitempty"`
 	VerifyHostname *bool  `json:"verifyHostname,omitempty"`
+	ProcessID      string `json:"processId,omitempty"`
 }
 
 type HttpEndpoint struct {
@@ -941,7 +942,7 @@ func equivalentHost(a string, b string) bool {
 
 func (a TcpEndpoint) Equivalent(b TcpEndpoint) bool {
 	if !equivalentHost(a.Host, b.Host) || a.Port != b.Port || a.Address != b.Address ||
-		a.SiteId != b.SiteId {
+		a.SiteId != b.SiteId || a.ProcessID != b.ProcessID {
 		return false
 	}
 	return true

--- a/pkg/site/connector.go
+++ b/pkg/site/connector.go
@@ -9,11 +9,15 @@ import (
 
 func UpdateBridgeConfigForConnector(siteId string, connector *skupperv1alpha1.Connector, config *qdr.BridgeConfig) {
 	if connector.Spec.Host != "" {
-		UpdateBridgeConfigForConnectorWithHost(siteId, connector, connector.Spec.Host, config)
+		UpdateBridgeConfigForConnectorWithHostProccess(siteId, connector, connector.Spec.Host, "", config)
 	}
 }
 
 func UpdateBridgeConfigForConnectorWithHost(siteId string, connector *skupperv1alpha1.Connector, host string, config *qdr.BridgeConfig) {
+	UpdateBridgeConfigForConnectorWithHostProccess(siteId, connector, host, "", config)
+}
+
+func UpdateBridgeConfigForConnectorWithHostProccess(siteId string, connector *skupperv1alpha1.Connector, host string, processID string, config *qdr.BridgeConfig) {
 	name := connector.Name + "-" + host
 	if connector.Spec.Type == "tcp" || connector.Spec.Type == "" {
 		config.AddTcpConnector(qdr.TcpEndpoint{
@@ -23,6 +27,7 @@ func UpdateBridgeConfigForConnectorWithHost(siteId string, connector *skupperv1a
 			Port:       strconv.Itoa(connector.Spec.Port),
 			Address:    connector.Spec.RoutingKey,
 			SslProfile: connector.Spec.TlsCredentials,
+			ProcessID:  processID,
 			//TODO:
 			//VerifyHostname
 		})

--- a/pkg/site/connector.go
+++ b/pkg/site/connector.go
@@ -9,15 +9,15 @@ import (
 
 func UpdateBridgeConfigForConnector(siteId string, connector *skupperv1alpha1.Connector, config *qdr.BridgeConfig) {
 	if connector.Spec.Host != "" {
-		UpdateBridgeConfigForConnectorWithHostProccess(siteId, connector, connector.Spec.Host, "", config)
+		UpdateBridgeConfigForConnectorWithHostProcess(siteId, connector, connector.Spec.Host, "", config)
 	}
 }
 
 func UpdateBridgeConfigForConnectorWithHost(siteId string, connector *skupperv1alpha1.Connector, host string, config *qdr.BridgeConfig) {
-	UpdateBridgeConfigForConnectorWithHostProccess(siteId, connector, host, "", config)
+	UpdateBridgeConfigForConnectorWithHostProcess(siteId, connector, host, "", config)
 }
 
-func UpdateBridgeConfigForConnectorWithHostProccess(siteId string, connector *skupperv1alpha1.Connector, host string, processID string, config *qdr.BridgeConfig) {
+func UpdateBridgeConfigForConnectorWithHostProcess(siteId string, connector *skupperv1alpha1.Connector, host string, processID string, config *qdr.BridgeConfig) {
 	name := connector.Name + "-" + host
 	if connector.Spec.Type == "tcp" || connector.Spec.Type == "" {
 		config.AddTcpConnector(qdr.TcpEndpoint{


### PR DESCRIPTION
Adds the new processId configuration option for tcp connectors and sets it as the pod UID when a selector is used to target that pod.