### PR TITLE
Fix controller image cross platform build

### DIFF
--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -1,12 +1,15 @@
 FROM --platform=$BUILDPLATFORM golang:1.22 AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 WORKDIR /go/src/app
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
 COPY . .
 
-RUN make GOOS=$TARGETOS GOARCH=$TARGETARCH
+RUN make build-controller GOOS=$TARGETOS GOARCH=$TARGETARCH
 
 FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9-minimal
 


### PR DESCRIPTION
Without these build args declared an amd64 binary is built and included in the arm64 controller image.