### PR TITLE
Configure slog as the controller's default logger

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -15,6 +16,11 @@ import (
 	"github.com/skupperproject/skupper/pkg/kube/grants"
 	"github.com/skupperproject/skupper/pkg/version"
 )
+
+func init() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+}
 
 func describe(i interface{}) {
 	fmt.Printf("(%v, %T)\n", i, i)


### PR DESCRIPTION
Fixes #1648

Update the v2 controller so slog is configured as the default logger.

With this change, any log.Printf calls will be issued through slog (at the info level).

Here is a snippet of the v2 controller logs:
```
$ kubectl -n skupper logs  skupper-controller-74dc9c8f86-7x5zt
time=2024-09-10T14:00:34.021Z level=INFO msg="Version: d7b1747-modified"
time=2024-09-10T14:00:34.021Z level=INFO msg="Skupper controller watching all namespaces"
time=2024-09-10T14:00:34.030Z level=INFO msg="WatchPods(skupper.io/component=router,skupper.io/type=site, )"
time=2024-09-10T14:00:34.049Z level=INFO msg="Starting informers"
time=2024-09-10T14:00:34.049Z level=INFO msg="Waiting for informer caches to sync"
I0910 14:00:35.238166       1 request.go:655] Throttling request took 1.183664367s, request: GET:https://10.96.0.1:443/apis/skupper.io/v1alpha1/securedaccesses?limit=500&resourceVersion=0
time=2024-09-10T14:00:35.250Z level=INFO msg="Checking Certificate skupper/skupper-grant-server-ca"
time=2024-09-10T14:00:35.464Z level=INFO msg="Creating secret skupper/skupper-grant-server-ca for Certificate skupper/skupper-grant-server-ca for hosts []"
time=2024-09-10T14:00:35.480Z level=INFO msg="Starting event loop"
```
