### PR TITLE
Rename function in skupper command interface

### DIFF
--- a/internal/cmd/skupper/connector/kube/connector_create.go
+++ b/internal/cmd/skupper/connector/kube/connector_create.go
@@ -60,7 +60,7 @@ func NewCmdConnectorCreate() *CmdConnectorCreate {
 			utils.HandleError(skupperCmd.Run())
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return skupperCmd.WaitUntilReady()
+			return skupperCmd.WaitUntil()
 		},
 	}
 
@@ -231,7 +231,7 @@ func (cmd *CmdConnectorCreate) Run() error {
 	}
 }
 
-func (cmd *CmdConnectorCreate) WaitUntilReady() error {
+func (cmd *CmdConnectorCreate) WaitUntil() error {
 	// the site resource was not created
 	if cmd.output != "" {
 		return nil
@@ -259,3 +259,5 @@ func (cmd *CmdConnectorCreate) WaitUntilReady() error {
 	fmt.Printf("Connector %q is ready\n", cmd.name)
 	return nil
 }
+
+func (cmd *CmdConnectorCreate) InputToOptions() {}

--- a/internal/cmd/skupper/connector/kube/connector_create_test.go
+++ b/internal/cmd/skupper/connector/kube/connector_create_test.go
@@ -920,7 +920,7 @@ func TestCmdConnectorCreate_WaitUntilReady(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 
-			err := cmd.WaitUntilReady()
+			err := cmd.WaitUntil()
 			if test.expectError {
 				assert.Check(t, err != nil)
 			} else {

--- a/internal/cmd/skupper/connector/kube/connector_delete.go
+++ b/internal/cmd/skupper/connector/kube/connector_delete.go
@@ -45,7 +45,7 @@ func NewCmdConnectorDelete() *CmdConnectorDelete {
 			utils.HandleError(skupperCmd.Run())
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return skupperCmd.WaitUntilReady()
+			return skupperCmd.WaitUntil()
 		},
 	}
 	skupperCmd.CobraCmd = cmd
@@ -106,7 +106,7 @@ func (cmd *CmdConnectorDelete) Run() error {
 	return err
 }
 
-func (cmd *CmdConnectorDelete) WaitUntilReady() error {
+func (cmd *CmdConnectorDelete) WaitUntil() error {
 	waitTime := int(cmd.flags.timeout.Seconds())
 	err := utils.NewSpinnerWithTimeout("Waiting for deletion to complete...", waitTime, func() error {
 
@@ -125,3 +125,5 @@ func (cmd *CmdConnectorDelete) WaitUntilReady() error {
 	fmt.Printf("Connector %q deleted\n", cmd.name)
 	return nil
 }
+
+func (cmd *CmdConnectorDelete) InputToOptions() {}

--- a/internal/cmd/skupper/connector/kube/connector_delete_test.go
+++ b/internal/cmd/skupper/connector/kube/connector_delete_test.go
@@ -232,7 +232,7 @@ func TestCmdConnectorDelete_WaitUntilReady(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 
-			err := cmd.WaitUntilReady()
+			err := cmd.WaitUntil()
 			if test.expectError {
 				assert.Check(t, err != nil)
 			} else {

--- a/internal/cmd/skupper/connector/kube/connector_status.go
+++ b/internal/cmd/skupper/connector/kube/connector_status.go
@@ -156,3 +156,5 @@ func (cmd *CmdConnectorStatus) Run() error {
 
 	return nil
 }
+func (cmd *CmdConnectorStatus) InputToOptions()  {}
+func (cmd *CmdConnectorStatus) WaitUntil() error { return nil }

--- a/internal/cmd/skupper/connector/kube/connector_update.go
+++ b/internal/cmd/skupper/connector/kube/connector_update.go
@@ -63,7 +63,7 @@ func NewCmdConnectorUpdate() *CmdConnectorUpdate {
 			utils.HandleError(skupperCmd.Run())
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return skupperCmd.WaitUntilReady()
+			return skupperCmd.WaitUntil()
 		},
 	}
 
@@ -239,7 +239,7 @@ func (cmd *CmdConnectorUpdate) Run() error {
 	}
 }
 
-func (cmd *CmdConnectorUpdate) WaitUntilReady() error {
+func (cmd *CmdConnectorUpdate) WaitUntil() error {
 
 	// the site resource was not created
 	if cmd.newSettings.output != "" {
@@ -268,3 +268,5 @@ func (cmd *CmdConnectorUpdate) WaitUntilReady() error {
 	fmt.Printf("Connector %q is ready\n", cmd.name)
 	return nil
 }
+
+func (cmd *CmdConnectorUpdate) InputToOptions() {}

--- a/internal/cmd/skupper/connector/kube/connector_update_test.go
+++ b/internal/cmd/skupper/connector/kube/connector_update_test.go
@@ -587,7 +587,7 @@ func TestCmdConnectorUpdate_WaitUntilReady(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 
-			err := cmd.WaitUntilReady()
+			err := cmd.WaitUntil()
 			if test.expectError {
 				assert.Check(t, err != nil)
 			} else {

--- a/internal/cmd/skupper/link/link_create.go
+++ b/internal/cmd/skupper/link/link_create.go
@@ -45,4 +45,4 @@ func (cmd *CmdLinkCreate) AddFlags()                                            
 func (cmd *CmdLinkCreate) ValidateInput(args []string) []error                  { return nil }
 func (cmd *CmdLinkCreate) InputToOptions()                                      {}
 func (cmd *CmdLinkCreate) Run() error                                           { fmt.Println("Not implemented yet."); return nil }
-func (cmd *CmdLinkCreate) WaitUntilReady() error                                { return nil }
+func (cmd *CmdLinkCreate) WaitUntil() error                                     { return nil }

--- a/internal/cmd/skupper/link/link_delete.go
+++ b/internal/cmd/skupper/link/link_delete.go
@@ -45,4 +45,4 @@ func (cmd *CmdLinkDelete) AddFlags()                                            
 func (cmd *CmdLinkDelete) ValidateInput(args []string) []error                  { return nil }
 func (cmd *CmdLinkDelete) InputToOptions()                                      {}
 func (cmd *CmdLinkDelete) Run() error                                           { fmt.Println("Not implemented yet."); return nil }
-func (cmd *CmdLinkDelete) WaitUntilReady() error                                { return nil }
+func (cmd *CmdLinkDelete) WaitUntil() error                                     { return nil }

--- a/internal/cmd/skupper/link/link_get.go
+++ b/internal/cmd/skupper/link/link_get.go
@@ -45,4 +45,4 @@ func (cmd *CmdLinkGet) AddFlags()                                            {}
 func (cmd *CmdLinkGet) ValidateInput(args []string) []error                  { return nil }
 func (cmd *CmdLinkGet) InputToOptions()                                      {}
 func (cmd *CmdLinkGet) Run() error                                           { fmt.Println("Not implemented yet."); return nil }
-func (cmd *CmdLinkGet) WaitUntilReady() error                                { return nil }
+func (cmd *CmdLinkGet) WaitUntil() error                                     { return nil }

--- a/internal/cmd/skupper/listener/kube/listener_create.go
+++ b/internal/cmd/skupper/listener/kube/listener_create.go
@@ -57,7 +57,7 @@ func NewCmdListenerCreate() *CmdListenerCreate {
 			utils.HandleError(skupperCmd.Run())
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return skupperCmd.WaitUntilReady()
+			return skupperCmd.WaitUntil()
 		},
 	}
 
@@ -208,7 +208,7 @@ func (cmd *CmdListenerCreate) Run() error {
 	}
 }
 
-func (cmd *CmdListenerCreate) WaitUntilReady() error {
+func (cmd *CmdListenerCreate) WaitUntil() error {
 	// the site resource was not created
 	if cmd.output != "" {
 		return nil
@@ -236,3 +236,5 @@ func (cmd *CmdListenerCreate) WaitUntilReady() error {
 	fmt.Printf("Listener %q is ready\n", cmd.name)
 	return nil
 }
+
+func (cmd *CmdListenerCreate) InputToOptions() {}

--- a/internal/cmd/skupper/listener/kube/listener_create_test.go
+++ b/internal/cmd/skupper/listener/kube/listener_create_test.go
@@ -794,7 +794,7 @@ func TestCmdListenerCreate_WaitUntilReady(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 
-			err := cmd.WaitUntilReady()
+			err := cmd.WaitUntil()
 			if test.expectError {
 				assert.Check(t, err != nil)
 			} else {

--- a/internal/cmd/skupper/listener/kube/listener_delete.go
+++ b/internal/cmd/skupper/listener/kube/listener_delete.go
@@ -45,7 +45,7 @@ func NewCmdListenerDelete() *CmdListenerDelete {
 			utils.HandleError(skupperCmd.Run())
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return skupperCmd.WaitUntilReady()
+			return skupperCmd.WaitUntil()
 		},
 	}
 	skupperCmd.CobraCmd = cmd
@@ -107,7 +107,7 @@ func (cmd *CmdListenerDelete) Run() error {
 	return err
 }
 
-func (cmd *CmdListenerDelete) WaitUntilReady() error {
+func (cmd *CmdListenerDelete) WaitUntil() error {
 	waitTime := int(cmd.flags.timeout.Seconds())
 	err := utils.NewSpinnerWithTimeout("Waiting for deletion to complete...", waitTime, func() error {
 
@@ -126,3 +126,5 @@ func (cmd *CmdListenerDelete) WaitUntilReady() error {
 	fmt.Printf("Listener %q deleted\n", cmd.name)
 	return nil
 }
+
+func (cmd *CmdListenerDelete) InputToOptions() {}

--- a/internal/cmd/skupper/listener/kube/listener_delete_test.go
+++ b/internal/cmd/skupper/listener/kube/listener_delete_test.go
@@ -255,7 +255,7 @@ func TestCmdListenerDelete_WaitUntilReady(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 
-			err := cmd.WaitUntilReady()
+			err := cmd.WaitUntil()
 			if test.expectError {
 				assert.Check(t, err != nil)
 			} else {

--- a/internal/cmd/skupper/listener/kube/listener_status.go
+++ b/internal/cmd/skupper/listener/kube/listener_status.go
@@ -156,3 +156,6 @@ func (cmd *CmdListenerStatus) Run() error {
 
 	return nil
 }
+
+func (cmd *CmdListenerStatus) InputToOptions()  {}
+func (cmd *CmdListenerStatus) WaitUntil() error { return nil }

--- a/internal/cmd/skupper/listener/kube/listener_update.go
+++ b/internal/cmd/skupper/listener/kube/listener_update.go
@@ -58,7 +58,7 @@ func NewCmdListenerUpdate() *CmdListenerUpdate {
 			utils.HandleError(skupperCmd.Run())
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return skupperCmd.WaitUntilReady()
+			return skupperCmd.WaitUntil()
 		},
 	}
 
@@ -208,7 +208,7 @@ func (cmd *CmdListenerUpdate) Run() error {
 	}
 }
 
-func (cmd *CmdListenerUpdate) WaitUntilReady() error {
+func (cmd *CmdListenerUpdate) WaitUntil() error {
 
 	// the site resource was not created
 	if cmd.newSettings.output != "" {
@@ -237,3 +237,5 @@ func (cmd *CmdListenerUpdate) WaitUntilReady() error {
 	fmt.Printf("Listener %q is ready\n", cmd.name)
 	return nil
 }
+
+func (cmd *CmdListenerUpdate) InputToOptions() {}

--- a/internal/cmd/skupper/listener/kube/listener_update_test.go
+++ b/internal/cmd/skupper/listener/kube/listener_update_test.go
@@ -519,7 +519,7 @@ func TestCmdListenerUpdate_WaitUntilReady(t *testing.T) {
 		cmd.newSettings.output = cmd.flags.output
 
 		t.Run(test.name, func(t *testing.T) {
-			err := cmd.WaitUntilReady()
+			err := cmd.WaitUntil()
 			if test.expectError {
 				assert.Check(t, err != nil)
 			} else {

--- a/internal/cmd/skupper/root/root.go
+++ b/internal/cmd/skupper/root/root.go
@@ -16,7 +16,7 @@ type SkupperCommand interface {
 	ValidateInput(args []string) []error
 	InputToOptions()
 	Run() error
-	WaitUntilReady() error
+	WaitUntil() error
 }
 
 var SelectedNamespace string

--- a/internal/cmd/skupper/site/kube/site_create.go
+++ b/internal/cmd/skupper/site/kube/site_create.go
@@ -60,7 +60,7 @@ func NewCmdSiteCreate() *CmdSiteCreate {
 			utils.HandleError(skupperCmd.Run())
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return skupperCmd.WaitUntilReady()
+			return skupperCmd.WaitUntil()
 		},
 	}
 
@@ -196,7 +196,7 @@ func (cmd *CmdSiteCreate) Run() error {
 
 }
 
-func (cmd *CmdSiteCreate) WaitUntilReady() error {
+func (cmd *CmdSiteCreate) WaitUntil() error {
 
 	// the site resource was not created
 	if cmd.output != "" {

--- a/internal/cmd/skupper/site/kube/site_create_test.go
+++ b/internal/cmd/skupper/site/kube/site_create_test.go
@@ -423,7 +423,7 @@ func TestCmdSiteCreate_WaitUntilReady(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 
-			err := command.WaitUntilReady()
+			err := command.WaitUntil()
 
 			if test.expectError {
 				assert.Check(t, err != nil)

--- a/internal/cmd/skupper/site/kube/site_delete.go
+++ b/internal/cmd/skupper/site/kube/site_delete.go
@@ -37,7 +37,7 @@ func NewCmdSiteDelete() *CmdSiteDelete {
 			utils.HandleError(skupperCmd.Run())
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return skupperCmd.WaitUntilReady()
+			return skupperCmd.WaitUntil()
 		},
 	}
 
@@ -99,7 +99,7 @@ func (cmd *CmdSiteDelete) Run() error {
 	err := cmd.Client.Sites(cmd.Namespace).Delete(context.TODO(), cmd.siteName, metav1.DeleteOptions{})
 	return err
 }
-func (cmd *CmdSiteDelete) WaitUntilReady() error {
+func (cmd *CmdSiteDelete) WaitUntil() error {
 	err := utils.NewSpinner("Waiting for deletion to complete...", 5, func() error {
 
 		resource, err := cmd.Client.Sites(cmd.Namespace).Get(context.TODO(), cmd.siteName, metav1.GetOptions{})

--- a/internal/cmd/skupper/site/kube/site_delete_test.go
+++ b/internal/cmd/skupper/site/kube/site_delete_test.go
@@ -347,7 +347,7 @@ func TestCmdSiteDelete_WaitUntilReady(t *testing.T) {
 		command.siteName = "my-site"
 		t.Run(test.name, func(t *testing.T) {
 
-			err := command.WaitUntilReady()
+			err := command.WaitUntil()
 			if err != nil {
 				assert.Check(t, test.expectError)
 			}

--- a/internal/cmd/skupper/site/kube/site_status.go
+++ b/internal/cmd/skupper/site/kube/site_status.go
@@ -87,4 +87,4 @@ func (cmd *CmdSiteStatus) Run() error {
 	writer.Flush()
 	return nil
 }
-func (cmd *CmdSiteStatus) WaitUntilReady() error { return nil }
+func (cmd *CmdSiteStatus) WaitUntil() error { return nil }

--- a/internal/cmd/skupper/site/kube/site_status_test.go
+++ b/internal/cmd/skupper/site/kube/site_status_test.go
@@ -147,7 +147,7 @@ func TestCmdSiteStatus_WaitUntilReady(t *testing.T) {
 		assert.Assert(t, err)
 		command.Client = fakeSkupperClient.GetSkupperClient().SkupperV1alpha1()
 
-		result := command.WaitUntilReady()
+		result := command.WaitUntil()
 		assert.Check(t, result == nil)
 
 	})

--- a/internal/cmd/skupper/site/kube/site_update.go
+++ b/internal/cmd/skupper/site/kube/site_update.go
@@ -55,7 +55,7 @@ func NewCmdSiteUpdate() *CmdSiteUpdate {
 			utils.HandleError(skupperCmd.Run())
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return skupperCmd.WaitUntilReady()
+			return skupperCmd.WaitUntil()
 		},
 	}
 
@@ -222,7 +222,7 @@ func (cmd *CmdSiteUpdate) Run() error {
 	}
 }
 
-func (cmd *CmdSiteUpdate) WaitUntilReady() error {
+func (cmd *CmdSiteUpdate) WaitUntil() error {
 
 	// the site resource was not updated
 	if cmd.output != "" {

--- a/internal/cmd/skupper/site/kube/site_update_test.go
+++ b/internal/cmd/skupper/site/kube/site_update_test.go
@@ -607,7 +607,7 @@ func TestCmdSiteUpdate_WaitUntilReady(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 
-			err := command.WaitUntilReady()
+			err := command.WaitUntil()
 			if err != nil {
 				assert.Check(t, test.expectError)
 				assert.Check(t, test.errorMessage == err.Error())

--- a/internal/cmd/skupper/token/kube/token_issue.go
+++ b/internal/cmd/skupper/token/kube/token_issue.go
@@ -53,7 +53,7 @@ func NewCmdTokenIssue() *CmdTokenIssue {
 			utils.HandleError(skupperCmd.Run())
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return skupperCmd.WaitUntilReady()
+			return skupperCmd.WaitUntil()
 		},
 	}
 
@@ -164,7 +164,7 @@ func (cmd *CmdTokenIssue) Run() error {
 
 }
 
-func (cmd *CmdTokenIssue) WaitUntilReady() error {
+func (cmd *CmdTokenIssue) WaitUntil() error {
 	err := utils.NewSpinnerWithTimeout("Waiting for token status ...", int(cmd.flags.timeout.Seconds()), func() error {
 
 		token, err := cmd.client.AccessGrants(cmd.namespace).Get(context.TODO(), cmd.grantName, metav1.GetOptions{})
@@ -202,3 +202,5 @@ func (cmd *CmdTokenIssue) WaitUntilReady() error {
 	fmt.Printf("\nThe token expires after %d use(s) or after %s.\n", cmd.flags.redemptions, cmd.flags.expiration.String())
 	return nil
 }
+
+func (cmd *CmdTokenIssue) InputToOptions() {}

--- a/internal/cmd/skupper/token/kube/token_issue_test.go
+++ b/internal/cmd/skupper/token/kube/token_issue_test.go
@@ -725,7 +725,7 @@ func TestCmdTokenIssue_WaitUntilReady(t *testing.T) {
 		cmd.namespace = "test"
 
 		t.Run(test.name, func(t *testing.T) {
-			err := cmd.WaitUntilReady()
+			err := cmd.WaitUntil()
 			if test.expectError {
 				assert.Check(t, err != nil)
 			} else {

--- a/internal/cmd/skupper/token/kube/token_redeem.go
+++ b/internal/cmd/skupper/token/kube/token_redeem.go
@@ -50,7 +50,7 @@ func NewCmdTokenRedeem() *CmdTokenRedeem {
 			utils.HandleError(skupperCmd.Run())
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
-			return skupperCmd.WaitUntilReady()
+			return skupperCmd.WaitUntil()
 		},
 	}
 
@@ -153,7 +153,7 @@ func (cmd *CmdTokenRedeem) Run() error {
 	return err
 }
 
-func (cmd *CmdTokenRedeem) WaitUntilReady() error {
+func (cmd *CmdTokenRedeem) WaitUntil() error {
 
 	err := utils.NewSpinnerWithTimeout("Waiting for token status ...", int(cmd.flags.timeout.Seconds()), func() error {
 
@@ -177,3 +177,5 @@ func (cmd *CmdTokenRedeem) WaitUntilReady() error {
 	fmt.Printf("You can now safely delete %s\n", cmd.fileName)
 	return nil
 }
+
+func (cmd *CmdTokenRedeem) InputToOptions() {}

--- a/internal/cmd/skupper/token/kube/token_redeem_test.go
+++ b/internal/cmd/skupper/token/kube/token_redeem_test.go
@@ -426,7 +426,7 @@ func TestCmdTokenRedeem_WaitUntilReady(t *testing.T) {
 		cmd.namespace = "test"
 
 		t.Run(test.name, func(t *testing.T) {
-			err := cmd.WaitUntilReady()
+			err := cmd.WaitUntil()
 			if test.expectError {
 				assert.Check(t, err != nil)
 			} else {


### PR DESCRIPTION
- rename WaitUntilReady() to WaintUntil()
- added missing implementations on commands that should implement `SkupperCommand` interface.