### PR TITLE
CollectorAPI add /api/v1alpha1/applicationflows

### DIFF
--- a/cmd/network-console-collector/internal/api/extras_gen.go
+++ b/cmd/network-console-collector/internal/api/extras_gen.go
@@ -25,6 +25,21 @@ func (r *AddressResponse) SetResults(v AddressRecord) {
 }
 
 // SetCount
+func (r *ApplicationFlowResponse) SetCount(v int64) {
+	r.Count = v
+}
+
+// SetResults
+func (r *ApplicationFlowResponse) SetResults(v []ApplicationFlowRecord) {
+	r.Results = v
+}
+
+// SetTimeRangeCount
+func (r *ApplicationFlowResponse) SetTimeRangeCount(v int64) {
+	r.TimeRangeCount = v
+}
+
+// SetCount
 func (r *ConnectionListResponse) SetCount(v int64) {
 	r.Count = v
 }
@@ -160,21 +175,6 @@ func (r *ProcessResponse) SetResults(v ProcessRecord) {
 }
 
 // SetCount
-func (r *RequestListResponse) SetCount(v int64) {
-	r.Count = v
-}
-
-// SetResults
-func (r *RequestListResponse) SetResults(v []RequestRecord) {
-	r.Results = v
-}
-
-// SetTimeRangeCount
-func (r *RequestListResponse) SetTimeRangeCount(v int64) {
-	r.TimeRangeCount = v
-}
-
-// SetCount
 func (r *RouterAccessListResponse) SetCount(v int64) {
 	r.Count = v
 }
@@ -277,6 +277,16 @@ func (r AddressRecord) GetStartTime() uint64 {
 }
 
 // GetEndTime
+func (r ApplicationFlowRecord) GetEndTime() uint64 {
+	return r.EndTime
+}
+
+// GetStartTime
+func (r ApplicationFlowRecord) GetStartTime() uint64 {
+	return r.StartTime
+}
+
+// GetEndTime
 func (r ConnectionRecord) GetEndTime() uint64 {
 	return r.EndTime
 }
@@ -343,16 +353,6 @@ func (r ProcessRecord) GetEndTime() uint64 {
 
 // GetStartTime
 func (r ProcessRecord) GetStartTime() uint64 {
-	return r.StartTime
-}
-
-// GetEndTime
-func (r RequestRecord) GetEndTime() uint64 {
-	return r.EndTime
-}
-
-// GetStartTime
-func (r RequestRecord) GetStartTime() uint64 {
 	return r.StartTime
 }
 

--- a/cmd/network-console-collector/internal/api/types_gen.go
+++ b/cmd/network-console-collector/internal/api/types_gen.go
@@ -82,7 +82,10 @@ type AddressRecord struct {
 	IsBound       bool   `json:"isBound"`
 	ListenerCount int    `json:"listenerCount"`
 	Name          string `json:"name"`
-	Protocol      string `json:"protocol"`
+
+	// ObservedApplicationProtocols Array of the observed application level protocols
+	ObservedApplicationProtocols []string `json:"observedApplicationProtocols"`
+	Protocol                     string   `json:"protocol"`
 
 	// StartTime The creation time in microseconds of the record in Unix timestamp format. The value 0 means that the record is not terminated
 	StartTime uint64 `json:"startTime"`

--- a/cmd/network-console-collector/internal/collector/flows.go
+++ b/cmd/network-console-collector/internal/collector/flows.go
@@ -85,14 +85,17 @@ type RequestRecord struct {
 	RoutingKey string
 	Protocol   string
 
-	Connector   NamedReference
-	Listener    NamedReference
-	Source      NamedReference
-	Dest        NamedReference
-	SourceSite  NamedReference
-	DestSite    NamedReference
-	SourceGroup NamedReference
-	DestGroup   NamedReference
+	Connector    NamedReference
+	Listener     NamedReference
+	Source       NamedReference
+	Dest         NamedReference
+	SourceSite   NamedReference
+	SourceRouter NamedReference
+	DestSite     NamedReference
+	DestRouter   NamedReference
+	SourceGroup  NamedReference
+	DestGroup    NamedReference
+	Trace        string
 
 	stor    store.Interface
 	metrics appMetrics
@@ -105,6 +108,15 @@ func (cr *RequestRecord) GetFlow() (vanflow.AppBiflowRecord, bool) {
 		return record, false
 	}
 	record, ok = ent.Record.(vanflow.AppBiflowRecord)
+	return record, ok
+}
+func (cr *RequestRecord) GetTransport() (vanflow.TransportBiflowRecord, bool) {
+	var record vanflow.TransportBiflowRecord
+	ent, ok := cr.stor.Get(cr.TransportID)
+	if !ok {
+		return record, false
+	}
+	record, ok = ent.Record.(vanflow.TransportBiflowRecord)
 	return record, ok
 }
 
@@ -131,6 +143,7 @@ func (r RequestRecord) toLabelSet() labelSet {
 		SourceComponentName: r.SourceGroup.Name,
 		DestComponentID:     r.DestGroup.ID,
 		DestComponentName:   r.DestGroup.Name,
+		Protocol:            r.Protocol,
 	}
 }
 

--- a/cmd/network-console-collector/internal/server/address_test.go
+++ b/cmd/network-console-collector/internal/server/address_test.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/skupperproject/skupper/cmd/network-console-collector/internal/api"
+	"github.com/skupperproject/skupper/cmd/network-console-collector/internal/collector"
+	"github.com/skupperproject/skupper/pkg/vanflow"
+	"github.com/skupperproject/skupper/pkg/vanflow/store"
+	"gotest.tools/assert"
+)
+
+func TestAddresses(t *testing.T) {
+	tlog := slog.Default()
+	stor := store.NewSyncMapStore(store.SyncMapStoreConfig{Indexers: collector.RecordIndexers()})
+	graph := collector.NewGraph(stor)
+	srv, c := requireTestClient(t, New(tlog, stor, graph))
+	defer srv.Close()
+
+	begin := time.Now()
+	testcases := []struct {
+		Records              []store.Entry
+		ExpectOK             bool
+		ExpectCount          int
+		ExpectTimeRangeCount int
+		ExpectResults        func(t *testing.T, results []api.AddressRecord)
+	}{
+		{ExpectOK: true},
+		{
+			Records: wrapRecords(
+				collector.AddressRecord{ID: "addr-1", Name: "pizza", Protocol: "tcp", Start: begin},
+				collector.AddressRecord{ID: "addr-2", Name: "icecream", Protocol: "tcp", Start: begin},
+				collector.AddressRecord{ID: "addr-3", Name: "waffles", Protocol: "tcp", Start: begin},
+				vanflow.ConnectorRecord{BaseRecord: vanflow.NewBase("c1"), Address: ptrTo("pizza"), Protocol: ptrTo("tcp")},
+				vanflow.ConnectorRecord{BaseRecord: vanflow.NewBase("c2"), Address: ptrTo("pizza"), Protocol: ptrTo("tcp")},
+				vanflow.ListenerRecord{BaseRecord: vanflow.NewBase("l1"), Address: ptrTo("pizza"), Protocol: ptrTo("tcp")},
+				vanflow.ListenerRecord{BaseRecord: vanflow.NewBase("l2"), Address: ptrTo("pizza"), Protocol: ptrTo("tcp")},
+				collector.RequestRecord{RoutingKey: "pizza", ID: "r1", Protocol: "yodel"},
+				collector.RequestRecord{RoutingKey: "pizza", ID: "r2", Protocol: "yodel"},
+			),
+			ExpectOK:    true,
+			ExpectCount: 3,
+			ExpectResults: func(t *testing.T, results []api.AddressRecord) {
+				for _, result := range results {
+					if result.Identity == "addr-1" {
+						assert.DeepEqual(t, result, api.AddressRecord{
+							Identity:                     "addr-1",
+							Name:                         "pizza",
+							ConnectorCount:               2,
+							ListenerCount:                2,
+							IsBound:                      true,
+							Protocol:                     "tcp",
+							ObservedApplicationProtocols: []string{"yodel"},
+							StartTime:                    uint64(begin.UnixMicro()),
+						})
+						return
+					}
+				}
+				t.Error("expected to find address record for addr-1")
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run("", func(t *testing.T) {
+			stor.Replace(tc.Records)
+			graph.(reset).Reset()
+			for _, r := range tc.Records {
+				graph.(reset).Reindex(r.Record)
+			}
+			resp, err := c.AddressesWithResponse(context.TODO())
+			assert.Check(t, err)
+			if tc.ExpectOK {
+				assert.Equal(t, resp.StatusCode(), 200)
+				assert.Equal(t, resp.JSON200.Count, int64(tc.ExpectCount))
+				assert.Assert(t, resp.JSON200.Results != nil)
+				assert.Equal(t, len(resp.JSON200.Results), tc.ExpectCount)
+				if tc.ExpectTimeRangeCount != 0 {
+					assert.Equal(t, resp.JSON200.TimeRangeCount, int64(tc.ExpectTimeRangeCount))
+				}
+				if tc.ExpectResults != nil {
+					tc.ExpectResults(t, resp.JSON200.Results)
+				}
+			} else {
+				assert.Check(t, resp.JSON400 != nil)
+			}
+		})
+	}
+}

--- a/cmd/network-console-collector/internal/server/handlers.go
+++ b/cmd/network-console-collector/internal/server/handlers.go
@@ -32,9 +32,9 @@ func (s *server) ConnectionsByAddress(w http.ResponseWriter, r *http.Request, id
 	}
 }
 
-func (s *server) Requests(w http.ResponseWriter, r *http.Request) {
-	results := views.NewRequestSliceProvider()(listByType[collector.RequestRecord](s.records))
-	if err := handleCollection(w, r, &api.RequestListResponse{}, results); err != nil {
+func (s *server) Applicationflows(w http.ResponseWriter, r *http.Request) {
+	results := views.NewRequestSliceProvider(s.records)(listByType[collector.RequestRecord](s.records))
+	if err := handleCollection(w, r, &api.ApplicationFlowResponse{}, results); err != nil {
 		s.logWriteError(r, err)
 	}
 }

--- a/cmd/network-console-collector/internal/server/handlers.go
+++ b/cmd/network-console-collector/internal/server/handlers.go
@@ -41,7 +41,7 @@ func (s *server) Applicationflows(w http.ResponseWriter, r *http.Request) {
 
 // (GET /api/v1alpha1/addresses/)
 func (s *server) Addresses(w http.ResponseWriter, r *http.Request) {
-	results := views.NewAddressSliceProvider(s.graph)(listByType[collector.AddressRecord](s.records))
+	results := views.NewAddressSliceProvider(s.records, s.graph)(listByType[collector.AddressRecord](s.records))
 	if err := handleCollection(w, r, &api.AddressListResponse{}, results); err != nil {
 		s.logWriteError(r, err)
 	}
@@ -49,7 +49,7 @@ func (s *server) Addresses(w http.ResponseWriter, r *http.Request) {
 
 // (GET /api/v1alpha1/addresses/{id}/)
 func (s *server) AddressByID(w http.ResponseWriter, r *http.Request, id string) {
-	getRecord := fetchAndMap(s.records, views.NewAddressProvider(s.graph), id)
+	getRecord := fetchAndMap(s.records, views.NewAddressProvider(s.records, s.graph), id)
 	if err := handleSingle(w, r, &api.AddressResponse{}, getRecord); err != nil {
 		s.logWriteError(r, err)
 	}

--- a/cmd/network-console-collector/internal/server/process_test.go
+++ b/cmd/network-console-collector/internal/server/process_test.go
@@ -66,7 +66,7 @@ func TestProcesses(t *testing.T) {
 					Identity:       "1",
 					Parent:         "site-1",
 					ParentName:     "site one",
-					Addresses:      ptrTo([]api.AtmarkDelimitedString{api.AtmarkDelimitedString("pizza@pizza-addr-id@tcp"), api.AtmarkDelimitedString("icecream@icecream-addr-id@tcp")}),
+					Addresses:      ptrTo([]api.AtmarkDelimitedString{api.AtmarkDelimitedString("icecream@icecream-addr-id@tcp"), api.AtmarkDelimitedString("pizza@pizza-addr-id@tcp")}),
 					GroupName:      "group-one",
 					GroupIdentity:  "group-1-id",
 					ProcessBinding: api.Bound,
@@ -153,6 +153,13 @@ func exProcessWithAddresses() []store.Entry {
 		vanflow.ConnectorRecord{
 			Parent:     ptrTo("router-1"),
 			BaseRecord: vanflow.NewBase("c2"),
+			Address:    ptrTo("icecream"),
+			Protocol:   ptrTo("tcp"),
+			DestHost:   ptrTo("10.99.99.2"),
+		},
+		vanflow.ConnectorRecord{
+			Parent:     ptrTo("router-1"),
+			BaseRecord: vanflow.NewBase("c3"),
 			Address:    ptrTo("icecream"),
 			Protocol:   ptrTo("tcp"),
 			DestHost:   ptrTo("10.99.99.2"),

--- a/cmd/network-console-collector/spec/openapi.yaml
+++ b/cmd/network-console-collector/spec/openapi.yaml
@@ -302,13 +302,13 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/getConnections'
-  /api/v1alpha1/requests/:
+  /api/v1alpha1/applicationflows/:
     get:
       tags: [flows]
-      operationId: requests
+      operationId: applicationflows
       responses:
         '200':
-          $ref: '#/components/responses/getRequests'
+          $ref: '#/components/responses/getApplicationFlows'
 
   /api/v1alpha1/sites/{id}/processes/:
     get:
@@ -505,12 +505,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ConnectionListResponse'
-    getRequests:
-      description: response with a list of requests
+    getApplicationFlows:
+      description: response with a list of application flows
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/RequestListResponse'
+            $ref: '#/components/schemas/ApplicationFlowResponse'
     getSiteByID:
       description: response with a single site
       content:
@@ -800,7 +800,7 @@ components:
         properties:
           results:
             $ref: '#/components/schemas/ConnectionRecord'
-    RequestListResponse:
+    ApplicationFlowResponse:
       allOf:
         - $ref: '#/components/schemas/collectionResponse'
         - type: object
@@ -809,7 +809,7 @@ components:
             results:
               type: array
               items:
-                $ref: '#/components/schemas/RequestRecord'
+                $ref: '#/components/schemas/ApplicationFlowRecord'
     baseRecord:
       type: object
       required:
@@ -1335,12 +1335,12 @@ components:
               description: Ordered array of the names of sites involved in proxying the connection
               items:
                 type: string
-    RequestRecord:
+    ApplicationFlowRecord:
       allOf:
         - $ref: '#/components/schemas/baseRecord'
         - type: object
           required:
-            - active
+            - duration
             - connectionId
             - sourceSiteId
             - sourceSiteName
@@ -1350,33 +1350,18 @@ components:
             - sourceProcessName
             - destProcessId
             - destProcessName
-            - duration
-            - processPairId
-            - processGroupPairId
-            - sitePairId
-            - protocol
             - routingKey
-            - listenerId
-            - connectorId
+            - protocol
             - method
-            - result
+            - status
+            - traceRouters
+            - traceSites
           properties:
             connectionId:
               type: string
-            active:
-              type: boolean
             duration:
               type: integer
               format: uint64
-              nullable: true
-            processPairId:
-              type: string
-              nullable: true
-            processGroupPairId:
-              type: string
-              nullable: true
-            sitePairId:
-              type: string
               nullable: true
             sourceSiteId:
               type: string
@@ -1394,21 +1379,27 @@ components:
               type: string
             destProcessName:
               type: string
-            listenerId:
-              type: string
-            connectorId:
-              type: string
             routingKey:
               type: string
             protocol:
               type: string
-              example: tcp
+              example: http1
             method:
               type: string
               example: GET
-            result:
+            status:
               type: string
               example: 200
+            traceRouters:
+              type: array
+              description: Ordered array of the names of routers involved in proxying the connection
+              items:
+                type: string
+            traceSites:
+              type: array
+              description: Ordered array of the names of sites involved in proxying the connection
+              items:
+                type: string
 
 tags:
   - name: site

--- a/cmd/network-console-collector/spec/openapi.yaml
+++ b/cmd/network-console-collector/spec/openapi.yaml
@@ -1031,6 +1031,7 @@ components:
           required:
             - name
             - protocol
+            - observedApplicationProtocols
             - listenerCount
             - connectorCount
             - isBound
@@ -1039,6 +1040,11 @@ components:
               type: string
             protocol:
               type: string
+            observedApplicationProtocols:
+              type: array
+              description: Array of the observed application level protocols
+              items:
+                type: string
             listenerCount:
               type: integer
             connectorCount:


### PR DESCRIPTION
* Replaces the /requests endpoint with /applicationflows
* Normalizes application protocol to "http1" and "http2" in metrics and API
* Introduces flow aggregates (process|group|site)pairs per-app protocol
* Introduces `observedApplicationProtocols` field on address records.