### PR TITLE
Update the collector to stop errant DNS Lookups

### DIFF
--- a/pkg/flow/flow_mem_driver.go
+++ b/pkg/flow/flow_mem_driver.go
@@ -2538,12 +2538,7 @@ func (fc *FlowCollector) reconcileConnectorRecords() error {
 				siteId := fc.getRecordSiteId(*connector)
 				var matchHost *string
 				found := false
-				if net.ParseIP(*connector.DestHost) == nil {
-					addrs, err := net.LookupHost(*connector.DestHost)
-					if err == nil && len(addrs) > 0 {
-						matchHost = &addrs[0]
-					}
-				} else {
+				if net.ParseIP(*connector.DestHost) != nil {
 					matchHost = connector.DestHost
 				}
 				for _, process := range fc.Processes {


### PR DESCRIPTION
The collector attempts to resolve a connector's destination to a process record by IP. When the connector is configured with a hostname instead of an IP it should NOT attempt to resolve the hostname to an IP, as there is no guarantee that the collector is running with an identical network environment to the router with the connector in question.

This may impact niche cases. ~~The most likely may be where a collector is running local to a podman site with podman containers exposed by hostname.~~ EDIT: I still think this code path could be in use, but the collector will fallback on other (more sensible) means in the case of podman containers exposed by name.