### PR TITLE
[v2] The CLI exits with success on an unknown command

### DIFF
--- a/internal/cmd/skupper/utils/handle_error.go
+++ b/internal/cmd/skupper/utils/handle_error.go
@@ -8,7 +8,7 @@ import (
 func HandleError(err error) {
 	if err != nil {
 		fmt.Println(err)
-		syscall.Exit(0)
+		syscall.Exit(1)
 	}
 }
 
@@ -18,7 +18,7 @@ func HandleErrorList(errList []error) {
 			fmt.Println(err)
 		}
 
-		syscall.Exit(0)
+		syscall.Exit(2)
 	}
 }
 

--- a/internal/cmd/skupper/utils/handle_error.go
+++ b/internal/cmd/skupper/utils/handle_error.go
@@ -5,10 +5,15 @@ import (
 	"syscall"
 )
 
+const (
+	GenericError    = 1
+	ValidationError = 2
+)
+
 func HandleError(err error) {
 	if err != nil {
 		fmt.Println(err)
-		syscall.Exit(1)
+		syscall.Exit(GenericError)
 	}
 }
 
@@ -18,7 +23,7 @@ func HandleErrorList(errList []error) {
 			fmt.Println(err)
 		}
 
-		syscall.Exit(2)
+		syscall.Exit(ValidationError)
 	}
 }
 


### PR DESCRIPTION
**Description of the issue**

```
~/code/skupper-example-hello-world$ skupper init
Error: unknown command "init" for "skupper"
Run 'skupper --help' for usage.
unknown command "init" for "skupper"

~/code/skupper-example-hello-world$ echo $?
0 
```
It should instead exit with an error code.

**Description of the solution**
When handling an error by default the exit command will be `1`.
When handling command validation errors the exit command will be `2`.

Fixes: #1498 