### PR TITLE
Run go tests with race detection enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,7 +474,6 @@ jobs:
                 exit 1
               fi
       - go/mod-download-cached
-      - run: make
       - run:
           name: Creating artifacts directory
           command: mkdir /tmp/artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,6 @@ executors:
   go_cimg:
     docker:
       - image: cimg/go:1.22
-    environment:
-      CGO_ENABLED: 0
 
   local_cluster_test_executor:
     machine:
@@ -480,14 +478,14 @@ jobs:
       - run:
           name: Creating artifacts directory
           command: mkdir /tmp/artifacts
-      - go/test:
-          coverpkg: "./internal/...,./pkg/...,./cmd/..."
-          verbose: true
-          coverprofile: "/tmp/artifacts/cover.out"
-          parallel: "3"
+      - run:
+          name: Run tests
+          command: make cover
       - run:
           name: Generating HTML coverage report
-          command: go tool cover -html /tmp/artifacts/cover.out -o /tmp/artifacts/cover.html
+          command: |
+            mv ./cover.out /tmp/artifacts
+            go tool cover -html /tmp/artifacts/cover.out -o /tmp/artifacts/cover.html
       - store_artifacts:
           path: /tmp/artifacts
           destination: test-artifacts
@@ -519,6 +517,8 @@ jobs:
   build-all:
     executor:
       name: go_cimg
+    environment:
+      CGO_ENABLED: 0
     steps:
       - checkout
       - go/mod-download-cached

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ TEST_IMAGE := quay.io/skupper/skupper-tests:v2-latest
 TEST_BINARIES_FOLDER := ${PWD}/test/integration/bin
 DOCKER := docker
 LDFLAGS := -X github.com/skupperproject/skupper/pkg/version.Version=${VERSION}
+TESTFLAGS := -v -race -short
 PLATFORMS ?= linux/amd64,linux/arm64
 GOOS ?= linux
 GOARCH ?= amd64
@@ -86,18 +87,16 @@ force-generate-client:
 vet:
 	go vet ./...
 
-cmd-test:
-	go test -v -count=1 ./cmd/...
-
-pkg-test:
-	go test -v -count=1 ./pkg/...
-
-internal-test:
-	go test -v -count=1 ./internal/...
-
 .PHONY: test
 test:
-	go test -v -count=1 ./pkg/... ./internal/... ./cmd/...
+	go test ${TESTFLAGS} ./...
+
+.PHONY: cover
+cover:
+	go test ${TESTFLAGS} \
+		-cover \
+		-coverprofile cover.out \
+		./...
 
 clean:
 	rm -rf skupper controller release config-sync manifest bootstrap network-console-collector ${TEST_BINARIES_FOLDER}

--- a/internal/nonkube/client/compat/container_test.go
+++ b/internal/nonkube/client/compat/container_test.go
@@ -256,6 +256,9 @@ func TestContainer(t *testing.T) {
 }
 
 func NewClientOrSkip(t *testing.T, endpoint string, ctx context.Context) (*CompatClient, *sync.WaitGroup) {
+	if testing.Short() {
+		t.Skip("short: skipping test with dependency on podman")
+	}
 	var cli *CompatClient
 	var err error
 	var wg *sync.WaitGroup

--- a/internal/nonkube/client/compat/rest_test.go
+++ b/internal/nonkube/client/compat/rest_test.go
@@ -51,6 +51,9 @@ func TestNewPodmanClient(t *testing.T) {
 // PodmanSkipValidation skips the current test if podman binary is not
 // available or if the client version found is lesser than 4.0.0.
 func PodmanSkipValidation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: skipping test with dependency on podman")
+	}
 	stdout := new(bytes.Buffer)
 	cmd := exec.Command("podman", "version", "--format=json")
 	cmd.Stdout = stdout

--- a/pkg/fs/watcher_test.go
+++ b/pkg/fs/watcher_test.go
@@ -69,6 +69,8 @@ func TestFileWatcher(t *testing.T) {
 
 			// validate results
 			watcher.waitDone(test.expected)
+			watcher.mutex.Lock()
+			defer watcher.mutex.Unlock()
 			assert.DeepEqual(t, test.expected.created, watcher.results.created)
 			assert.DeepEqual(t, test.expected.updated, watcher.results.updated)
 			assert.DeepEqual(t, test.expected.deleted, watcher.results.deleted)
@@ -154,6 +156,8 @@ func (m *ModificationHandler) OnRemove(s string) {
 
 func (m *ModificationHandler) waitDone(expected modificationResult) {
 	_ = utils.RetryError(time.Millisecond*200, 10, func() error {
+		m.mutex.Lock()
+		defer m.mutex.Unlock()
 		if reflect.DeepEqual(m.results.created, expected.created) &&
 			reflect.DeepEqual(m.results.updated, expected.updated) &&
 			reflect.DeepEqual(m.results.deleted, expected.deleted) {

--- a/pkg/vanflow/eventsource/client.go
+++ b/pkg/vanflow/eventsource/client.go
@@ -136,10 +136,10 @@ func (c *Client) Listen(ctx context.Context, attributes ListenerConfigProvider) 
 // Close stops all listeners
 func (c *Client) Close() {
 	c.lock.Lock()
-	defer c.lock.Unlock()
 	for _, cancel := range c.cleanup {
 		cancel()
 	}
+	c.lock.Unlock()
 	c.wg.Wait()
 }
 

--- a/pkg/vanflow/session/mock.go
+++ b/pkg/vanflow/session/mock.go
@@ -19,6 +19,8 @@ type mockContainer struct {
 	Router *MockRouter
 }
 
+func (c *mockContainer) IsMock() {}
+
 func (c *mockContainer) Start(ctx context.Context) {
 }
 


### PR DESCRIPTION
Updates makefile and CI to use the go test `-race` flag, fixes a race in the fs watcher test harness, and skips compat tests that depend on an external container engine.