### PR TITLE
fix client cleanup panic

### DIFF
--- a/pkg/vanflow/eventsource/client.go
+++ b/pkg/vanflow/eventsource/client.go
@@ -48,15 +48,7 @@ func NewClient(container session.Container, cfg ClientOptions) *Client {
 			slog.String("instance", cfg.Source.ID),
 		),
 	}
-	c.start()
 	return c
-}
-
-func (c *Client) start() {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	done := make(chan struct{})
-	c.cleanup = append(c.cleanup, func() { close(done) })
 }
 
 type HeartbeatMessageHandler func(vanflow.HeartbeatMessage)

--- a/pkg/vanflow/eventsource/client_test.go
+++ b/pkg/vanflow/eventsource/client_test.go
@@ -87,6 +87,15 @@ func TestClient(t *testing.T) {
 		t.Error("expected client.Close() to promptly return")
 	}
 
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("client.Close() should be safe to call multiple times but paniced: %v", r)
+			}
+		}()
+		client.Close()
+	}()
+
 	msg, err := record.Encode()
 	assert.Check(t, err)
 	sender.Send(tstCtx, msg)


### PR DESCRIPTION
Fixes https://github.com/skupperproject/skupper/issues/1628

Removes some effectively dead code left over from an iteration of development that was the root cause of a panic (closing a closed channel.)