### PR TITLE
Add support for connector workload flag

### DIFF
--- a/internal/cmd/skupper/common/constants.go
+++ b/internal/cmd/skupper/common/constants.go
@@ -5,4 +5,5 @@ var (
 	OutputTypes     = []string{"json", "yaml"}
 	ListenerTypes   = []string{"tcp"}
 	ConnectorTypes  = []string{"tcp"}
+	WorkloadTypes   = []string{"deployment", "service", "daemonset", "statefulset"}
 )

--- a/internal/cmd/skupper/connector/kube/connector_create.go
+++ b/internal/cmd/skupper/connector/kube/connector_create.go
@@ -12,7 +12,6 @@ import (
 	"github.com/skupperproject/skupper/internal/kube/client"
 	"github.com/skupperproject/skupper/pkg/apis/skupper/v1alpha1"
 	skupperv1alpha1 "github.com/skupperproject/skupper/pkg/generated/client/clientset/versioned/typed/skupper/v1alpha1"
-	"github.com/skupperproject/skupper/pkg/kube"
 	pkgUtils "github.com/skupperproject/skupper/pkg/utils"
 	"github.com/skupperproject/skupper/pkg/utils/validator"
 	"github.com/spf13/cobra"
@@ -145,7 +144,7 @@ func (cmd *CmdConnectorCreate) ValidateInput(args []string) []error {
 		} else {
 			switch resourceType {
 			case "deployment":
-				deployment, err := kube.GetDeployment(resourceName, cmd.namespace, cmd.KubeClient)
+				deployment, err := cmd.KubeClient.AppsV1().Deployments(cmd.namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
 				if err != nil {
 					validationErrors = append(validationErrors, fmt.Errorf("failed trying to get Deployment specified by workload: %s", err))
 				} else {
@@ -167,7 +166,7 @@ func (cmd *CmdConnectorCreate) ValidateInput(args []string) []error {
 					}
 				}
 			case "daemonset":
-				daemonSet, err := kube.GetDaemonSet(resourceName, cmd.namespace, cmd.KubeClient)
+				daemonSet, err := cmd.KubeClient.AppsV1().DaemonSets(cmd.namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
 				if err != nil {
 					validationErrors = append(validationErrors, fmt.Errorf("failed trying to get DaemonSet specified by workload: %s", err))
 				} else {
@@ -178,7 +177,7 @@ func (cmd *CmdConnectorCreate) ValidateInput(args []string) []error {
 					}
 				}
 			case "statefulset":
-				statefulSet, err := kube.GetStatefulSet(resourceName, cmd.namespace, cmd.KubeClient)
+				statefulSet, err := cmd.KubeClient.AppsV1().StatefulSets(cmd.namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
 				if err != nil {
 					validationErrors = append(validationErrors, fmt.Errorf("failed trying to get StatefulSet specified by workload: %s", err))
 				} else {

--- a/internal/cmd/skupper/connector/kube/connector_create.go
+++ b/internal/cmd/skupper/connector/kube/connector_create.go
@@ -12,6 +12,8 @@ import (
 	"github.com/skupperproject/skupper/internal/kube/client"
 	"github.com/skupperproject/skupper/pkg/apis/skupper/v1alpha1"
 	skupperv1alpha1 "github.com/skupperproject/skupper/pkg/generated/client/clientset/versioned/typed/skupper/v1alpha1"
+	"github.com/skupperproject/skupper/pkg/kube"
+	pkgUtils "github.com/skupperproject/skupper/pkg/utils"
 	"github.com/skupperproject/skupper/pkg/utils/validator"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -57,8 +59,9 @@ func (cmd *CmdConnectorCreate) ValidateInput(args []string) []error {
 	numberValidator := validator.NewNumberValidator()
 	connectorTypeValidator := validator.NewOptionValidator(common.ConnectorTypes)
 	outputTypeValidator := validator.NewOptionValidator(common.OutputTypes)
-	workloadStringValidator := validator.NewWorkloadStringValidator()
 	timeoutValidator := validator.NewTimeoutInSecondsValidator()
+	workloadStringValidator := validator.NewWorkloadStringValidator(common.WorkloadTypes)
+	selectorStringValidator := validator.NewSelectorStringValidator()
 
 	// Validate arguments name and port
 	if len(args) < 2 {
@@ -94,7 +97,6 @@ func (cmd *CmdConnectorCreate) ValidateInput(args []string) []error {
 			validationErrors = append(validationErrors, fmt.Errorf("there is already a connector %s created for namespace %s", cmd.name, cmd.namespace))
 		}
 	}
-
 	// Validate flags
 	if cmd.Flags != nil && cmd.Flags.RoutingKey != "" {
 		ok, err := resourceStringValidator.Evaluate(cmd.Flags.RoutingKey)
@@ -126,18 +128,67 @@ func (cmd *CmdConnectorCreate) ValidateInput(args []string) []error {
 		if cmd.Flags.Workload != "" || cmd.Flags.Host != "" {
 			validationErrors = append(validationErrors, fmt.Errorf("If selector is configured, cannot configure workload or host"))
 		}
-		ok, err := workloadStringValidator.Evaluate(cmd.Flags.Selector)
+		ok, err := selectorStringValidator.Evaluate(cmd.Flags.Selector)
 		if !ok {
 			validationErrors = append(validationErrors, fmt.Errorf("selector is not valid: %s", err))
 		}
+		cmd.selector = cmd.Flags.Selector
 	}
 	if cmd.Flags != nil && cmd.Flags.Workload != "" {
 		if cmd.Flags.Selector != "" || cmd.Flags.Host != "" {
 			validationErrors = append(validationErrors, fmt.Errorf("If workload is configured, cannot configure selector or host"))
 		}
-		ok, err := workloadStringValidator.Evaluate(cmd.Flags.Workload)
+		//workload get resource-type/resource-name and find selector labels
+		resourceType, resourceName, ok, err := workloadStringValidator.Evaluate(cmd.Flags.Workload)
 		if !ok {
 			validationErrors = append(validationErrors, fmt.Errorf("workload is not valid: %s", err))
+		} else {
+			switch resourceType {
+			case "deployment":
+				deployment, err := kube.GetDeployment(resourceName, cmd.namespace, cmd.KubeClient)
+				if err != nil {
+					validationErrors = append(validationErrors, fmt.Errorf("failed trying to get Deployment specified by workload: %s", err))
+				} else {
+					if deployment.Spec.Selector.MatchLabels != nil {
+						cmd.selector = pkgUtils.StringifySelector(deployment.Spec.Selector.MatchLabels)
+					} else {
+						validationErrors = append(validationErrors, fmt.Errorf("workload, no selector Matchlabels found"))
+					}
+				}
+			case "service":
+				service, err := cmd.KubeClient.CoreV1().Services(cmd.namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
+				if err != nil {
+					validationErrors = append(validationErrors, fmt.Errorf("failed trying to get Service specified by workload: %s", err))
+				} else {
+					if service.Spec.Selector != nil {
+						cmd.selector = pkgUtils.StringifySelector(service.Spec.Selector)
+					} else {
+						validationErrors = append(validationErrors, fmt.Errorf("workload, no selector labels found"))
+					}
+				}
+			case "daemonset":
+				daemonSet, err := kube.GetDaemonSet(resourceName, cmd.namespace, cmd.KubeClient)
+				if err != nil {
+					validationErrors = append(validationErrors, fmt.Errorf("failed trying to get DaemonSet specified by workload: %s", err))
+				} else {
+					if daemonSet.Spec.Selector.MatchLabels != nil {
+						cmd.selector = pkgUtils.StringifySelector(daemonSet.Spec.Selector.MatchLabels)
+					} else {
+						validationErrors = append(validationErrors, fmt.Errorf("workload, no selector Matchlabels found"))
+					}
+				}
+			case "statefulset":
+				statefulSet, err := kube.GetStatefulSet(resourceName, cmd.namespace, cmd.KubeClient)
+				if err != nil {
+					validationErrors = append(validationErrors, fmt.Errorf("failed trying to get StatefulSet specified by workload: %s", err))
+				} else {
+					if statefulSet.Spec.Selector.MatchLabels != nil {
+						cmd.selector = pkgUtils.StringifySelector(statefulSet.Spec.Selector.MatchLabels)
+					} else {
+						validationErrors = append(validationErrors, fmt.Errorf("workload, no selector Matchlabels found"))
+					}
+				}
+			}
 		}
 	}
 	//TBD what is valid timeout

--- a/internal/cmd/skupper/connector/kube/connector_create_test.go
+++ b/internal/cmd/skupper/connector/kube/connector_create_test.go
@@ -404,14 +404,13 @@ func TestCmdConnectorCreate_ValidateWorkload(t *testing.T) {
 					},
 					Spec: v12.ServiceSpec{
 						Selector: map[string]string{
-							"app":  "backend",
-							"test": "test2",
+							"app": "backend",
 						},
 					},
 				},
 			},
 			expectedErrors:   []string{},
-			expectedSelector: "app=backend,test=test2",
+			expectedSelector: "app=backend",
 		},
 		{
 			name: "workload-no-daemonset",

--- a/internal/cmd/skupper/connector/kube/connector_update.go
+++ b/internal/cmd/skupper/connector/kube/connector_update.go
@@ -11,7 +11,6 @@ import (
 	"github.com/skupperproject/skupper/internal/kube/client"
 	"github.com/skupperproject/skupper/pkg/apis/skupper/v1alpha1"
 	skupperv1alpha1 "github.com/skupperproject/skupper/pkg/generated/client/clientset/versioned/typed/skupper/v1alpha1"
-	"github.com/skupperproject/skupper/pkg/kube"
 	pkgUtils "github.com/skupperproject/skupper/pkg/utils"
 	"github.com/skupperproject/skupper/pkg/utils/validator"
 	"github.com/spf13/cobra"
@@ -99,6 +98,7 @@ func (cmd *CmdConnectorUpdate) ValidateInput(args []string) []error {
 			cmd.newSettings.tlsSecret = connector.Spec.TlsCredentials
 			cmd.newSettings.connectorType = connector.Spec.Type
 			cmd.newSettings.includeNotReady = connector.Spec.IncludeNotReady
+			cmd.newSettings.routingKey = connector.Spec.RoutingKey
 
 			cmd.existingHost = connector.Spec.Host
 			cmd.existingSelector = connector.Spec.Selector
@@ -163,7 +163,7 @@ func (cmd *CmdConnectorUpdate) ValidateInput(args []string) []error {
 		} else {
 			switch resourceType {
 			case "deployment":
-				deployment, err := kube.GetDeployment(resourceName, cmd.namespace, cmd.KubeClient)
+				deployment, err := cmd.KubeClient.AppsV1().Deployments(cmd.namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
 				if err != nil {
 					validationErrors = append(validationErrors, fmt.Errorf("failed trying to get Deployment specified by workload: %s", err))
 				} else {
@@ -185,7 +185,7 @@ func (cmd *CmdConnectorUpdate) ValidateInput(args []string) []error {
 					}
 				}
 			case "daemonset":
-				daemonSet, err := kube.GetDaemonSet(resourceName, cmd.namespace, cmd.KubeClient)
+				daemonSet, err := cmd.KubeClient.AppsV1().DaemonSets(cmd.namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
 				if err != nil {
 					validationErrors = append(validationErrors, fmt.Errorf("failed trying to get DaemonSet specified by workload: %s", err))
 				} else {
@@ -196,7 +196,7 @@ func (cmd *CmdConnectorUpdate) ValidateInput(args []string) []error {
 					}
 				}
 			case "statefulset":
-				statefulSet, err := kube.GetStatefulSet(resourceName, cmd.namespace, cmd.KubeClient)
+				statefulSet, err := cmd.KubeClient.AppsV1().StatefulSets(cmd.namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
 				if err != nil {
 					validationErrors = append(validationErrors, fmt.Errorf("failed trying to get StatefulSet specified by workload: %s", err))
 				} else {
@@ -236,7 +236,6 @@ func (cmd *CmdConnectorUpdate) ValidateInput(args []string) []error {
 			cmd.newSettings.output = cmd.Flags.Output
 		}
 	}
-
 	return validationErrors
 }
 

--- a/internal/cmd/skupper/connector/kube/connector_update.go
+++ b/internal/cmd/skupper/connector/kube/connector_update.go
@@ -11,6 +11,8 @@ import (
 	"github.com/skupperproject/skupper/internal/kube/client"
 	"github.com/skupperproject/skupper/pkg/apis/skupper/v1alpha1"
 	skupperv1alpha1 "github.com/skupperproject/skupper/pkg/generated/client/clientset/versioned/typed/skupper/v1alpha1"
+	"github.com/skupperproject/skupper/pkg/kube"
+	pkgUtils "github.com/skupperproject/skupper/pkg/utils"
 	"github.com/skupperproject/skupper/pkg/utils/validator"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -32,14 +34,16 @@ type ConnectorUpdates struct {
 }
 
 type CmdConnectorUpdate struct {
-	client          skupperv1alpha1.SkupperV1alpha1Interface
-	CobraCmd        *cobra.Command
-	Flags           *common.CommandConnectorUpdateFlags
-	namespace       string
-	name            string
-	resourceVersion string
-	newSettings     ConnectorUpdates
-	KubeClient      kubernetes.Interface
+	client           skupperv1alpha1.SkupperV1alpha1Interface
+	CobraCmd         *cobra.Command
+	Flags            *common.CommandConnectorUpdateFlags
+	namespace        string
+	name             string
+	resourceVersion  string
+	newSettings      ConnectorUpdates
+	existingHost     string
+	existingSelector string
+	KubeClient       kubernetes.Interface
 }
 
 func NewCmdConnectorUpdate() *CmdConnectorUpdate {
@@ -63,8 +67,9 @@ func (cmd *CmdConnectorUpdate) ValidateInput(args []string) []error {
 	numberValidator := validator.NewNumberValidator()
 	connectorTypeValidator := validator.NewOptionValidator(common.ConnectorTypes)
 	outputTypeValidator := validator.NewOptionValidator(common.OutputTypes)
-	workloadStringValidator := validator.NewWorkloadStringValidator()
 	timeoutValidator := validator.NewTimeoutInSecondsValidator()
+	workloadStringValidator := validator.NewWorkloadStringValidator(common.WorkloadTypes)
+	selectorStringValidator := validator.NewSelectorStringValidator()
 
 	// Validate arguments name
 	if len(args) < 1 {
@@ -90,12 +95,13 @@ func (cmd *CmdConnectorUpdate) ValidateInput(args []string) []error {
 		} else {
 			// save existing values
 			cmd.resourceVersion = connector.ResourceVersion
-			cmd.newSettings.host = connector.Spec.Host
 			cmd.newSettings.port = connector.Spec.Port
 			cmd.newSettings.tlsSecret = connector.Spec.TlsCredentials
 			cmd.newSettings.connectorType = connector.Spec.Type
-			cmd.newSettings.selector = connector.Spec.Selector
 			cmd.newSettings.includeNotReady = connector.Spec.IncludeNotReady
+
+			cmd.existingHost = connector.Spec.Host
+			cmd.existingSelector = connector.Spec.Selector
 		}
 	}
 
@@ -143,33 +149,83 @@ func (cmd *CmdConnectorUpdate) ValidateInput(args []string) []error {
 		cmd.newSettings.host = cmd.Flags.Host
 	}
 	if cmd.Flags != nil && cmd.Flags.Selector != "" {
-		ok, err := workloadStringValidator.Evaluate(cmd.Flags.Selector)
+		ok, err := selectorStringValidator.Evaluate(cmd.Flags.Selector)
 		if !ok {
 			validationErrors = append(validationErrors, fmt.Errorf("selector is not valid: %s", err))
 		}
 		cmd.newSettings.selector = cmd.Flags.Selector
 	}
+	//workload get resource-type/resource-name and find selector labels
 	if cmd.Flags != nil && cmd.Flags.Workload != "" {
-		ok, err := workloadStringValidator.Evaluate(cmd.Flags.Workload)
+		resourceType, resourceName, ok, err := workloadStringValidator.Evaluate(cmd.Flags.Workload)
 		if !ok {
 			validationErrors = append(validationErrors, fmt.Errorf("workload is not valid: %s", err))
+		} else {
+			switch resourceType {
+			case "deployment":
+				deployment, err := kube.GetDeployment(resourceName, cmd.namespace, cmd.KubeClient)
+				if err != nil {
+					validationErrors = append(validationErrors, fmt.Errorf("failed trying to get Deployment specified by workload: %s", err))
+				} else {
+					if deployment.Spec.Selector.MatchLabels != nil {
+						cmd.newSettings.workload = pkgUtils.StringifySelector(deployment.Spec.Selector.MatchLabels)
+					} else {
+						validationErrors = append(validationErrors, fmt.Errorf("workload, no selector Matchlabels found"))
+					}
+				}
+			case "service":
+				service, err := cmd.KubeClient.CoreV1().Services(cmd.namespace).Get(context.TODO(), resourceName, metav1.GetOptions{})
+				if err != nil {
+					validationErrors = append(validationErrors, fmt.Errorf("failed trying to get Service specified by workload: %s", err))
+				} else {
+					if service.Spec.Selector != nil {
+						cmd.newSettings.workload = pkgUtils.StringifySelector(service.Spec.Selector)
+					} else {
+						validationErrors = append(validationErrors, fmt.Errorf("workload, no selector labels found"))
+					}
+				}
+			case "daemonset":
+				daemonSet, err := kube.GetDaemonSet(resourceName, cmd.namespace, cmd.KubeClient)
+				if err != nil {
+					validationErrors = append(validationErrors, fmt.Errorf("failed trying to get DaemonSet specified by workload: %s", err))
+				} else {
+					if daemonSet.Spec.Selector.MatchLabels != nil {
+						cmd.newSettings.workload = pkgUtils.StringifySelector(daemonSet.Spec.Selector.MatchLabels)
+					} else {
+						validationErrors = append(validationErrors, fmt.Errorf("workload, no selector Matchlabels found"))
+					}
+				}
+			case "statefulset":
+				statefulSet, err := kube.GetStatefulSet(resourceName, cmd.namespace, cmd.KubeClient)
+				if err != nil {
+					validationErrors = append(validationErrors, fmt.Errorf("failed trying to get StatefulSet specified by workload: %s", err))
+				} else {
+					if statefulSet.Spec.Selector.MatchLabels != nil {
+						cmd.newSettings.workload = pkgUtils.StringifySelector(statefulSet.Spec.Selector.MatchLabels)
+					} else {
+						validationErrors = append(validationErrors, fmt.Errorf("workload, no selector Matchlabels found"))
+					}
+				}
+			}
 		}
-		cmd.newSettings.workload = cmd.Flags.Workload
 	}
 	//Can only have one workload/Selector/host set
-	if cmd.Flags != nil && cmd.newSettings.host != "" {
-		if cmd.newSettings.workload != "" || cmd.newSettings.selector != "" {
+	if cmd.newSettings.host == "" && cmd.newSettings.selector == "" && cmd.newSettings.workload == "" {
+		// no host/selector/workload being modified use existing values
+		cmd.newSettings.selector = cmd.existingSelector
+		cmd.newSettings.host = cmd.existingHost
+	} else {
+		if cmd.newSettings.host != "" && (cmd.newSettings.workload != "" || cmd.newSettings.selector != "") {
 			validationErrors = append(validationErrors, fmt.Errorf("If host is configured, cannot configure workload or selector"))
 		}
-	}
-	if cmd.Flags != nil && cmd.newSettings.selector != "" {
-		if cmd.newSettings.host != "" || cmd.newSettings.workload != "" {
+		if cmd.newSettings.selector != "" && (cmd.newSettings.host != "" || cmd.newSettings.workload != "") {
 			validationErrors = append(validationErrors, fmt.Errorf("If selector is configured, cannot configure workload or host"))
 		}
-	}
-	if cmd.Flags != nil && cmd.newSettings.workload != "" {
-		if cmd.newSettings.selector != "" || cmd.newSettings.host != "" {
-			validationErrors = append(validationErrors, fmt.Errorf("If workload is configured, cannot configure selector or host"))
+		if cmd.newSettings.workload != "" {
+			if cmd.newSettings.selector != "" || cmd.newSettings.host != "" {
+				validationErrors = append(validationErrors, fmt.Errorf("If workload is configured, cannot configure selector or host"))
+			}
+			cmd.newSettings.selector = cmd.newSettings.workload
 		}
 	}
 	if cmd.Flags != nil && cmd.Flags.Output != "" {

--- a/pkg/kube/deployments.go
+++ b/pkg/kube/deployments.go
@@ -39,6 +39,24 @@ func GetDeployment(name string, namespace string, cli kubernetes.Interface) (*ap
 	}
 }
 
+func GetDaemonSet(name string, namespace string, cli kubernetes.Interface) (*appsv1.DaemonSet, error) {
+	existing, err := cli.AppsV1().DaemonSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	} else {
+		return existing, err
+	}
+}
+
+func GetStatefulSet(name string, namespace string, cli kubernetes.Interface) (*appsv1.StatefulSet, error) {
+	existing, err := cli.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	} else {
+		return existing, err
+	}
+}
+
 func GetContainerPort(deployment *appsv1.Deployment) map[int]int {
 	if len(deployment.Spec.Template.Spec.Containers) > 0 && len(deployment.Spec.Template.Spec.Containers[0].Ports) > 0 {
 		return GetAllContainerPorts(deployment.Spec.Template.Spec.Containers[0])

--- a/pkg/kube/deployments.go
+++ b/pkg/kube/deployments.go
@@ -39,24 +39,6 @@ func GetDeployment(name string, namespace string, cli kubernetes.Interface) (*ap
 	}
 }
 
-func GetDaemonSet(name string, namespace string, cli kubernetes.Interface) (*appsv1.DaemonSet, error) {
-	existing, err := cli.AppsV1().DaemonSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	} else {
-		return existing, err
-	}
-}
-
-func GetStatefulSet(name string, namespace string, cli kubernetes.Interface) (*appsv1.StatefulSet, error) {
-	existing, err := cli.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	} else {
-		return existing, err
-	}
-}
-
 func GetContainerPort(deployment *appsv1.Deployment) map[int]int {
 	if len(deployment.Spec.Template.Spec.Containers) > 0 && len(deployment.Spec.Template.Spec.Containers[0].Ports) > 0 {
 		return GetAllContainerPorts(deployment.Spec.Template.Spec.Containers[0])

--- a/pkg/utils/validator/simple_validator.go
+++ b/pkg/utils/validator/simple_validator.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -38,8 +39,8 @@ func NewResourceStringValidator() *StringValidator {
 	}
 }
 
-// TBD what are valid characters for workload field
-func NewWorkloadStringValidator() *StringValidator {
+// TBD what are valid characters for selector field
+func NewSelectorStringValidator() *StringValidator {
 	re, err := regexp.Compile("^[A-Za-z0-9=:./-]+$")
 	if err != nil {
 		fmt.Printf("Error compiling regex: %v", err)
@@ -168,4 +169,46 @@ func (i DurationValidator) Evaluate(value time.Duration) (bool, error) {
 	}
 
 	return true, nil
+}
+
+type WorkloadValidator struct {
+	Expression     *regexp.Regexp
+	AllowedOptions []string
+}
+
+func NewWorkloadStringValidator(validOptions []string) *WorkloadValidator {
+	re, err := regexp.Compile("^[A-Za-z0-9.-_]+$")
+	if err != nil {
+		fmt.Printf("Error compiling regex: %v", err)
+		return nil
+	}
+	return &WorkloadValidator{
+		Expression:     re,
+		AllowedOptions: validOptions,
+	}
+}
+
+func (s WorkloadValidator) Evaluate(value interface{}) (string, string, bool, error) {
+
+	v, ok := value.(string)
+
+	if !ok {
+		return "", "", false, fmt.Errorf("value is not a string")
+	}
+
+	// workload has two parts <resource-type>/<resource-name>
+	resource := strings.Split(v, "/")
+	if len(resource) != 2 {
+		return "", "", false, fmt.Errorf("workload must include <resource-type>/<resource-name>")
+	}
+
+	if s.Expression.MatchString(resource[1]) {
+		resourceType := strings.ToLower(resource[0])
+		for _, option := range s.AllowedOptions {
+			if option == resourceType {
+				return option, resource[1], true, nil
+			}
+		}
+	}
+	return "", "", false, fmt.Errorf("value does not match this regular expression: %s", s.Expression)
 }

--- a/pkg/utils/validator/simple_validator_test.go
+++ b/pkg/utils/validator/simple_validator_test.go
@@ -184,18 +184,18 @@ func TestNewResourceStringValidator_Evaluate(t *testing.T) {
 	}
 }
 
-func TestNewWorkloadStringValidator(t *testing.T) {
+func TestNewSelectorStringValidator(t *testing.T) {
 
-	t.Run("Test New Resource String Validator constructor", func(t *testing.T) {
+	t.Run("Test New Selector String Validator constructor", func(t *testing.T) {
 
 		validRegexp, _ := regexp.Compile("^[A-Za-z0-9=:./-]+$")
 		expectedResult := &StringValidator{validRegexp}
-		actualResult := NewWorkloadStringValidator()
+		actualResult := NewSelectorStringValidator()
 		assert.Assert(t, reflect.DeepEqual(actualResult, expectedResult))
 	})
 }
 
-func TestNewWorkloadStringValidator_Evaluate(t *testing.T) {
+func TestNewSelectorStringValidator_Evaluate(t *testing.T) {
 	type test struct {
 		name   string
 		value  interface{}
@@ -217,7 +217,7 @@ func TestNewWorkloadStringValidator_Evaluate(t *testing.T) {
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
-			stringValidator := NewWorkloadStringValidator()
+			stringValidator := NewSelectorStringValidator()
 			expectedResult := test.result
 			actualResult, _ := stringValidator.Evaluate(test.value)
 			assert.Assert(t, reflect.DeepEqual(actualResult, expectedResult))
@@ -262,6 +262,47 @@ func TestNewFilePathStringValidator_Evaluate(t *testing.T) {
 			stringValidator := NewFilePathStringValidator()
 			expectedResult := test.result
 			actualResult, _ := stringValidator.Evaluate(test.value)
+			assert.Assert(t, reflect.DeepEqual(actualResult, expectedResult))
+		})
+	}
+}
+
+func TestNewWorkloadStringValidator(t *testing.T) {
+
+	t.Run("Test New Workload String Validator constructor", func(t *testing.T) {
+
+		validRegexp, _ := regexp.Compile("^[A-Za-z0-9.-_]+$")
+		expectedResult := &WorkloadValidator{validRegexp, []string{"a", "b"}}
+		actualResult := NewWorkloadStringValidator([]string{"a", "b"})
+		assert.Assert(t, reflect.DeepEqual(actualResult, expectedResult))
+	})
+}
+func TestWorkloadStringValidator_Evaluate(t *testing.T) {
+	type test struct {
+		name   string
+		value  interface{}
+		result bool
+	}
+
+	testTable := []test{
+		{name: "empty string", value: "", result: false},
+		{name: "valid value", value: "a/name", result: true},
+		{name: "string without /", value: "aname", result: false},
+		{name: "string with numbers", value: "b/name123", result: true},
+		{name: "number", value: 123, result: false},
+		{name: "nil value", value: nil, result: false},
+		{name: "string without name", value: "a/", result: false},
+		{name: "string without type", value: "/name", result: false},
+		{name: "string non matching type", value: "c/name", result: false},
+		{name: "bad value", value: "a/name@#", result: false},
+	}
+
+	for _, test := range testTable {
+		t.Run(test.name, func(t *testing.T) {
+
+			stringValidator := NewWorkloadStringValidator([]string{"a", "b"})
+			expectedResult := test.result
+			_, _, actualResult, _ := stringValidator.Evaluate(test.value)
 			assert.Assert(t, reflect.DeepEqual(actualResult, expectedResult))
 		})
 	}


### PR DESCRIPTION
Look up the resource-type and resource-name in the workload flag and find deployment/service/daemonset/statefulset for proper labels and then use them as the selector to map connector to app.

fixes #1612