### PR TITLE
V2 Default values for listener and connector commands

### DIFF
--- a/cmd/skupper/README.md
+++ b/cmd/skupper/README.md
@@ -53,13 +53,13 @@ skupper site create site2  -n east
 # Expose backend in east site (create a connector)
 
 ```
-skupper connector create backend 8080 --routing-key backend --selector app=backend -n east
+skupper connector create backend 8080 -n east
 ```
 
 # Consume backend in west site (create a listener)
 
 ```
-skupper listener create backend 8080 --routing-key backend -n west
+skupper listener create backend 8080 -n west
 ```
 
 # Link sites

--- a/internal/cmd/skupper/site/kube/site_create.go
+++ b/internal/cmd/skupper/site/kube/site_create.go
@@ -6,6 +6,8 @@ package kube
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common/utils"
 	"github.com/skupperproject/skupper/internal/kube/client"
@@ -15,7 +17,6 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"time"
 )
 
 type CmdSiteCreate struct {


### PR DESCRIPTION
Default routing-key in listener and connector commands
Default selector in connector command

if routing-key flag is not set then set the routing-key to equal the name of the listener or connector.  If selector, host or workload are not set in the connector command default to selector to equal "app=connector-name".