### PR TITLE
Fix SecuredAccessManager updatePorts

### DIFF
--- a/pkg/kube/securedaccess/access.go
+++ b/pkg/kube/securedaccess/access.go
@@ -425,6 +425,7 @@ func updatePorts(spec *corev1.ServiceSpec, desired []skupperv1alpha1.SecuredAcce
 	for _, actual := range spec.Ports {
 		if port, ok := expected[actual.Name]; ok {
 			ports = append(ports, port)
+			port.NodePort = actual.NodePort
 			delete(expected, actual.Name)
 			if actual != port {
 				changed = true


### PR DESCRIPTION
When comparing desired and actual state of services, ignore the value of NodePort as this is assigned dynamically by an external controller and is not managed by us.