### PR TITLE
Fix image-pull test when not using :main tag

### DIFF
--- a/client/podman/container_test.go
+++ b/client/podman/container_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -116,7 +117,8 @@ func TestContainer(t *testing.T) {
 	// Pulling image
 	t.Run("image-pull", func(t *testing.T) {
 		assert.Assert(t, cli.ImagePull(ctx, image))
-		invalidImage := strings.Replace(images.GetSiteControllerImageName(), ":main", ":invalid", 1)
+		tagOrDig := regexp.MustCompile("(@.*$|:[-a-zA-Z_.]*$|$)")
+		invalidImage := tagOrDig.ReplaceAllString(images.GetSiteControllerImageName(), ":") + "invalid"
 		invalidImageErr := cli.ImagePull(ctx, invalidImage)
 		assert.Assert(t, invalidImageErr != nil)
 		assert.Assert(t, strings.Contains(invalidImageErr.Error(), "Recommendation:"))

--- a/client/podman/container_test.go
+++ b/client/podman/container_test.go
@@ -117,7 +117,7 @@ func TestContainer(t *testing.T) {
 	// Pulling image
 	t.Run("image-pull", func(t *testing.T) {
 		assert.Assert(t, cli.ImagePull(ctx, image))
-		tagOrDig := regexp.MustCompile("(@.*$|:[-a-zA-Z_.]*$|$)")
+		tagOrDig := regexp.MustCompile("(@.*$|:[-a-zA-Z0-9_.]*$|$)")
 		invalidImage := tagOrDig.ReplaceAllString(images.GetSiteControllerImageName(), ":") + "invalid"
 		invalidImageErr := cli.ImagePull(ctx, invalidImage)
 		assert.Assert(t, invalidImageErr != nil)


### PR DESCRIPTION
The test was creating an invalid image name by replacing `:main` by `:invalid`.  However, if the image was not using `:main` in the first place, nothing was replaced, and the generated name still pointed to a valid image.