### PR TITLE
Include Version in kube/flow's SiteRecord

### DIFF
--- a/cmd/config-sync/collector.go
+++ b/cmd/config-sync/collector.go
@@ -15,6 +15,7 @@ import (
 	kubeflow "github.com/skupperproject/skupper/pkg/kube/flow"
 	"github.com/skupperproject/skupper/pkg/vanflow"
 	"github.com/skupperproject/skupper/pkg/vanflow/session"
+	"github.com/skupperproject/skupper/pkg/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1informer "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -85,6 +86,7 @@ func startFlowController(ctx context.Context, cli *internalclient.KubeClient) er
 			Name:       &siteName,
 			Namespace:  &cli.Namespace,
 			Platform:   &platform,
+			Version:    &version.Version,
 		},
 	})
 	go informer.Run(ctx.Done())

--- a/pkg/kube/flow/process.go
+++ b/pkg/kube/flow/process.go
@@ -26,7 +26,7 @@ func asProcessRecord(pod *corev1.Pod) vanflow.ProcessRecord {
 	process.Hostname = &pod.Spec.NodeName
 	if labelName, ok := pod.ObjectMeta.Labels["app.kubernetes.io/part-of"]; ok {
 		process.Group = &labelName
-		if labelName == "skupper" {
+		if labelName == "skupper" || labelName == "skupper-network-console" {
 			process.Mode = &modeInternal
 		}
 	} else if labelComponent, ok := pod.ObjectMeta.Labels["app.kubernetes.io/name"]; ok {


### PR DESCRIPTION
This is needed in the network console. It was previously set in the v1 collector-lite but was missed in the migration.