### PR TITLE
[v2] pkg/kube/site issues logs via slog

### DIFF
--- a/pkg/kube/site/site_test.go
+++ b/pkg/kube/site/site_test.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"log/slog"
 )
 
 func TestSite_Recover(t *testing.T) {
@@ -1051,6 +1052,9 @@ func newSiteMocks(namespace string, k8sObjects []runtime.Object, skupperObjects 
 		access:     securedaccess.NewSecuredAccessManager(client, nil, &securedaccess.Config{DefaultAccessType: "loadbalancer"}, securedaccess.ControllerContext{}),
 		adaptor:    BindingAdaptor{},
 		routerPods: make(map[string]*corev1.Pod),
+		logger: slog.New(slog.Default().Handler()).With(
+			slog.String("component", "kube.site.site"),
+		),
 	}
 
 	newSite.site = site


### PR DESCRIPTION
Updating pkg/kube/site to issue logs via slog.

Fixes #1692

Below, I've pasted the info logs that the skupper-controller issued while I ran the hello-world steps:
  - create a site in east, west.
  - link sites
  - create listener, connector
  - delete listener, connector.  delete accessgrant, accesstoken.  delete sites. 

```
kubectl -n skupper logs skupper-controller-67f6c9f66b-s6m8z --follow | grep "component=kube.site"
time=2024-10-01T14:57:58.603Z level=INFO msg="Initialising site" component=kube.site.site namespace=west name=west
time=2024-10-01T14:57:58.610Z level=INFO msg="Config map created successfully" component=kube.site.site namespace=west group=skupper-router
time=2024-10-01T14:57:58.610Z level=INFO msg="Router config created for site" component=kube.site.site namespace=west name=west
time=2024-10-01T14:58:02.448Z level=INFO msg="Initialising site" component=kube.site.site namespace=east name=east
time=2024-10-01T14:58:02.455Z level=INFO msg="Config map created successfully" component=kube.site.site namespace=east group=skupper-router
time=2024-10-01T14:58:02.455Z level=INFO msg="Router config created for site" component=kube.site.site namespace=east name=east
time=2024-10-01T14:58:49.187Z level=INFO msg="Connecting site using token" component=kube.site.site namespace=east token=my-token
time=2024-10-01T14:59:11.369Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-2qr8c connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.369Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-7d5m5 connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.369Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-zct5z connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.372Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-7d5m5 connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.372Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-zct5z connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.372Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-2qr8c connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.391Z level=INFO msg="INFO No pods available for target selection component=kube.site.bindings id=\"Connector backend/east\""
time=2024-10-01T14:59:11.396Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-2qr8c connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.396Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-7d5m5 connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.396Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-zct5z connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.400Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-7d5m5 connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.400Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-zct5z connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.400Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-2qr8c connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.404Z level=INFO msg="INFO No pods available for target selection component=kube.site.bindings id=\"Connector backend/east\""
time=2024-10-01T14:59:11.404Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-2qr8c connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.404Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-7d5m5 connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.404Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-zct5z connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.407Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-7d5m5 connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.407Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-zct5z connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.407Z level=INFO msg="INFO Pod selected for connector component=kube.site.bindings pod=backend-8485574c8b-2qr8c connector=\"Connector backend/east\""
time=2024-10-01T14:59:11.411Z level=INFO msg="INFO No pods available for target selection component=kube.site.bindings id=\"Connector backend/east\""
time=2024-10-01T15:00:24.090Z level=INFO msg="Deleting site" component=kube.site.site namespace=west name=west
time=2024-10-01T15:00:27.647Z level=INFO msg="Deleting site" component=kube.site.site namespace=east name=east

```