### PR TITLE
Revert 1596

### DIFF
--- a/internal/cmd/skupper/connector/kube/connector_create_test.go
+++ b/internal/cmd/skupper/connector/kube/connector_create_test.go
@@ -910,7 +910,6 @@ func TestCmdConnectorCreate_WaitUntil(t *testing.T) {
 	}
 
 	for _, test := range testTable {
-		test := test
 		cmd, err := newCmdConnectorCreateWithMocks("test", test.k8sObjects, test.skupperObjects, test.skupperErrorMessage)
 		assert.Assert(t, err)
 
@@ -920,7 +919,6 @@ func TestCmdConnectorCreate_WaitUntil(t *testing.T) {
 		cmd.namespace = "test"
 
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 
 			err := cmd.WaitUntil()
 			if test.expectError {

--- a/internal/cmd/skupper/connector/kube/connector_update_test.go
+++ b/internal/cmd/skupper/connector/kube/connector_update_test.go
@@ -574,7 +574,6 @@ func TestCmdConnectorUpdate_WaitUntil(t *testing.T) {
 	}
 
 	for _, test := range testTable {
-		test := test
 		cmd, err := newCmdConnectorUpdateWithMocks("test", test.k8sObjects, test.skupperObjects, test.skupperErrorMessage)
 		assert.Assert(t, err)
 
@@ -587,7 +586,7 @@ func TestCmdConnectorUpdate_WaitUntil(t *testing.T) {
 		cmd.newSettings.output = cmd.flags.output
 
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
+
 			err := cmd.WaitUntil()
 			if test.expectError {
 				assert.Check(t, err != nil)

--- a/internal/cmd/skupper/link/kube/link_delete_test.go
+++ b/internal/cmd/skupper/link/kube/link_delete_test.go
@@ -2,8 +2,6 @@ package kube
 
 import (
 	"fmt"
-	"testing"
-
 	"github.com/skupperproject/skupper/internal/cmd/skupper/utils"
 	fakeclient "github.com/skupperproject/skupper/internal/kube/client/fake"
 	"github.com/skupperproject/skupper/pkg/apis/skupper/v1alpha1"
@@ -11,6 +9,7 @@ import (
 	"gotest.tools/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"testing"
 )
 
 func TestCmdLinkDelete_NewCmdLinkDelete(t *testing.T) {
@@ -369,13 +368,12 @@ func TestCmdLinkDelete_WaitUntil(t *testing.T) {
 	}
 
 	for _, test := range testTable {
-		test := test
 		cmd, err := newCmdLinkDeleteWithMocks("test", nil, test.skupperObjects, "")
 		assert.Assert(t, err)
 		cmd.linkName = "my-link"
 		cmd.timeout = test.timeout
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
+
 			err := cmd.WaitUntil()
 			if err != nil {
 				assert.Check(t, test.expectError)

--- a/internal/cmd/skupper/link/kube/link_generate_test.go
+++ b/internal/cmd/skupper/link/kube/link_generate_test.go
@@ -2,8 +2,6 @@ package kube
 
 import (
 	"fmt"
-	"testing"
-
 	"github.com/skupperproject/skupper/internal/cmd/skupper/utils"
 	fakeclient "github.com/skupperproject/skupper/internal/kube/client/fake"
 	"github.com/skupperproject/skupper/pkg/apis/skupper/v1alpha1"
@@ -13,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"testing"
 )
 
 func TestCmdLinkGenerate_NewCmdLinkGenerate(t *testing.T) {
@@ -952,12 +951,11 @@ func TestCmdLinkGenerate_WaitUntil(t *testing.T) {
 	}
 
 	for _, test := range testTable {
-		test := test
 		command, err := newCmdLinkGenerateWithMocks("test", test.k8sObjects, test.skupperObjects, test.skupperError)
 		assert.Assert(t, err)
 
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
+
 			command.output = test.outputType
 			command.generateCredential = test.generateCredential
 			command.tlsSecret = test.tlsSecret

--- a/internal/cmd/skupper/link/kube/link_update_test.go
+++ b/internal/cmd/skupper/link/kube/link_update_test.go
@@ -2,8 +2,6 @@ package kube
 
 import (
 	"fmt"
-	"testing"
-
 	"github.com/skupperproject/skupper/internal/cmd/skupper/utils"
 	fakeclient "github.com/skupperproject/skupper/internal/kube/client/fake"
 	"github.com/skupperproject/skupper/pkg/apis/skupper/v1alpha1"
@@ -12,6 +10,7 @@ import (
 	v12 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"testing"
 )
 
 func TestCmdLinkUpdate_NewCmdLinkUpdate(t *testing.T) {
@@ -608,7 +607,6 @@ func TestCmdLinkUpdate_WaitUntil(t *testing.T) {
 	}
 
 	for _, test := range testTable {
-		test := test
 		cmd, err := newCmdLinkUpdateWithMocks("test", test.k8sObjects, test.skupperObjects, test.skupperErrorMessage)
 		assert.Assert(t, err)
 		cmd.linkName = test.linkName
@@ -616,7 +614,7 @@ func TestCmdLinkUpdate_WaitUntil(t *testing.T) {
 		cmd.timeout = test.timeout
 
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
+
 			err := cmd.WaitUntil()
 
 			if test.expectError {

--- a/internal/cmd/skupper/listener/kube/listener_create_test.go
+++ b/internal/cmd/skupper/listener/kube/listener_create_test.go
@@ -780,7 +780,6 @@ func TestCmdListenerCreate_WaitUntil(t *testing.T) {
 	}
 
 	for _, test := range testTable {
-		test := test
 		cmd, err := newCmdListenerCreateWithMocks("test", test.k8sObjects, test.skupperObjects, test.skupperErrorMessage)
 		assert.Assert(t, err)
 
@@ -794,7 +793,6 @@ func TestCmdListenerCreate_WaitUntil(t *testing.T) {
 		cmd.namespace = "test"
 
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 
 			err := cmd.WaitUntil()
 			if test.expectError {

--- a/internal/cmd/skupper/listener/kube/listener_update_test.go
+++ b/internal/cmd/skupper/listener/kube/listener_update_test.go
@@ -507,7 +507,6 @@ func TestCmdListenerUpdate_WaitUntil(t *testing.T) {
 	}
 
 	for _, test := range testTable {
-		test := test
 		cmd, err := newCmdListenerUpdateWithMocks("test", test.k8sObjects, test.skupperObjects, test.skupperErrorMessage)
 		assert.Assert(t, err)
 
@@ -520,7 +519,6 @@ func TestCmdListenerUpdate_WaitUntil(t *testing.T) {
 		cmd.newSettings.output = cmd.flags.output
 
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			err := cmd.WaitUntil()
 			if test.expectError {
 				assert.Check(t, err != nil)

--- a/internal/cmd/skupper/site/kube/site_create_test.go
+++ b/internal/cmd/skupper/site/kube/site_create_test.go
@@ -2,7 +2,6 @@ package kube
 
 import (
 	"fmt"
-
 	"github.com/skupperproject/skupper/internal/cmd/skupper/utils"
 
 	"testing"
@@ -421,7 +420,6 @@ func TestCmdSiteCreate_WaitUntil(t *testing.T) {
 	}
 
 	for _, test := range testTable {
-		test := test
 		command := &CmdSiteCreate{
 			Namespace: "test",
 		}
@@ -433,7 +431,6 @@ func TestCmdSiteCreate_WaitUntil(t *testing.T) {
 		command.output = test.output
 
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 
 			err := command.WaitUntil()
 

--- a/internal/cmd/skupper/site/kube/site_delete_test.go
+++ b/internal/cmd/skupper/site/kube/site_delete_test.go
@@ -355,7 +355,6 @@ func TestCmdSiteDelete_WaitUntil(t *testing.T) {
 	}
 
 	for _, test := range testTable {
-		test := test
 		command := &CmdSiteDelete{
 			Namespace: "test",
 		}
@@ -365,7 +364,7 @@ func TestCmdSiteDelete_WaitUntil(t *testing.T) {
 		command.Client = fakeSkupperClient.GetSkupperClient().SkupperV1alpha1()
 		command.siteName = "my-site"
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
+
 			err := command.WaitUntil()
 			if err != nil {
 				assert.Check(t, test.expectError)

--- a/internal/cmd/skupper/site/kube/site_update_test.go
+++ b/internal/cmd/skupper/site/kube/site_update_test.go
@@ -596,7 +596,6 @@ func TestCmdSiteUpdate_WaitUntil(t *testing.T) {
 	}
 
 	for _, test := range testTable {
-		test := test
 		command := &CmdSiteUpdate{
 			Namespace: "test",
 		}
@@ -607,7 +606,6 @@ func TestCmdSiteUpdate_WaitUntil(t *testing.T) {
 		command.siteName = test.siteName
 
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 
 			err := command.WaitUntil()
 			if err != nil {

--- a/internal/cmd/skupper/token/kube/token_issue_test.go
+++ b/internal/cmd/skupper/token/kube/token_issue_test.go
@@ -712,7 +712,6 @@ func TestCmdTokenIssue_WaitUntil(t *testing.T) {
 	}
 
 	for _, test := range testTable {
-		test := test
 		cmd, err := newCmdTokenIssueWithMocks("test", test.k8sObjects, test.skupperObjects, test.skupperErrorMessage)
 		assert.Assert(t, err)
 
@@ -726,7 +725,6 @@ func TestCmdTokenIssue_WaitUntil(t *testing.T) {
 		cmd.namespace = "test"
 
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			err := cmd.WaitUntil()
 			if test.expectError {
 				assert.Check(t, err != nil)

--- a/internal/cmd/skupper/token/kube/token_redeem_test.go
+++ b/internal/cmd/skupper/token/kube/token_redeem_test.go
@@ -417,7 +417,6 @@ func TestCmdTokenRedeem_WaitUntil(t *testing.T) {
 	}
 
 	for _, test := range testTable {
-		test := test
 		cmd, err := newCmdTokenRedeemWithMocks("test", test.k8sObjects, test.skupperObjects, test.skupperErrorMessage)
 		assert.Assert(t, err)
 
@@ -427,7 +426,6 @@ func TestCmdTokenRedeem_WaitUntil(t *testing.T) {
 		cmd.namespace = "test"
 
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			err := cmd.WaitUntil()
 			if test.expectError {
 				assert.Check(t, err != nil)

--- a/pkg/utils/retry_test.go
+++ b/pkg/utils/retry_test.go
@@ -253,21 +253,21 @@ type TestTryUntilItem struct {
 func TestTryUntil(t *testing.T) {
 	testTable := []TestTryUntilItem{
 		{
-			workOnSecond:  100 * time.Millisecond,
+			workOnSecond:  time.Second,
 			funcError:     nil,
 			funcValue:     []string{"first", "second", "third"},
-			maxDuration:   500 * time.Millisecond,
+			maxDuration:   5 * time.Second,
 			expectTimeout: false,
 		},
 		{
-			workOnSecond:  400 * time.Millisecond,
+			workOnSecond:  4 * time.Second,
 			funcError:     nil,
 			funcValue:     5,
-			maxDuration:   1000 * time.Millisecond,
+			maxDuration:   5 * time.Second,
 			expectTimeout: false,
 		},
 		{
-			workOnSecond:  100 * time.Millisecond,
+			workOnSecond:  time.Second,
 			funcError:     fmt.Errorf("function is not working"),
 			funcValue:     nil,
 			maxDuration:   5 * time.Second,
@@ -277,7 +277,7 @@ func TestTryUntil(t *testing.T) {
 			workOnSecond:  30 * time.Second,
 			funcError:     nil,
 			funcValue:     nil,
-			maxDuration:   500 * time.Millisecond,
+			maxDuration:   5 * time.Second,
 			expectTimeout: true,
 		},
 	}
@@ -285,9 +285,8 @@ func TestTryUntil(t *testing.T) {
 	for _, item := range testTable {
 		name := fmt.Sprintf("workOnSecond: %v maxDuration: %v expectTimeout: %v",
 			item.workOnSecond, item.maxDuration, item.expectTimeout)
-		item := item
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
+
 			resp, err := TryUntil(item.maxDuration, func() Result {
 				time.Sleep(item.workOnSecond)
 				return Result{
@@ -328,31 +327,31 @@ func TestRetryErrorWithContext(t *testing.T) {
 	testTable := []TestRetryErrorWithContextItem{
 		{
 			doc:           "The execution should work at the first try",
-			timeout:       time.Millisecond * 200,
+			timeout:       time.Second * 2,
 			workOnTry:     1,
 			expectedTries: 1,
 			expectSuccess: true,
 		}, {
 			doc:           "The execution should work at the second try",
-			timeout:       time.Millisecond * 300,
+			timeout:       time.Second * 3,
 			workOnTry:     2,
 			expectedTries: 2,
 			expectSuccess: true,
 		}, {
 			doc:           "The execution should work after many tries",
-			timeout:       time.Millisecond * 500,
+			timeout:       time.Second * 5,
 			workOnTry:     4,
 			expectedTries: 4,
 			expectSuccess: true,
 		}, {
 			doc:           "The execution should time out after one retry due the context",
-			timeout:       time.Millisecond * 100,
+			timeout:       time.Second,
 			workOnTry:     5,
 			expectedTries: 1,
 			expectSuccess: false,
 		}, {
 			doc:           "The execution should time out after many retries due the context",
-			timeout:       time.Millisecond * 400,
+			timeout:       time.Second * 4,
 			workOnTry:     5,
 			expectedTries: 4,
 			expectSuccess: false,
@@ -360,10 +359,8 @@ func TestRetryErrorWithContext(t *testing.T) {
 	}
 
 	for _, item := range testTable {
-		item := item
 
 		t.Run(item.doc, func(t *testing.T) {
-			t.Parallel()
 			var currentTry int
 
 			ctx, cancel := context.WithTimeout(context.Background(), item.timeout)
@@ -371,7 +368,7 @@ func TestRetryErrorWithContext(t *testing.T) {
 
 			start := time.Now()
 
-			resp := RetryErrorWithContext(ctx, 100*time.Millisecond, func() (err error) {
+			resp := RetryErrorWithContext(ctx, time.Second, func() (err error) {
 				currentTry++
 				if currentTry == item.workOnTry {
 					return nil

--- a/pkg/utils/retry_test.go
+++ b/pkg/utils/retry_test.go
@@ -253,21 +253,21 @@ type TestTryUntilItem struct {
 func TestTryUntil(t *testing.T) {
 	testTable := []TestTryUntilItem{
 		{
-			workOnSecond:  time.Second,
+			workOnSecond:  100 * time.Millisecond,
 			funcError:     nil,
 			funcValue:     []string{"first", "second", "third"},
-			maxDuration:   5 * time.Second,
+			maxDuration:   500 * time.Millisecond,
 			expectTimeout: false,
 		},
 		{
-			workOnSecond:  4 * time.Second,
+			workOnSecond:  400 * time.Millisecond,
 			funcError:     nil,
 			funcValue:     5,
-			maxDuration:   5 * time.Second,
+			maxDuration:   1000 * time.Millisecond,
 			expectTimeout: false,
 		},
 		{
-			workOnSecond:  time.Second,
+			workOnSecond:  100 * time.Millisecond,
 			funcError:     fmt.Errorf("function is not working"),
 			funcValue:     nil,
 			maxDuration:   5 * time.Second,
@@ -277,7 +277,7 @@ func TestTryUntil(t *testing.T) {
 			workOnSecond:  30 * time.Second,
 			funcError:     nil,
 			funcValue:     nil,
-			maxDuration:   5 * time.Second,
+			maxDuration:   500 * time.Millisecond,
 			expectTimeout: true,
 		},
 	}
@@ -285,8 +285,9 @@ func TestTryUntil(t *testing.T) {
 	for _, item := range testTable {
 		name := fmt.Sprintf("workOnSecond: %v maxDuration: %v expectTimeout: %v",
 			item.workOnSecond, item.maxDuration, item.expectTimeout)
+		item := item
 		t.Run(name, func(t *testing.T) {
-
+			t.Parallel()
 			resp, err := TryUntil(item.maxDuration, func() Result {
 				time.Sleep(item.workOnSecond)
 				return Result{
@@ -327,31 +328,31 @@ func TestRetryErrorWithContext(t *testing.T) {
 	testTable := []TestRetryErrorWithContextItem{
 		{
 			doc:           "The execution should work at the first try",
-			timeout:       time.Second * 2,
+			timeout:       time.Millisecond * 200,
 			workOnTry:     1,
 			expectedTries: 1,
 			expectSuccess: true,
 		}, {
 			doc:           "The execution should work at the second try",
-			timeout:       time.Second * 3,
+			timeout:       time.Millisecond * 300,
 			workOnTry:     2,
 			expectedTries: 2,
 			expectSuccess: true,
 		}, {
 			doc:           "The execution should work after many tries",
-			timeout:       time.Second * 5,
+			timeout:       time.Millisecond * 500,
 			workOnTry:     4,
 			expectedTries: 4,
 			expectSuccess: true,
 		}, {
 			doc:           "The execution should time out after one retry due the context",
-			timeout:       time.Second,
+			timeout:       time.Millisecond * 100,
 			workOnTry:     5,
 			expectedTries: 1,
 			expectSuccess: false,
 		}, {
 			doc:           "The execution should time out after many retries due the context",
-			timeout:       time.Second * 4,
+			timeout:       time.Millisecond * 400,
 			workOnTry:     5,
 			expectedTries: 4,
 			expectSuccess: false,
@@ -359,8 +360,10 @@ func TestRetryErrorWithContext(t *testing.T) {
 	}
 
 	for _, item := range testTable {
+		item := item
 
 		t.Run(item.doc, func(t *testing.T) {
+			t.Parallel()
 			var currentTry int
 
 			ctx, cancel := context.WithTimeout(context.Background(), item.timeout)
@@ -368,7 +371,7 @@ func TestRetryErrorWithContext(t *testing.T) {
 
 			start := time.Now()
 
-			resp := RetryErrorWithContext(ctx, time.Second, func() (err error) {
+			resp := RetryErrorWithContext(ctx, 100*time.Millisecond, func() (err error) {
 				currentTry++
 				if currentTry == item.workOnTry {
 					return nil


### PR DESCRIPTION
Whoops. Rolling back part of this one after witnessing `TestCmdListenerCreate_WaitUntil/listener_is_ready` flapping in CI.

I suspect there may just be some sort of race here that parallel execution could be exacerbating.