### PR TITLE
Update link cost when receiving a flow record

### DIFF
--- a/pkg/flow/flow_mem_driver.go
+++ b/pkg/flow/flow_mem_driver.go
@@ -811,6 +811,11 @@ func (fc *FlowCollector) updateRecord(record interface{}) error {
 				if link.EndTime > 0 {
 					current.EndTime = link.EndTime
 					fc.deleteRecord(current)
+				} else {
+					if current.LinkCost == nil && link.LinkCost != nil {
+						current.LinkCost = link.LinkCost
+						fc.addRecord(current)
+					}
 				}
 			}
 			fc.updateLastHeard(link.Source)

--- a/pkg/flow/flow_mem_driver.go
+++ b/pkg/flow/flow_mem_driver.go
@@ -814,7 +814,9 @@ func (fc *FlowCollector) updateRecord(record interface{}) error {
 				} else {
 					if current.LinkCost == nil && link.LinkCost != nil {
 						current.LinkCost = link.LinkCost
-						fc.addRecord(current)
+						if fc.mode == RecordStatus {
+							fc.updateNetworkStatus()
+						}
 					}
 				}
 			}


### PR DESCRIPTION
update the link cost in link record so the proper value is displayed in configmap skupper-network-status
and with skupper network status -v command.

fixes #1654 