### PR TITLE
Bootstrap reads token access files

### DIFF
--- a/pkg/non_kube/common/claim_redeemer.go
+++ b/pkg/non_kube/common/claim_redeemer.go
@@ -2,9 +2,121 @@ package common
 
 import (
 	"github.com/skupperproject/skupper/pkg/non_kube/apis"
+
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"time"
+
+	skupperv1alpha1 "github.com/skupperproject/skupper/pkg/apis/skupper/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 func RedeemClaims(siteState *apis.SiteState) error {
-	// TODO Redeem logic that will populate siteState.Secrets and siteState.Links
+	var errs []error
+
+	for name, claim := range siteState.Claims {
+		err := redeemAccessToken(claim, siteState)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to redeem claim %s: %w", name, err))
+			fmt.Printf("RedeemClaims: failed to redeem claim: %s: %s\n", name, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to redeem %d claims", len(errs))
+	}
+
+	return nil
+}
+
+// Redeem logic that populates siteState.Secrets and siteState.Links
+func redeemAccessToken(claim *skupperv1alpha1.AccessToken, siteState *apis.SiteState) error {
+	transport := &http.Transport{}
+	if claim.Spec.Ca != "" {
+		caPool := x509.NewCertPool()
+		caPool.AppendCertsFromPEM([]byte(claim.Spec.Ca))
+		transport.TLSClientConfig = &tls.Config{
+			RootCAs: caPool,
+		}
+	}
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   10 * time.Second,
+	}
+	request, err := http.NewRequest(http.MethodPost, claim.Spec.Url, bytes.NewReader([]byte(claim.Spec.Code)))
+	request.Header.Add("name", claim.Name)
+	request.Header.Add("subject", string(siteState.Site.Name))
+	response, err := client.Do(request)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(response.Body)
+		if err == nil {
+			err = fmt.Errorf("Received HTTP Response %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+		} else {
+			err = fmt.Errorf("Received HTTP Response %d. Could not read body: %s", response.StatusCode, err)
+		}
+		return err
+	}
+	// TODO should bootstrap log helpful status info (like the following)?
+	// log.Printf("HTTP Post to %s for %s/%s was sucessful, decoding response body", claim.Spec.Url, claim.Namespace, claim.Name)
+
+	decoder := newLinkDecoder(response.Body)
+	if err := decoder.decodeAll(); err != nil {
+		return err
+	}
+
+	siteState.Secrets[decoder.secret.ObjectMeta.Name] = &decoder.secret
+
+	for _, link := range decoder.links {
+		siteState.Links[link.ObjectMeta.Name] = &link
+	}
+
+	return nil
+}
+
+type LinkDecoder struct {
+	decoder *yaml.YAMLOrJSONDecoder
+	secret  corev1.Secret
+	links   []skupperv1alpha1.Link
+}
+
+func newLinkDecoder(r io.Reader) *LinkDecoder {
+	return &LinkDecoder{
+		decoder: yaml.NewYAMLOrJSONDecoder(r, 1024),
+	}
+}
+
+func (d *LinkDecoder) decodeSecret() error {
+	return d.decoder.Decode(&d.secret)
+}
+
+func (d *LinkDecoder) decodeLink() error {
+	var link skupperv1alpha1.Link
+	if err := d.decoder.Decode(&link); err != nil {
+		return err
+	}
+	d.links = append(d.links, link)
+	return nil
+}
+
+func (d *LinkDecoder) decodeAll() error {
+	if err := d.decodeSecret(); err != nil {
+		return err
+	}
+	for err := d.decodeLink(); err != io.EOF; err = d.decodeLink() {
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/non_kube/common/site_state_loader.go
+++ b/pkg/non_kube/common/site_state_loader.go
@@ -88,7 +88,7 @@ func LoadIntoSiteState(reader *bufio.Reader, siteState *apis.SiteState) error {
 				var link v1alpha1.Link
 				runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(runtime.Unstructured).UnstructuredContent(), &link)
 				siteState.Links[link.Name] = &link
-			case "Claim":
+			case "AccessToken":
 				var claim v1alpha1.AccessToken
 				runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(runtime.Unstructured).UnstructuredContent(), &claim)
 				siteState.Claims[claim.Name] = &claim


### PR DESCRIPTION
Tested manually: bootstrap successfully redeems claim; links to kube v2 site.

Test steps:
  - In minikube, ran skupper v2.  Created site west
  - In minikube, created access token.
  - Updated non-kube site.yaml to have name fedora-east.
  - Copied access token to non-kube input directory.  
  - Ran bootstrap.
  - Monitored skupper-router logs in kube (west) site, verified skupper connection open.

```
[kschoener@fedora skupper]$ ./bootstrap -- /home/kschoener/cheatsheets/redhat_non_kube_notes/20240625_zipfile/karenpatches/east-fedora
Skupper nonkube bootstrap (version: 72a4632-modified)
It is recommended to enable lingering for kschoener, otherwise Skupper may not start on boot.
Site "fedora-east" has been created
[kschoener@fedora skupper]$
```



Tested manually: bootstrap fails to redeem claim.

Test steps: 
  - Test with access_token with invalid (unreachable) claim url.
  - I added a 10 second (hardcoded) timeout to claim_redeemer.go
  
```
[kschoener@fedora skupper]$ ./bootstrap -- /home/kschoener/cheatsheets/redhat_non_kube_notes/20240625_zipfile/karenpatches/east-fedora
Skupper nonkube bootstrap (version: 72a4632)
RedeemClaims: failed to redeem claim: go-west: Post "https://10.110.118.107:9090/88fc1fd2-4127-45eb-a5c3-ad6b1f5a1705": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
Failed to bootstrap: failed to render site state: failed to redeem claims: failed to redeem 1 claims
```



