### PR TITLE
Add expiration validator to set minimum expiration time to 1m.

### DIFF
--- a/internal/cmd/skupper/token/kube/token_issue.go
+++ b/internal/cmd/skupper/token/kube/token_issue.go
@@ -46,6 +46,7 @@ func (cmd *CmdTokenIssue) ValidateInput(args []string) []error {
 	resourceStringValidator := validator.NewResourceStringValidator()
 	tokenStringValidator := validator.NewFilePathStringValidator()
 	timeoutValidator := validator.NewTimeoutInSecondsValidator()
+	expirationValidator := validator.NewExpirationInSecondsValidator()
 
 	// Validate token file name
 	if len(args) < 1 {
@@ -95,13 +96,12 @@ func (cmd *CmdTokenIssue) ValidateInput(args []string) []error {
 	}
 
 	// Validate flags
-	//TBD is there a limit to number of redemptions
 	if cmd.Flags != nil && cmd.Flags.RedemptionsAllowed < 1 {
 		validationErrors = append(validationErrors, fmt.Errorf("number of redemptions is not valid"))
 	}
 
 	if cmd.Flags != nil && cmd.Flags.ExpirationWindow.String() != "" {
-		ok, err := timeoutValidator.Evaluate(cmd.Flags.ExpirationWindow)
+		ok, err := expirationValidator.Evaluate(cmd.Flags.ExpirationWindow)
 		if !ok {
 			validationErrors = append(validationErrors, fmt.Errorf("expiration time is not valid: %s", err))
 		}

--- a/internal/cmd/skupper/token/kube/token_issue_test.go
+++ b/internal/cmd/skupper/token/kube/token_issue_test.go
@@ -364,9 +364,9 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 			name: "expiration is not valid",
 			args: []string{"~/token.yaml"},
 			flags: common.CommandTokenIssueFlags{
-				ExpirationWindow:   0 * time.Minute,
+				ExpirationWindow:   10 * time.Second,
 				RedemptionsAllowed: 1,
-				Timeout:            60 * time.Second,
+				Timeout:            10 * time.Second,
 			},
 			skupperObjects: []runtime.Object{
 				&v1alpha1.SiteList{
@@ -394,7 +394,7 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 					},
 				},
 			},
-			expectedErrors: []string{"expiration time is not valid: duration must not be less than 10s; got 0s"},
+			expectedErrors: []string{"expiration time is not valid: duration must not be less than 1m0s; got 10s"},
 		},
 		{
 			name: "timeout is not valid",

--- a/pkg/utils/validator/simple_validator.go
+++ b/pkg/utils/validator/simple_validator.go
@@ -162,6 +162,12 @@ func NewTimeoutInSecondsValidator() *DurationValidator {
 	}
 }
 
+func NewExpirationInSecondsValidator() *DurationValidator {
+	return &DurationValidator{
+		MinDuration: time.Minute * 1,
+	}
+}
+
 func (i DurationValidator) Evaluate(value time.Duration) (bool, error) {
 
 	if value < i.MinDuration {


### PR DESCRIPTION
Sets a minimum time value for a token to be valid. 