### PR TITLE
Make config-sync exit on lost leader election

### DIFF
--- a/cmd/config-sync/collector.go
+++ b/cmd/config-sync/collector.go
@@ -101,60 +101,44 @@ func startFlowController(ctx context.Context, cli *internalclient.KubeClient) er
 	return nil
 }
 
-func runLeaderElection(lock *resourcelock.ConfigMapLock, ctx context.Context, id string, cli *internalclient.KubeClient) {
-	var (
-		leaderCtx context.Context
-		cancel    context.CancelFunc = func() {}
-	)
+func runLeaderElection(lock *resourcelock.ConfigMapLock, id string, cli *internalclient.KubeClient) {
+	ctx := context.Background()
 	begin := time.Now()
 	podname, _ := os.Hostname()
-	limiter := time.NewTicker(time.Second * 15)
-	defer limiter.Stop()
-	for {
-		leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
-			Lock:            lock,
-			ReleaseOnCancel: true,
-			LeaseDuration:   15 * time.Second,
-			RenewDeadline:   10 * time.Second,
-			RetryPeriod:     2 * time.Second,
-			Callbacks: leaderelection.LeaderCallbacks{
-				OnStartedLeading: func(c context.Context) {
-					log.Printf("COLLECTOR: Leader %s starting site collection after %s\n", podname, time.Since(begin))
-					leaderCtx, cancel = context.WithCancel(ctx)
-					siteCollector(leaderCtx, cli)
-					if err := startFlowController(leaderCtx, cli); err != nil {
-						log.Printf("COLLECTOR: Failed to start controller for emitting site events: %s", err)
-					}
-				},
-				OnStoppedLeading: func() {
-					// No longer the leader, transition to inactive
-					cancel()
-					log.Printf("COLLECTOR: Lost leader after %s\n", time.Since(begin))
-				},
-				OnNewLeader: func(current_id string) {
-					if current_id == id {
-						// Remain as the leader
-						return
-					}
-					log.Printf("COLLECTOR: New leader for site collection is %s\n", current_id)
-				},
+	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		ReleaseOnCancel: true,
+		LeaseDuration:   15 * time.Second,
+		RenewDeadline:   10 * time.Second,
+		RetryPeriod:     2 * time.Second,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(c context.Context) {
+				log.Printf("COLLECTOR: Leader %s starting site collection after %s\n", podname, time.Since(begin))
+				siteCollector(ctx, cli)
+				if err := startFlowController(ctx, cli); err != nil {
+					log.Printf("COLLECTOR: Failed to start controller for emitting site events: %s", err)
+				}
 			},
-		})
-		if ctx.Err() != nil {
-			return
-		}
-		<-limiter.C
-		log.Println("COLLECTOR: retrying leader election")
-	}
+			OnStoppedLeading: func() {
+				// we held the lock but lost it. This indicates that something
+				// went wrong. Exit and restart.
+				log.Fatalf("COLLECTOR: Lost leader lock after %s", time.Since(begin))
+			},
+			OnNewLeader: func(current_id string) {
+				if current_id == id {
+					// Remain as the leader
+					return
+				}
+				log.Printf("COLLECTOR: New leader for site collection is %s\n", current_id)
+			},
+		},
+	})
 }
 
 func startCollector(cli *internalclient.KubeClient) {
 	lockname := types.SiteLeaderLockName
 	namespace := cli.Namespace
 	podname, _ := os.Hostname()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	cmLock := &resourcelock.ConfigMapLock{
 		ConfigMapMeta: metav1.ObjectMeta{
@@ -167,7 +151,7 @@ func startCollector(cli *internalclient.KubeClient) {
 		},
 	}
 
-	runLeaderElection(cmLock, ctx, podname, cli)
+	runLeaderElection(cmLock, podname, cli)
 }
 
 func deploymentName() string {

--- a/cmd/config-sync/collector.go
+++ b/cmd/config-sync/collector.go
@@ -108,6 +108,8 @@ func runLeaderElection(lock *resourcelock.ConfigMapLock, ctx context.Context, id
 	)
 	begin := time.Now()
 	podname, _ := os.Hostname()
+	limiter := time.NewTicker(time.Second * 15)
+	defer limiter.Stop()
 	for {
 		leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 			Lock:            lock,
@@ -141,6 +143,7 @@ func runLeaderElection(lock *resourcelock.ConfigMapLock, ctx context.Context, id
 		if ctx.Err() != nil {
 			return
 		}
+		<-limiter.C
 		log.Println("COLLECTOR: retrying leader election")
 	}
 }


### PR DESCRIPTION
When config-sync acquires the skupper-site-leader lock it is expected that it will continue to keep that lease active by periodically checking in. When some disruption causes that check-in to fail the k8s client-go implementation of leaderelection.RunOrDie will return and no further attempts are made to re-acquire the lock.

This change makes it so that when config-sync is running and it fails to hold the leader lease, it will restart itself so that a clean instance can attempt to reclaim the lock.