### PR TITLE
Expose ModTime through Tarball.AddFileData

### DIFF
--- a/internal/nonkube/bundle/tarball.go
+++ b/internal/nonkube/bundle/tarball.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path"
 	"text/template"
+	"time"
 
 	"github.com/skupperproject/skupper/internal/utils"
 	pkgutils "github.com/skupperproject/skupper/pkg/utils"
@@ -37,7 +38,7 @@ func (s *TarballBundle) Generate(tarBall *utils.Tarball, defaultPlatform string)
 	if err != nil {
 		return err
 	}
-	if err = tarBall.AddFileData("install.sh", 0755, parsedInstallScript.Bytes()); err != nil {
+	if err = tarBall.AddFileData("install.sh", 0755, time.Now(), parsedInstallScript.Bytes()); err != nil {
 		return fmt.Errorf("error writing install.sh: %w", err)
 	}
 	err = tarBall.Save(s.InstallFile())

--- a/internal/utils/tarball.go
+++ b/internal/utils/tarball.go
@@ -153,13 +153,13 @@ func (t *Tarball) addFiles(dir string) error {
 	return nil
 }
 
-func (t *Tarball) AddFileData(fileName string, mode int64, data []byte) error {
+func (t *Tarball) AddFileData(fileName string, mode int64, mod time.Time, data []byte) error {
 	var err error
 	err = t.tw.WriteHeader(&tar.Header{
 		Name:    fileName,
 		Mode:    mode,
 		Size:    int64(len(data)),
-		ModTime: time.Now(),
+		ModTime: mod,
 	})
 	if err != nil {
 		return err

--- a/internal/utils/tarball_test.go
+++ b/internal/utils/tarball_test.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/assert"
 )
@@ -50,6 +51,7 @@ func TestTarball(t *testing.T) {
 					assert.Assert(t, os.RemoveAll(fileOrDir))
 				}
 			}()
+			now := time.Now()
 			// Generating files and asserting generation was successful
 			err = createFiles(baseDir, tc.files, []byte(testFileContent), tree)
 			assert.Assert(t, err, "unable to create files")
@@ -92,7 +94,7 @@ func TestTarball(t *testing.T) {
 				tb := NewTarball()
 				assert.Assert(t, tb != nil)
 				assert.Assert(t, tb.AddFiles(baseDir))
-				assert.Assert(t, tb.AddFileData("sample.file", 0755, []byte(testFileContent)))
+				assert.Assert(t, tb.AddFileData("sample.file", 0755, now, []byte(testFileContent)))
 				savedDataExtra, err = tb.SaveData()
 				assert.Assert(t, err)
 				assert.Assert(t, len(savedDataExtra) > 0)
@@ -102,13 +104,13 @@ func TestTarball(t *testing.T) {
 				tb := NewTarball()
 				assert.Assert(t, tb != nil)
 				assert.Assert(t, tb.AddFiles(baseDir))
-				assert.Assert(t, tb.AddFileData("sample.file", 0755, []byte(testFileContent)))
+				assert.Assert(t, tb.AddFileData("sample.file", 0755, now, []byte(testFileContent)))
 				err = tb.Save(savedFileExtra)
 				assert.Assert(t, err)
 				cleanupList = append(cleanupList, savedFileExtra)
-				savedFileStat, err := os.Stat(savedFileExtra)
+				savedFileData, err := os.ReadFile(savedFileExtra)
 				assert.Assert(t, err)
-				assert.Assert(t, savedFileStat.Size() == int64(len(savedDataExtra)))
+				assert.DeepEqual(t, savedFileData, savedDataExtra)
 				assert.Assert(t, len(savedDataExtra) > len(savedData))
 			})
 			t.Run(tc.description+"-Uncompress", func(t *testing.T) {


### PR DESCRIPTION
Adds a mod parameter to allow tarball output to be deterministic. Fixes #1679.