### PR TITLE
Avoid hiding the cursor when displaying a spinner

### DIFF
--- a/client/router_create.go
+++ b/client/router_create.go
@@ -1386,7 +1386,7 @@ sasldb_path: /tmp/skrouterd.sasldb
 						waitingFor = "Waiting for LoadBalancer IP or hostname..."
 					}
 
-					spin = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+					spin = spinner.New(spinner.CharSets[9], 100*time.Millisecond, spinner.WithHiddenCursor(false))
 					spin.Prefix = waitingFor
 					spin.FinalMSG = waitingFor + "\n"
 				}
@@ -1575,7 +1575,7 @@ func (cli *VanClient) appendLoadBalancerHostOrIp(ctx context.Context, serviceNam
 
 	ctx, _ = getCurrentContextOrDefault(ctx)
 	deadlineExceeded := false
-	spin := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	spin := spinner.New(spinner.CharSets[9], 100*time.Millisecond, spinner.WithHiddenCursor(false))
 
 	message := "Waiting for LoadBalancer IP or hostname..."
 	spin.Prefix = message

--- a/pkg/utils/spinner.go
+++ b/pkg/utils/spinner.go
@@ -1,13 +1,14 @@
 package utils
 
 import (
-	"github.com/briandowns/spinner"
 	"time"
+
+	"github.com/briandowns/spinner"
 )
 
 func NewSpinner(message string, maxRetries int, function func() error) error {
 
-	spin := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	spin := spinner.New(spinner.CharSets[9], 100*time.Millisecond, spinner.WithHiddenCursor(false))
 	spin.Prefix = message
 	spin.FinalMSG = message + "\n"
 


### PR DESCRIPTION
This ensures the cursor is still visible if the skupper command is interrupted.

Fixes: #1585