### PR TITLE
Update unit tests for connector and listeners

### DIFF
--- a/internal/cmd/skupper/connector/kube/connector_delete.go
+++ b/internal/cmd/skupper/connector/kube/connector_delete.go
@@ -87,9 +87,7 @@ func (cmd *CmdConnectorDelete) ValidateInput(args []string) []error {
 		// Validate that there is already a connector with this name in the namespace
 		if cmd.name != "" {
 			connector, err := cmd.client.Connectors(cmd.namespace).Get(context.TODO(), cmd.name, metav1.GetOptions{})
-			if err != nil {
-				validationErrors = append(validationErrors, err)
-			} else if connector == nil {
+			if err != nil || connector == nil {
 				validationErrors = append(validationErrors, fmt.Errorf("connector %s does not exist in namespace %s", cmd.name, cmd.namespace))
 			}
 		}

--- a/internal/cmd/skupper/connector/kube/connector_status.go
+++ b/internal/cmd/skupper/connector/kube/connector_status.go
@@ -134,7 +134,7 @@ func (cmd *CmdConnectorStatus) Run() error {
 		}
 	} else {
 		resource, err := cmd.client.Connectors(cmd.namespace).Get(context.TODO(), cmd.name, metav1.GetOptions{})
-		if resource == nil || errors.IsNotFound(err) {
+		if err != nil || resource == nil {
 			fmt.Println("No connectors found")
 			return err
 		}

--- a/internal/cmd/skupper/connector/kube/connector_update.go
+++ b/internal/cmd/skupper/connector/kube/connector_update.go
@@ -247,7 +247,7 @@ func (cmd *CmdConnectorUpdate) WaitUntilReady() error {
 	}
 
 	waitTime := int(cmd.flags.timeout.Seconds())
-	err := utils.NewSpinnerWithTimeout("Waiting for create to complete...", waitTime, func() error {
+	err := utils.NewSpinnerWithTimeout("Waiting for update to complete...", waitTime, func() error {
 
 		resource, err := cmd.client.Connectors(cmd.namespace).Get(context.TODO(), cmd.name, metav1.GetOptions{})
 		if err != nil {

--- a/internal/cmd/skupper/listener/kube/listener_delete.go
+++ b/internal/cmd/skupper/listener/kube/listener_delete.go
@@ -88,9 +88,7 @@ func (cmd *CmdListenerDelete) ValidateInput(args []string) []error {
 		if cmd.name != "" {
 			// Validate that there is already a listener with this name in the namespace
 			listener, err := cmd.client.Listeners(cmd.namespace).Get(context.TODO(), cmd.name, metav1.GetOptions{})
-			if err != nil {
-				validationErrors = append(validationErrors, err)
-			} else if listener == nil {
+			if err != nil || listener == nil {
 				validationErrors = append(validationErrors, fmt.Errorf("listener %s does not exist in namespace %s", cmd.name, cmd.namespace))
 			}
 		}

--- a/internal/cmd/skupper/listener/kube/listener_status.go
+++ b/internal/cmd/skupper/listener/kube/listener_status.go
@@ -88,10 +88,10 @@ func (cmd *CmdListenerStatus) ValidateInput(args []string) []error {
 		}
 	}
 
-	// Validate that there is no listener with this name in the namespace
+	// Validate that there is a listener with this name in the namespace
 	if cmd.name != "" {
 		listener, err := cmd.client.Listeners(cmd.namespace).Get(context.TODO(), cmd.name, metav1.GetOptions{})
-		if listener == nil || errors.IsNotFound(err) {
+		if err != nil || listener == nil {
 			validationErrors = append(validationErrors, fmt.Errorf("listener %s does not exist in namespace %s", cmd.name, cmd.namespace))
 		}
 	}


### PR DESCRIPTION
Rewrite unit tests for listeners and connectors to use new mock code.
Add checks that site is active before allowing connector or listener to be created.