### PR TITLE
Update nonkube to include router Site config

### DIFF
--- a/pkg/nonkube/api/site_state.go
+++ b/pkg/nonkube/api/site_state.go
@@ -263,8 +263,7 @@ func (s *SiteState) ToRouterConfig(sslProfileBasePath string, platform string) q
 		routerName = fmt.Sprintf("%s-%d", s.Site.Name, time.Now().Unix())
 	}
 	routerConfig := qdr.InitialConfig(routerName, s.SiteId, version.Version, !s.IsInterior(), 3)
-	routerConfig.SiteConfig = qdr.SiteConfig{
-		Present:   true,
+	routerConfig.SiteConfig = &qdr.SiteConfig{
 		Name:      routerName,
 		Namespace: s.GetNamespace(),
 		Platform:  platform,

--- a/pkg/nonkube/api/site_state.go
+++ b/pkg/nonkube/api/site_state.go
@@ -254,7 +254,7 @@ func (s *SiteState) bindings() *site.Bindings {
 	return b
 }
 
-func (s *SiteState) ToRouterConfig(sslProfileBasePath string) qdr.RouterConfig {
+func (s *SiteState) ToRouterConfig(sslProfileBasePath string, platform string) qdr.RouterConfig {
 	if s.SiteId == "" {
 		s.SiteId = uuid.New().String()
 	}
@@ -263,6 +263,13 @@ func (s *SiteState) ToRouterConfig(sslProfileBasePath string) qdr.RouterConfig {
 		routerName = fmt.Sprintf("%s-%d", s.Site.Name, time.Now().Unix())
 	}
 	routerConfig := qdr.InitialConfig(routerName, s.SiteId, version.Version, !s.IsInterior(), 3)
+	routerConfig.SiteConfig = qdr.SiteConfig{
+		Present:   true,
+		Name:      routerName,
+		Namespace: s.GetNamespace(),
+		Platform:  platform,
+	}
+
 	// override metadata
 	if s.bundle {
 		routerConfig.Metadata.Id += "-{{.SiteNameSuffix}}"
@@ -273,6 +280,8 @@ func (s *SiteState) ToRouterConfig(sslProfileBasePath string) qdr.RouterConfig {
 		}
 		metadataJson, _ := encodingjson.Marshal(metadata)
 		routerConfig.Metadata.Metadata = string(metadataJson)
+		routerConfig.SiteConfig.Namespace = "{{.Namespace}}"
+		routerConfig.SiteConfig.Platform = "{{.Platform}}"
 	}
 	// LinkAccess
 	s.linkAccessMap().DesiredConfig(nil, path.Join(sslProfileBasePath, "certificates/server")).Apply(&routerConfig)

--- a/pkg/nonkube/api/site_state_test.go
+++ b/pkg/nonkube/api/site_state_test.go
@@ -116,12 +116,15 @@ func TestSiteState_ToRouterConfig(t *testing.T) {
 			assert.Assert(t, strings.HasPrefix(routerConfig.SslProfiles["local-access-one"].CaCertFile, sslProfileBasePath))
 			assert.Equal(t, len(routerConfig.Bridges.TcpListeners), 2)
 			assert.Equal(t, len(routerConfig.Bridges.TcpConnectors), 1)
-			assert.Equal(t, routerConfig.SiteConfig.Present, true)
+			assert.Assert(t, routerConfig.SiteConfig != nil)
 			expectedPlatform := "podman"
+			expectedNamespace := "default"
 			if test.bundle {
 				expectedPlatform = "{{.Platform}}"
+				expectedNamespace = "{{.Namespace}}"
 			}
 			assert.Equal(t, routerConfig.SiteConfig.Platform, expectedPlatform)
+			assert.Equal(t, routerConfig.SiteConfig.Namespace, expectedNamespace)
 
 		})
 	}

--- a/pkg/nonkube/api/site_state_test.go
+++ b/pkg/nonkube/api/site_state_test.go
@@ -94,7 +94,7 @@ func TestSiteState_ToRouterConfig(t *testing.T) {
 			ss := fakeSiteState()
 			ss.bundle = test.bundle
 			sslProfileBasePath := "${SSL_PROFILE_BASE_PATH}"
-			routerConfig := ss.ToRouterConfig(sslProfileBasePath)
+			routerConfig := ss.ToRouterConfig(sslProfileBasePath, "podman")
 			if test.bundle {
 				assert.Assert(t, strings.HasSuffix(routerConfig.Metadata.Id, "-{{.SiteNameSuffix}}"))
 				assert.Assert(t, strings.Contains(routerConfig.Metadata.Metadata, `"id":"{{.SiteId}}"`), routerConfig.Metadata.Metadata)
@@ -116,6 +116,13 @@ func TestSiteState_ToRouterConfig(t *testing.T) {
 			assert.Assert(t, strings.HasPrefix(routerConfig.SslProfiles["local-access-one"].CaCertFile, sslProfileBasePath))
 			assert.Equal(t, len(routerConfig.Bridges.TcpListeners), 2)
 			assert.Equal(t, len(routerConfig.Bridges.TcpConnectors), 1)
+			assert.Equal(t, routerConfig.SiteConfig.Present, true)
+			expectedPlatform := "podman"
+			if test.bundle {
+				expectedPlatform = "{{.Platform}}"
+			}
+			assert.Equal(t, routerConfig.SiteConfig.Platform, expectedPlatform)
+
 		})
 	}
 }

--- a/pkg/nonkube/common/fs_config_renderer.go
+++ b/pkg/nonkube/common/fs_config_renderer.go
@@ -265,7 +265,7 @@ func (c *FileSystemConfigurationRenderer) createTokens(siteState *api.SiteState)
 }
 
 func (c *FileSystemConfigurationRenderer) createRouterConfig(siteState *api.SiteState) error {
-	c.RouterConfig = siteState.ToRouterConfig(c.SslProfileBasePath)
+	c.RouterConfig = siteState.ToRouterConfig(c.SslProfileBasePath, c.Platform)
 
 	// Saving router config
 	routerConfigJson, err := qdr.MarshalRouterConfig(c.RouterConfig)

--- a/pkg/qdr/qdr.go
+++ b/pkg/qdr/qdr.go
@@ -22,7 +22,7 @@ type RouterConfig struct {
 	Connectors  map[string]Connector
 	Addresses   map[string]Address
 	LogConfig   map[string]LogConfig
-	SiteConfig  SiteConfig
+	SiteConfig  *SiteConfig
 	Bridges     BridgeConfig
 }
 
@@ -589,8 +589,6 @@ type HttpEndpoint struct {
 }
 
 type SiteConfig struct {
-	Present bool `json:"-"`
-
 	Name      string `json:"name,omitempty"`
 	Location  string `json:"location,omitempty"`
 	Provider  string `json:"provider,omitempty"`
@@ -699,12 +697,11 @@ func UnmarshalRouterConfig(config string) (RouterConfig, error) {
 			}
 			result.LogConfig[logConfig.Module] = logConfig
 		case "site":
-			var siteConfig SiteConfig
-			err = convert(element[1], &siteConfig)
+			siteConfig := &SiteConfig{}
+			err = convert(element[1], siteConfig)
 			if err != nil {
 				return result, fmt.Errorf("Invalid %s element got %#v", entityType, element[1])
 			}
-			siteConfig.Present = true
 			result.SiteConfig = siteConfig
 		case "tcpConnector":
 			connector := TcpEndpoint{}
@@ -810,10 +807,10 @@ func MarshalRouterConfig(config RouterConfig) (string, error) {
 		}
 		elements = append(elements, tuple)
 	}
-	if config.SiteConfig.Present {
+	if config.SiteConfig != nil {
 		tuple := []interface{}{
 			"site",
-			config.SiteConfig,
+			*config.SiteConfig,
 		}
 		elements = append(elements, tuple)
 	}

--- a/pkg/qdr/qdr.go
+++ b/pkg/qdr/qdr.go
@@ -22,6 +22,7 @@ type RouterConfig struct {
 	Connectors  map[string]Connector
 	Addresses   map[string]Address
 	LogConfig   map[string]LogConfig
+	SiteConfig  SiteConfig
 	Bridges     BridgeConfig
 }
 
@@ -587,6 +588,16 @@ type HttpEndpoint struct {
 	VerifyHostname  *bool  `json:"verifyHostname,omitempty"`
 }
 
+type SiteConfig struct {
+	Present bool `json:"-"`
+
+	Name      string `json:"name,omitempty"`
+	Location  string `json:"location,omitempty"`
+	Provider  string `json:"provider,omitempty"`
+	Platform  string `json:"platform,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
 func convert(from interface{}, to interface{}) error {
 	data, err := json.Marshal(from)
 	if err != nil {
@@ -687,6 +698,14 @@ func UnmarshalRouterConfig(config string) (RouterConfig, error) {
 				return result, fmt.Errorf("Invalid %s element got %#v", entityType, element[1])
 			}
 			result.LogConfig[logConfig.Module] = logConfig
+		case "site":
+			var siteConfig SiteConfig
+			err = convert(element[1], &siteConfig)
+			if err != nil {
+				return result, fmt.Errorf("Invalid %s element got %#v", entityType, element[1])
+			}
+			siteConfig.Present = true
+			result.SiteConfig = siteConfig
 		case "tcpConnector":
 			connector := TcpEndpoint{}
 			err = convert(element[1], &connector)
@@ -788,6 +807,13 @@ func MarshalRouterConfig(config RouterConfig) (string, error) {
 		tuple := []interface{}{
 			"log",
 			e,
+		}
+		elements = append(elements, tuple)
+	}
+	if config.SiteConfig.Present {
+		tuple := []interface{}{
+			"site",
+			config.SiteConfig,
 		}
 		elements = append(elements, tuple)
 	}

--- a/pkg/qdr/qdr_test.go
+++ b/pkg/qdr/qdr_test.go
@@ -1,6 +1,7 @@
 package qdr
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -328,6 +329,13 @@ func TestMarshalUnmarshalRouterConfig(t *testing.T) {
 				Distribution: "balanced",
 			},
 		},
+		SiteConfig: SiteConfig{
+			Present:   true,
+			Name:      "razzle",
+			Namespace: "dazzle",
+			Location:  "pizzazz",
+			Provider:  "azure",
+		},
 	}
 	data, err := MarshalRouterConfig(input)
 	if err != nil {
@@ -354,6 +362,9 @@ func TestMarshalUnmarshalRouterConfig(t *testing.T) {
 	}
 	if !reflect.DeepEqual(input.Bridges, output.Bridges) {
 		t.Errorf("Incorrect bridges. Expected %#v got %#v", input.Bridges, output.Bridges)
+	}
+	if !reflect.DeepEqual(input.SiteConfig, output.SiteConfig) {
+		t.Errorf("Incorrect siteconfig. Expected %#v got %#v", input.SiteConfig, output.SiteConfig)
 	}
 }
 
@@ -676,4 +687,32 @@ func TestGetSslProfilesDifference(t *testing.T) {
 	assert.Assert(t, utils.StringSlicesEqual(addedSslProfiles, expectedAddedSslProfiles), "Expected %v but got %v", expectedAddedSslProfiles, addedSslProfiles)
 	assert.Assert(t, utils.StringSlicesEqual(deletedSslProfiles, expectedDeletedSslProfiles), "Expected %v but got %v", expectedDeletedSslProfiles, deletedSslProfiles)
 
+}
+
+func TestSiteConfig(t *testing.T) {
+	config := InitialConfig("foo", "bar", "1.2.3", true, 10)
+	if config.SiteConfig.Present {
+		t.Error("expected no site configuration by default")
+	}
+
+	data, err := MarshalRouterConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+
+	var entities [][]json.RawMessage
+	if err := json.Unmarshal([]byte(data), &entities); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+	for _, entity := range entities {
+		if len(entity) > 1 {
+			var entityType string
+			if err := json.Unmarshal(entity[0], &entityType); err != nil {
+				t.Fatalf("Failed to unmarshal entity type: %v", err)
+			}
+			if entityType == "site" {
+				t.Errorf("expected no site config entity but got %q", string(entity[1]))
+			}
+		}
+	}
 }

--- a/pkg/qdr/qdr_test.go
+++ b/pkg/qdr/qdr_test.go
@@ -329,8 +329,7 @@ func TestMarshalUnmarshalRouterConfig(t *testing.T) {
 				Distribution: "balanced",
 			},
 		},
-		SiteConfig: SiteConfig{
-			Present:   true,
+		SiteConfig: &SiteConfig{
 			Name:      "razzle",
 			Namespace: "dazzle",
 			Location:  "pizzazz",
@@ -691,7 +690,7 @@ func TestGetSslProfilesDifference(t *testing.T) {
 
 func TestSiteConfig(t *testing.T) {
 	config := InitialConfig("foo", "bar", "1.2.3", true, 10)
-	if config.SiteConfig.Present {
+	if config.SiteConfig != nil {
 		t.Error("expected no site configuration by default")
 	}
 


### PR DESCRIPTION
Exposes router configuration for including a site vanflow record to be emitted from the router in lieu of a dedicated controller to share this information.