### PR TITLE
Remove checking if site exists when creating connector or listener.

### DIFF
--- a/internal/cmd/skupper/connector/kube/connector_create.go
+++ b/internal/cmd/skupper/connector/kube/connector_create.go
@@ -86,16 +86,6 @@ func (cmd *CmdConnectorCreate) ValidateInput(args []string) []error {
 		}
 	}
 
-	// Validate there is already a site defined in the namespace before a connector can be created
-	siteList, _ := cmd.client.Sites(cmd.namespace).List(context.TODO(), metav1.ListOptions{})
-	if siteList == nil || len(siteList.Items) == 0 {
-		validationErrors = append(validationErrors, fmt.Errorf("A site must exist in namespace %s before a connector can be created", cmd.namespace))
-	} else {
-		if !utils.SiteConfigured(siteList) {
-			validationErrors = append(validationErrors, fmt.Errorf("there is no active skupper site in this namespace"))
-		}
-	}
-
 	// Validate if there is already a Connector with this name in the namespace
 	if cmd.name != "" {
 		connector, err := cmd.client.Connectors(cmd.namespace).Get(context.TODO(), cmd.name, metav1.GetOptions{})

--- a/internal/cmd/skupper/connector/kube/connector_create_test.go
+++ b/internal/cmd/skupper/connector/kube/connector_create_test.go
@@ -43,7 +43,7 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 						Port:     8080,
 						Type:     "tcp",
 						Host:     "test",
-						Selector: "mySelector",
+						Selector: "app=mySelector",
 					},
 					Status: v1alpha1.ConnectorStatus{
 						Status: v1alpha1.Status{
@@ -56,58 +56,8 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 						},
 					},
 				},
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 			expectedErrors: []string{"there is already a connector my-connector created for namespace test"},
-		},
-		{
-			name: "connector no site",
-			args: []string{"connector-site", "8090"},
-			flags: common.CommandConnectorCreateFlags{
-				Host:    "127.0.0.1",
-				Timeout: 1 * time.Minute,
-			},
-			expectedErrors: []string{"A site must exist in namespace test before a connector can be created"},
-		},
-		{
-			name: "Connector no site with ok status",
-			args: []string{"connector-site", "8090"},
-			flags: common.CommandConnectorCreateFlags{
-				Timeout:  1 * time.Minute,
-				Selector: "backend",
-			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-						},
-					},
-				},
-			},
-			expectedErrors: []string{"there is no active skupper site in this namespace"},
 		},
 		{
 			name: "connector name and port are not specified",
@@ -115,28 +65,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 			flags: common.CommandConnectorCreateFlags{
 				Selector: "backend",
 				Timeout:  1 * time.Minute,
-			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 			expectedErrors: []string{"connector name and port must be configured"},
 		},
@@ -147,28 +75,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 				Selector: "backend",
 				Timeout:  1 * time.Minute,
 			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			expectedErrors: []string{"connector name must not be empty"},
 		},
 		{
@@ -177,28 +83,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 			flags: common.CommandConnectorCreateFlags{
 				Selector: "backend",
 				Timeout:  1 * time.Minute,
-			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 			expectedErrors: []string{"connector port must not be empty"},
 		},
@@ -209,28 +93,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 				Selector: "backend",
 				Timeout:  1 * time.Minute,
 			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			expectedErrors: []string{"connector port is not valid: value is not positive"},
 		},
 		{
@@ -239,28 +101,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 			flags: common.CommandConnectorCreateFlags{
 				Selector: "backend",
 				Timeout:  1 * time.Minute,
-			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 			expectedErrors: []string{"connector name and port must be configured"},
 		},
@@ -271,28 +111,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 				Selector: "backend",
 				Timeout:  1 * time.Minute,
 			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			expectedErrors: []string{"connector name and port must be configured"},
 		},
 		{
@@ -301,28 +119,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 			flags: common.CommandConnectorCreateFlags{
 				Selector: "backend",
 				Timeout:  1 * time.Minute,
-			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 			expectedErrors: []string{"only two arguments are allowed for this command"},
 		},
@@ -333,28 +129,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 				Selector: "backend",
 				Timeout:  1 * time.Minute,
 			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			expectedErrors: []string{"connector name is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$"},
 		},
 		{
@@ -363,28 +137,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 			flags: common.CommandConnectorCreateFlags{
 				Selector: "backend",
 				Timeout:  1 * time.Minute,
-			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 			expectedErrors: []string{"connector port is not valid: strconv.Atoi: parsing \"abcd\": invalid syntax"},
 		},
@@ -395,28 +147,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 				ConnectorType: "not-valid",
 				Timeout:       1 * time.Minute,
 				Selector:      "backend",
-			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 			expectedErrors: []string{
 				"connector type is not valid: value not-valid not allowed. It should be one of this options: [tcp]"},
@@ -429,28 +159,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 				Timeout:    1 * time.Minute,
 				Selector:   "backend",
 			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			expectedErrors: []string{
 				"routing key is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$"},
 		},
@@ -462,28 +170,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 				Timeout:   1 * time.Minute,
 				Selector:  "backend",
 			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			expectedErrors: []string{"tls-secret is not valid: does not exist"},
 		},
 		{
@@ -492,28 +178,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 			flags: common.CommandConnectorCreateFlags{
 				Workload: "@345",
 				Timeout:  1 * time.Minute,
-			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 			expectedErrors: []string{
 				"workload is not valid: value does not match this regular expression: ^[A-Za-z0-9=:./-]+$"},
@@ -525,28 +189,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 				Selector: "@#$%",
 				Timeout:  20 * time.Second,
 			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			expectedErrors: []string{
 				"selector is not valid: value does not match this regular expression: ^[A-Za-z0-9=:./-]+$"},
 		},
@@ -557,28 +199,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 				Workload: "workload",
 				Timeout:  0 * time.Second,
 			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			expectedErrors: []string{"timeout is not valid"},
 		},
 		{
@@ -588,28 +208,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 				Workload: "workload",
 				Timeout:  1 * time.Second,
 				Output:   "not-supported",
-			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 			expectedErrors: []string{
 				"output type is not valid: value not-supported not allowed. It should be one of this options: [json yaml]"},
@@ -623,28 +221,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 				Selector: "app=test",
 				Host:     "test",
 			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			expectedErrors: []string{
 				"If host is configured, cannot configure workload or selector",
 				"If selector is configured, cannot configure workload or host"},
@@ -657,28 +233,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 				Output:   "json",
 				Workload: "deployment/test",
 				Host:     "test",
-			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 			expectedErrors: []string{
 				"If host is configured, cannot configure workload or selector",
@@ -694,28 +248,6 @@ func TestCmdConnectorCreate_ValidateInput(t *testing.T) {
 				IncludeNotReady: true,
 				Timeout:         30 * time.Second,
 				Output:          "json",
-			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 			k8sObjects: []runtime.Object{
 				&v12.Secret{

--- a/internal/cmd/skupper/listener/kube/listener_create.go
+++ b/internal/cmd/skupper/listener/kube/listener_create.go
@@ -84,16 +84,6 @@ func (cmd *CmdListenerCreate) ValidateInput(args []string) []error {
 		}
 	}
 
-	// Validate there is already a site defined in the namespace before a listener can be created
-	siteList, _ := cmd.client.Sites(cmd.namespace).List(context.TODO(), metav1.ListOptions{})
-	if siteList == nil || len(siteList.Items) < 1 {
-		validationErrors = append(validationErrors, fmt.Errorf("A site must exist in namespace %s before a listener can be created", cmd.namespace))
-	} else {
-		if !utils.SiteConfigured(siteList) {
-			validationErrors = append(validationErrors, fmt.Errorf("there is no active skupper site in this namespace"))
-		}
-	}
-
 	// Validate if there is already a listener with this name in the namespace
 	if cmd.name != "" {
 		listener, err := cmd.client.Listeners(cmd.namespace).Get(context.TODO(), cmd.name, metav1.GetOptions{})

--- a/internal/cmd/skupper/listener/kube/listener_create_test.go
+++ b/internal/cmd/skupper/listener/kube/listener_create_test.go
@@ -32,26 +32,6 @@ func TestCmdListenerCreate_ValidateInput(t *testing.T) {
 			args:  []string{"my-listener", "8080"},
 			flags: common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
 			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 				&v1alpha1.Listener{
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "my-listener",
@@ -74,256 +54,51 @@ func TestCmdListenerCreate_ValidateInput(t *testing.T) {
 				"there is already a listener my-listener created for namespace test"},
 		},
 		{
-			name:           "listener no site",
-			args:           []string{"listener-site", "8090"},
+			name:           "listener name and port are not specified",
+			args:           []string{},
 			flags:          common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
-			expectedErrors: []string{"A site must exist in namespace test before a listener can be created"},
-		},
-		{
-			name:  "listener no site with ok status",
-			args:  []string{"listener-site", "8090"},
-			flags: common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									StatusMessage: "",
-								},
-							},
-						},
-					},
-				},
-			},
-			expectedErrors: []string{"there is no active skupper site in this namespace"},
-		},
-		{
-			name:  "listener name and port are not specified",
-			args:  []string{},
-			flags: common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			expectedErrors: []string{"listener name and port must be configured"},
 		},
 		{
-			name:  "listener name empty",
-			args:  []string{"", "8090"},
-			flags: common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:           "listener name empty",
+			args:           []string{"", "8090"},
+			flags:          common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
 			expectedErrors: []string{"listener name must not be empty"},
 		},
 		{
-			name:  "listener port empty",
-			args:  []string{"my-name-port-empty", ""},
-			flags: common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:           "listener port empty",
+			args:           []string{"my-name-port-empty", ""},
+			flags:          common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
 			expectedErrors: []string{"listener port must not be empty"},
 		},
 		{
-			name:  "listener port not positive",
-			args:  []string{"my-port-positive", "-45"},
-			flags: common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:           "listener port not positive",
+			args:           []string{"my-port-positive", "-45"},
+			flags:          common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
 			expectedErrors: []string{"listener port is not valid: value is not positive"},
 		},
 		{
-			name:  "listener name and port are not specified",
-			args:  []string{},
-			flags: common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:           "listener name and port are not specified",
+			args:           []string{},
+			flags:          common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
 			expectedErrors: []string{"listener name and port must be configured"},
 		},
 		{
-			name:  "listener port is not specified",
-			args:  []string{"my-name"},
-			flags: common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:           "listener port is not specified",
+			args:           []string{"my-name"},
+			flags:          common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
 			expectedErrors: []string{"listener name and port must be configured"},
 		},
 		{
-			name:  "more than two arguments are specified",
-			args:  []string{"my", "listener", "8080"},
-			flags: common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:           "more than two arguments are specified",
+			args:           []string{"my", "listener", "8080"},
+			flags:          common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
 			expectedErrors: []string{"only two arguments are allowed for this command"},
 		},
 		{
 			name:  "listener name is not valid.",
 			args:  []string{"my new listener", "8080"},
 			flags: common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			expectedErrors: []string{
 				"listener name is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$"},
 		},
@@ -331,28 +106,6 @@ func TestCmdListenerCreate_ValidateInput(t *testing.T) {
 			name:  "port is not valid.",
 			args:  []string{"my-listener-port", "abcd"},
 			flags: common.CommandListenerCreateFlags{Timeout: 1 * time.Minute},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			expectedErrors: []string{
 				"listener port is not valid: strconv.Atoi: parsing \"abcd\": invalid syntax"},
 		},
@@ -362,28 +115,6 @@ func TestCmdListenerCreate_ValidateInput(t *testing.T) {
 			flags: common.CommandListenerCreateFlags{
 				Timeout:      1 * time.Minute,
 				ListenerType: "not-valid",
-			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 			expectedErrors: []string{
 				"listener type is not valid: value not-valid not allowed. It should be one of this options: [tcp]"},
@@ -395,28 +126,6 @@ func TestCmdListenerCreate_ValidateInput(t *testing.T) {
 				Timeout:    60 * time.Second,
 				RoutingKey: "not-valid$",
 			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			expectedErrors: []string{
 				"routing key is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$"},
 		},
@@ -427,56 +136,12 @@ func TestCmdListenerCreate_ValidateInput(t *testing.T) {
 				Timeout:   1 * time.Minute,
 				TlsSecret: "not-valid",
 			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			expectedErrors: []string{"tls-secret is not valid: does not exist"},
 		},
 		{
-			name:  "timeout is not valid",
-			args:  []string{"bad-timeout", "8080"},
-			flags: common.CommandListenerCreateFlags{Timeout: 0 * time.Second},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			name:           "timeout is not valid",
+			args:           []string{"bad-timeout", "8080"},
+			flags:          common.CommandListenerCreateFlags{Timeout: 0 * time.Second},
 			expectedErrors: []string{"timeout is not valid"},
 		},
 		{
@@ -485,28 +150,6 @@ func TestCmdListenerCreate_ValidateInput(t *testing.T) {
 			flags: common.CommandListenerCreateFlags{
 				Timeout: 30 * time.Second,
 				Output:  "not-supported",
-			},
-			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 			expectedErrors: []string{
 				"output type is not valid: value not-supported not allowed. It should be one of this options: [json yaml]"},
@@ -523,26 +166,6 @@ func TestCmdListenerCreate_ValidateInput(t *testing.T) {
 				Output:       "json",
 			},
 			skupperObjects: []runtime.Object{
-				&v1alpha1.SiteList{
-					Items: []v1alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v1alpha1.SiteStatus{
-								Status: v1alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 				&v1alpha1.Listener{
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "my-listener",


### PR DESCRIPTION
We were checking that the site existed before allowing connectors and listeners to be configured.
It was decided to change this behavior and allow the connector or listener to be created without
a site existing. 