### PR TITLE
Updated rootful namespace home to var lib

### DIFF
--- a/cmd/bootstrap/README.md
+++ b/cmd/bootstrap/README.md
@@ -65,7 +65,7 @@ files are stored, like certificates, configurations, the original sources
 (original custom resources used to bootstrap the nonkube site) and
 the runtime files generated during initialization.
 
-Namespaces are stored under ${XDG_DATA_HOME}/.local/share/skupper/namespaces
+Namespaces are stored under ${XDG_DATA_HOME}/skupper/namespaces
 for regular users when XDG_DATA_HOME environment variable is set, or under
 ${HOME}/.local/share/skupper/namespaces when it is not set.
 As the root user, namespaces are stored under: /var/lib/skupper/namespaces.

--- a/cmd/bootstrap/README.md
+++ b/cmd/bootstrap/README.md
@@ -68,7 +68,7 @@ the runtime files generated during initialization.
 Namespaces are stored under ${XDG_DATA_HOME}/.local/share/skupper/namespaces
 for regular users when XDG_DATA_HOME environment variable is set, or under
 ${HOME}/.local/share/skupper/namespaces when it is not set.
-As the root user, namespaces are stored under: /usr/local/share/skupper/namespaces.
+As the root user, namespaces are stored under: /var/lib/skupper/namespaces.
 
 In case the path (-p) flag is omitted, Skupper will try to process
 custom resources stored at the sources directory of the default namespace,

--- a/cmd/bootstrap/bootstrap.go
+++ b/cmd/bootstrap/bootstrap.go
@@ -46,7 +46,7 @@ the runtime files generated during initialization.
 Namespaces are stored under ${XDG_DATA_HOME}/.local/share/skupper/namespaces
 for regular users when XDG_DATA_HOME environment variable is set, or under
 ${HOME}/.local/share/skupper/namespaces when it is not set.
-As the root user, namespaces are stored under: /usr/local/share/skupper/namespaces.
+As the root user, namespaces are stored under: /var/lib/skupper/namespaces.
 
 In case the path (-p) flag is omitted, Skupper will try to process
 custom resources stored at the sources directory of the default namespace,
@@ -102,7 +102,7 @@ func main() {
 	// definition based on CR files, if an input path has been provided.
 	// The /output path must be mapped to the Host's XDG_DATA_HOME/skupper
 	// or $HOME/.local/share/skupper (non-root)
-	// and /usr/local/share/skupper (root).
+	// and /var/lib/skupper (root).
 	//
 	fmt.Printf("Skupper nonkube bootstrap (version: %s)\n", version.Version)
 

--- a/cmd/bootstrap/bootstrap.go
+++ b/cmd/bootstrap/bootstrap.go
@@ -43,7 +43,7 @@ files are stored, like certificates, configurations, the original sources
 (original custom resources used to bootstrap the nonkube site) and
 the runtime files generated during initialization.
 
-Namespaces are stored under ${XDG_DATA_HOME}/.local/share/skupper/namespaces
+Namespaces are stored under ${XDG_DATA_HOME}/skupper/namespaces
 for regular users when XDG_DATA_HOME environment variable is set, or under
 ${HOME}/.local/share/skupper/namespaces when it is not set.
 As the root user, namespaces are stored under: /var/lib/skupper/namespaces.

--- a/cmd/bootstrap/bootstrap.sh
+++ b/cmd/bootstrap/bootstrap.sh
@@ -79,7 +79,7 @@ container_env() {
             export CONTAINER_ENDPOINT_DEFAULT="unix:///run/podman/podman.sock"
         fi
         export USERNS=""
-        export SKUPPER_OUTPUT_PATH="/usr/local/share/skupper"
+        export SKUPPER_OUTPUT_PATH="/var/lib/skupper"
         export SERVICE_DIR="/etc/systemd/system"
     fi
     mkdir -p "${SKUPPER_OUTPUT_PATH}"

--- a/cmd/bootstrap/remove.sh
+++ b/cmd/bootstrap/remove.sh
@@ -16,7 +16,7 @@ namespaces_path="${XDG_DATA_HOME:-${HOME}/.local/share}/skupper/namespaces"
 service_path="${XDG_CONFIG_HOME:-${HOME}/.config}/systemd/user"
 systemctl="systemctl --user"
 if [ "${UID}" -eq 0 ]; then
-    namespaces_path="/usr/local/share/skupper/namespaces"
+    namespaces_path="/var/lib/skupper/namespaces"
     service_path="/etc/systemd/system"
     systemctl="systemctl"
 fi

--- a/internal/nonkube/bundle/install.sh.template
+++ b/internal/nonkube/bundle/install.sh.template
@@ -30,7 +30,7 @@ export USERNS="keep-id"
 GID=$(id -g "${UID}")
 export RUNAS="${UID}:${GID}"
 if [ "${UID}" -eq 0 ]; then
-    export SKUPPER_OUTPUT_PATH="/usr/local/share/skupper"
+    export SKUPPER_OUTPUT_PATH="/var/lib/skupper"
     export SERVICE_DIR="/etc/systemd/system"
     export RUNTIME_DIR="/run"
     export SYSTEMCTL="systemctl"

--- a/pkg/config/platform.go
+++ b/pkg/config/platform.go
@@ -161,7 +161,7 @@ func GetPlatform() types.Platform {
 
 func getDataHome() string {
 	if os.Getuid() == 0 {
-		return "/usr/local/share/skupper"
+		return "/var/lib/skupper"
 	}
 	dataHome, ok := os.LookupEnv("XDG_DATA_HOME")
 	if !ok {

--- a/pkg/nonkube/api/environment.go
+++ b/pkg/nonkube/api/environment.go
@@ -33,7 +33,7 @@ var getUid IdGetter = os.Getuid
 
 func GetDataHome() string {
 	if getUid() == 0 {
-		return "/usr/local/share/skupper"
+		return "/var/lib/skupper"
 	}
 	dataHome, ok := os.LookupEnv("XDG_DATA_HOME")
 	if !ok {


### PR DESCRIPTION
* Only rootful namespace home has been updated to /var/lib
* Rootless remain as is assuming that XDG_DATA_HOME seems to be appropriate
   (see: https://specifications.freedesktop.org/basedir-spec/latest/)

Fixes #1689