### PR TITLE
Collector api bugfixes

### DIFF
--- a/cmd/network-console-collector/internal/collector/connections.go
+++ b/cmd/network-console-collector/internal/collector/connections.go
@@ -580,38 +580,6 @@ func (c *connectionManager) run(ctx context.Context) {
 						continue
 					}
 
-					sn := c.graph.Process(pair.Source)
-					sSiteID := sn.Parent().ID()
-					dn := c.graph.Process(pair.Dest)
-					dSiteID := dn.Parent().ID()
-
-					sourceProc, ok := sn.GetRecord()
-					if !ok {
-						return
-					}
-					destProc, ok := dn.GetRecord()
-					if !ok {
-						return
-					}
-
-					var (
-						sourceGroupID string
-						destGroupID   string
-					)
-					sGroup, dGroup := dref(sourceProc.Group), dref(destProc.Group)
-					sGroupEntries := c.records.Index(IndexByTypeName, store.Entry{Record: ProcessGroupRecord{
-						Name: sGroup,
-					}})
-					if len(sGroupEntries) > 0 {
-						sourceGroupID = sGroupEntries[0].Record.Identity()
-					}
-					dGroupEntries := c.records.Index(IndexByTypeName, store.Entry{Record: ProcessGroupRecord{
-						Name: dGroup,
-					}})
-					if len(dGroupEntries) > 0 {
-						destGroupID = dGroupEntries[0].Record.Identity()
-					}
-
 					id := c.idp.ID("processpair", pair.Source, pair.Dest, pair.Protocol)
 					if _, ok := c.records.Get(id); !ok {
 						record := ProcPairRecord{
@@ -624,37 +592,6 @@ func (c *connectionManager) run(ctx context.Context) {
 						c.logger.Info("Adding process pairs", slog.Any("id", id))
 						c.records.Add(record, store.SourceRef{ID: "self"})
 					}
-
-					if sSiteID != "" && dSiteID != "" {
-						id := c.idp.ID("sitepair", sSiteID, dSiteID, pair.Protocol)
-						if _, ok := c.records.Get(id); !ok {
-							record := SitePairRecord{
-								ID:       id,
-								Source:   sSiteID,
-								Dest:     dSiteID,
-								Protocol: pair.Protocol,
-								Start:    time.Now(),
-							}
-							c.logger.Info("Adding site pairs", slog.Any("id", id))
-							c.records.Add(record, store.SourceRef{ID: "self"})
-						}
-					}
-
-					if sourceGroupID != "" && destGroupID != "" {
-						id := c.idp.ID("processgrouppair", sourceGroupID, destGroupID, pair.Protocol)
-						if _, ok := c.records.Get(id); !ok {
-							record := ProcGroupPairRecord{
-								ID:       id,
-								Source:   sourceGroupID,
-								Dest:     destGroupID,
-								Protocol: pair.Protocol,
-								Start:    time.Now(),
-							}
-							c.logger.Info("Adding process group pairs", slog.Any("id", id))
-							c.records.Add(record, store.SourceRef{ID: "self"})
-						}
-					}
-
 					c.processPairs[pair] = false
 				}
 			}()

--- a/cmd/network-console-collector/internal/collector/records.go
+++ b/cmd/network-console-collector/internal/collector/records.go
@@ -62,11 +62,13 @@ func (r SitePairRecord) GetTypeMeta() vanflow.TypeMeta {
 }
 
 type ProcGroupPairRecord struct {
-	ID       string
-	Protocol string
-	Source   string
-	Dest     string
-	Start    time.Time
+	ID         string
+	Protocol   string
+	Source     string
+	SourceName string
+	Dest       string
+	DestName   string
+	Start      time.Time
 }
 
 func (r ProcGroupPairRecord) Identity() string {

--- a/cmd/network-console-collector/internal/server/process_test.go
+++ b/cmd/network-console-collector/internal/server/process_test.go
@@ -76,6 +76,17 @@ func TestProcesses(t *testing.T) {
 				})
 			},
 		}, {
+			Records:     append(exProcessWithAddresses(), wrapRecords(vanflow.ProcessRecord{BaseRecord: vanflow.NewBase("0")})...),
+			ExpectOK:    true,
+			ExpectCount: 2,
+			Parameters: map[string][]string{
+				"sortBy": {"processBinding.asc"},
+			},
+			ExpectResults: func(t *testing.T, results []api.ProcessRecord) {
+				assert.Equal(t, results[0].Identity, "1")
+				assert.Equal(t, results[1].Identity, "0")
+			},
+		}, {
 			Records: exProcessWithAddresses(),
 			Parameters: map[string][]string{
 				"addresses": {"pizza-addr-id"},

--- a/cmd/network-console-collector/internal/server/query.go
+++ b/cmd/network-console-collector/internal/server/query.go
@@ -159,10 +159,9 @@ func (m fieldIndex[T]) Compare(x, y T) int {
 		}
 		vx, vy = vx.Elem(), vy.Elem()
 	}
-	xx, yy := vx.Interface(), vy.Interface()
-	switch xx := xx.(type) {
-	case string:
-		yy := yy.(string)
+	switch vx.Kind() {
+	case reflect.String:
+		xx, yy := vx.String(), vy.String()
 		if xx == yy {
 			return 0
 		}
@@ -170,14 +169,18 @@ func (m fieldIndex[T]) Compare(x, y T) int {
 			return -1
 		}
 		return 1
-	case uint64:
-		return int(xx - yy.(uint64))
-	case int32:
-		return int(xx - yy.(int32))
-	case int64:
-		return int(xx - yy.(int64))
-	case int:
-		return int(xx - yy.(int))
+	case reflect.Uint32:
+		fallthrough
+	case reflect.Uint64:
+		xx, yy := vx.Uint(), vy.Uint()
+		return int(xx - yy)
+	case reflect.Int32:
+		fallthrough
+	case reflect.Int:
+		fallthrough
+	case reflect.Int64:
+		xx, yy := vx.Int(), vy.Int()
+		return int(xx - yy)
 	}
 	return 0
 }

--- a/cmd/network-console-collector/internal/server/router_test.go
+++ b/cmd/network-console-collector/internal/server/router_test.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/skupperproject/skupper/cmd/network-console-collector/internal/api"
+	"github.com/skupperproject/skupper/cmd/network-console-collector/internal/collector"
+	"github.com/skupperproject/skupper/pkg/vanflow"
+	"github.com/skupperproject/skupper/pkg/vanflow/store"
+	"gotest.tools/assert"
+)
+
+func TestRouters(t *testing.T) {
+	tlog := slog.Default()
+	stor := store.NewSyncMapStore(store.SyncMapStoreConfig{Indexers: collector.RecordIndexers()})
+	graph := collector.NewGraph(stor)
+	srv, c := requireTestClient(t, New(tlog, stor, graph))
+	defer srv.Close()
+
+	van := []vanflow.Record{
+		vanflow.SiteRecord{BaseRecord: vanflow.NewBase("site-a"), Name: ptrTo("site a")},
+		vanflow.RouterRecord{BaseRecord: vanflow.NewBase("router-a-1"), Name: ptrTo("router a.1"), Parent: ptrTo("site-a"),
+			Mode: ptrTo("inter-router"),
+		},
+
+		vanflow.SiteRecord{BaseRecord: vanflow.NewBase("site-b"), Name: ptrTo("site b")},
+		vanflow.RouterRecord{BaseRecord: vanflow.NewBase("router-b-1"), Name: ptrTo("router b.1"), Parent: ptrTo("site-b")},
+		vanflow.RouterRecord{BaseRecord: vanflow.NewBase("router-b-2"), Name: ptrTo("router b.2"), Parent: ptrTo("site-b")},
+	}
+
+	testcases := []struct {
+		Records              []store.Entry
+		Parameters           map[string][]string
+		ExpectOK             bool
+		ExpectCount          int
+		ExpectTimeRangeCount int
+		ExpectResults        func(t *testing.T, results []api.RouterRecord)
+	}{
+		{ExpectOK: true},
+		{
+			ExpectOK:    true,
+			Records:     wrapRecords(van...),
+			ExpectCount: 3,
+			ExpectResults: func(t *testing.T, results []api.RouterRecord) {
+				for _, result := range results {
+					switch result.Identity {
+					case "router-a-1":
+						assert.DeepEqual(
+							t, result, api.RouterRecord{
+								Identity:     "router-a-1",
+								Name:         "router a.1",
+								HostName:     "unknown",
+								ImageName:    "unknown",
+								ImageVersion: "unknown",
+								Mode:         "inter-router",
+								Parent:       "site-a",
+							},
+						)
+
+					}
+
+				}
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run("", func(t *testing.T) {
+			stor.Replace(tc.Records)
+			graph.(reset).Reset()
+			for _, r := range tc.Records {
+				graph.(reset).Reindex(r.Record)
+			}
+			resp, err := c.RoutersWithResponse(context.TODO(), WithParameters(tc.Parameters))
+			assert.Check(t, err)
+			if tc.ExpectOK {
+				assert.Equal(t, resp.StatusCode(), 200)
+				assert.Equal(t, resp.JSON200.Count, int64(tc.ExpectCount))
+				assert.Assert(t, resp.JSON200.Results != nil)
+				assert.Equal(t, len(resp.JSON200.Results), tc.ExpectCount)
+				if tc.ExpectTimeRangeCount != 0 {
+					assert.Equal(t, resp.JSON200.TimeRangeCount, int64(tc.ExpectTimeRangeCount))
+				}
+				if tc.ExpectResults != nil {
+					tc.ExpectResults(t, resp.JSON200.Results)
+				}
+			} else {
+				assert.Check(t, resp.JSON400 != nil)
+			}
+		})
+	}
+}

--- a/cmd/network-console-collector/internal/server/views/views.go
+++ b/cmd/network-console-collector/internal/server/views/views.go
@@ -555,6 +555,7 @@ func Router(record vanflow.RouterRecord) api.RouterRecord {
 	out := defaultRouter(record.ID)
 	out.StartTime, out.EndTime = vanflowTimes(record.BaseRecord)
 	out.Namespace = record.Namespace
+	setOpt(&out.Parent, record.Parent)
 	setOpt(&out.HostName, record.Hostname)
 	setOpt(&out.ImageName, record.ImageName)
 	setOpt(&out.ImageVersion, record.ImageVersion)

--- a/cmd/network-console-collector/internal/server/views/views.go
+++ b/cmd/network-console-collector/internal/server/views/views.go
@@ -105,7 +105,9 @@ func NewProcessGroupPairProvider() func(collector.ProcGroupPairRecord) api.FlowA
 		out.StartTime = uint64(record.Start.UnixMicro())
 		out.PairType = api.PROCESSGROUP
 		out.SourceId = record.Source
+		out.SourceName = record.SourceName
 		out.DestinationId = record.Dest
+		out.DestinationName = record.DestName
 		out.Protocol = record.Protocol
 		return out
 	}


### PR DESCRIPTION
Quick followup to the updated network-console-collector fixing a few bugs.

* Fix several bugs in "pair" manager - including double sitepair records and fixing processgrouppairs.
* Update our sortBy logic to work with the types generated by openapi-spec instead of only primitives.
* /routers should have parent that points to a site.