### PR TITLE
rollback changes to network console api version

### DIFF
--- a/cmd/network-console-collector/internal/api/types_gen.go
+++ b/cmd/network-console-collector/internal/api/types_gen.go
@@ -1370,7 +1370,7 @@ func NewAddressesRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/addresses/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/addresses/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1404,7 +1404,7 @@ func NewAddressByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/addresses/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/addresses/%s/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1438,7 +1438,7 @@ func NewConnectionsByAddressRequest(server string, id PathID) (*http.Request, er
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/addresses/%s/connections/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/addresses/%s/connections/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1472,7 +1472,7 @@ func NewProcessesByAddressRequest(server string, id PathID) (*http.Request, erro
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/addresses/%s/processes/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/addresses/%s/processes/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1506,7 +1506,7 @@ func NewProcessPairsByAddressRequest(server string, id PathID) (*http.Request, e
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/addresses/%s/processpairs/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/addresses/%s/processpairs/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1533,7 +1533,7 @@ func NewApplicationflowsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/applicationflows/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/applicationflows/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1560,7 +1560,7 @@ func NewConnectionsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/connections/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/connections/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1587,7 +1587,7 @@ func NewConnectorsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/connectors/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/connectors/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1621,7 +1621,7 @@ func NewConnectorByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/connectors/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/connectors/%s/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1648,7 +1648,7 @@ func NewHostsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/hosts/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/hosts/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1682,7 +1682,7 @@ func NewHostsByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/hosts/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/hosts/%s/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1709,7 +1709,7 @@ func NewLinksRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/links/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/links/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1743,7 +1743,7 @@ func NewLinkByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/links/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/links/%s/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1770,7 +1770,7 @@ func NewListenersRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/listeners/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/listeners/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1804,7 +1804,7 @@ func NewListenerByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/listeners/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/listeners/%s/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1831,7 +1831,7 @@ func NewProcessesRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/processes/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/processes/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1865,7 +1865,7 @@ func NewProcessByIdRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/processes/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/processes/%s/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1892,7 +1892,7 @@ func NewProcessgrouppairsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/processgrouppairs/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/processgrouppairs/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1926,7 +1926,7 @@ func NewProcessgrouppairByIDRequest(server string, id PathID) (*http.Request, er
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/processgrouppairs/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/processgrouppairs/%s/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1953,7 +1953,7 @@ func NewProcessgroupsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/processgroups/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/processgroups/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1987,7 +1987,7 @@ func NewProcessgroupByIDRequest(server string, id PathID) (*http.Request, error)
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/processgroups/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/processgroups/%s/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2014,7 +2014,7 @@ func NewProcesspairsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/processpairs/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/processpairs/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2048,7 +2048,7 @@ func NewProcesspairByIDRequest(server string, id PathID) (*http.Request, error) 
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/processpairs/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/processpairs/%s/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2075,7 +2075,7 @@ func NewRouteraccessRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/routeraccess/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/routeraccess/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2109,7 +2109,7 @@ func NewRouteraccessByIDRequest(server string, id PathID) (*http.Request, error)
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/routeraccess/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/routeraccess/%s/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2136,7 +2136,7 @@ func NewRouterlinksRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/routerlinks/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/routerlinks/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2170,7 +2170,7 @@ func NewRouterlinkByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/routerlinks/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/routerlinks/%s/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2197,7 +2197,7 @@ func NewRoutersRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/routers/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/routers/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2231,7 +2231,7 @@ func NewRouterByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/routers/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/routers/%s/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2265,7 +2265,7 @@ func NewLinksByRouterRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/routers/%s/links/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/routers/%s/links/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2292,7 +2292,7 @@ func NewSitepairsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/sitepairs/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/sitepairs/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2326,7 +2326,7 @@ func NewSitepairByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/sitepairs/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/sitepairs/%s/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2353,7 +2353,7 @@ func NewSitesRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/sites/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/sites/")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2387,7 +2387,7 @@ func NewSiteByIdRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/sites/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/sites/%s/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2421,7 +2421,7 @@ func NewHostsBySiteRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/sites/%s/hosts/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/sites/%s/hosts/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2455,7 +2455,7 @@ func NewLinksBySiteRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/sites/%s/links/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/sites/%s/links/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2489,7 +2489,7 @@ func NewProcessesBySiteRequest(server string, id PathID) (*http.Request, error) 
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/sites/%s/processes/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/sites/%s/processes/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2523,7 +2523,7 @@ func NewRoutersBySiteRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v2alpha1/sites/%s/routers/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/sites/%s/routers/", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5124,118 +5124,118 @@ func ParseRoutersBySiteResponse(rsp *http.Response) (*RoutersBySiteResponse, err
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
 
-	// (GET /api/v2alpha1/addresses/)
+	// (GET /api/v1alpha1/addresses/)
 	Addresses(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/addresses/{id}/)
+	// (GET /api/v1alpha1/addresses/{id}/)
 	AddressByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/addresses/{id}/connections/)
+	// (GET /api/v1alpha1/addresses/{id}/connections/)
 	ConnectionsByAddress(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/addresses/{id}/processes/)
+	// (GET /api/v1alpha1/addresses/{id}/processes/)
 	ProcessesByAddress(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/addresses/{id}/processpairs/)
+	// (GET /api/v1alpha1/addresses/{id}/processpairs/)
 	ProcessPairsByAddress(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/applicationflows/)
+	// (GET /api/v1alpha1/applicationflows/)
 	Applicationflows(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/connections/)
+	// (GET /api/v1alpha1/connections/)
 	Connections(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/connectors/)
+	// (GET /api/v1alpha1/connectors/)
 	Connectors(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/connectors/{id}/)
+	// (GET /api/v1alpha1/connectors/{id}/)
 	ConnectorByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/hosts/)
+	// (GET /api/v1alpha1/hosts/)
 	Hosts(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/hosts/{id}/)
+	// (GET /api/v1alpha1/hosts/{id}/)
 	HostsByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/links/)
+	// (GET /api/v1alpha1/links/)
 	Links(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/links/{id}/)
+	// (GET /api/v1alpha1/links/{id}/)
 	LinkByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/listeners/)
+	// (GET /api/v1alpha1/listeners/)
 	Listeners(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/listeners/{id}/)
+	// (GET /api/v1alpha1/listeners/{id}/)
 	ListenerByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/processes/)
+	// (GET /api/v1alpha1/processes/)
 	Processes(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/processes/{id}/)
+	// (GET /api/v1alpha1/processes/{id}/)
 	ProcessById(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/processgrouppairs/)
+	// (GET /api/v1alpha1/processgrouppairs/)
 	Processgrouppairs(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/processgrouppairs/{id}/)
+	// (GET /api/v1alpha1/processgrouppairs/{id}/)
 	ProcessgrouppairByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/processgroups/)
+	// (GET /api/v1alpha1/processgroups/)
 	Processgroups(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/processgroups/{id}/)
+	// (GET /api/v1alpha1/processgroups/{id}/)
 	ProcessgroupByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/processpairs/)
+	// (GET /api/v1alpha1/processpairs/)
 	Processpairs(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/processpairs/{id}/)
+	// (GET /api/v1alpha1/processpairs/{id}/)
 	ProcesspairByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/routeraccess/)
+	// (GET /api/v1alpha1/routeraccess/)
 	Routeraccess(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/routeraccess/{id}/)
+	// (GET /api/v1alpha1/routeraccess/{id}/)
 	RouteraccessByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/routerlinks/)
+	// (GET /api/v1alpha1/routerlinks/)
 	Routerlinks(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/routerlinks/{id}/)
+	// (GET /api/v1alpha1/routerlinks/{id}/)
 	RouterlinkByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/routers/)
+	// (GET /api/v1alpha1/routers/)
 	Routers(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/routers/{id}/)
+	// (GET /api/v1alpha1/routers/{id}/)
 	RouterByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/routers/{id}/links/)
+	// (GET /api/v1alpha1/routers/{id}/links/)
 	LinksByRouter(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/sitepairs/)
+	// (GET /api/v1alpha1/sitepairs/)
 	Sitepairs(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/sitepairs/{id}/)
+	// (GET /api/v1alpha1/sitepairs/{id}/)
 	SitepairByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/sites/)
+	// (GET /api/v1alpha1/sites/)
 	Sites(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v2alpha1/sites/{id}/)
+	// (GET /api/v1alpha1/sites/{id}/)
 	SiteById(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/sites/{id}/hosts/)
+	// (GET /api/v1alpha1/sites/{id}/hosts/)
 	HostsBySite(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/sites/{id}/links/)
+	// (GET /api/v1alpha1/sites/{id}/links/)
 	LinksBySite(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/sites/{id}/processes/)
+	// (GET /api/v1alpha1/sites/{id}/processes/)
 	ProcessesBySite(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v2alpha1/sites/{id}/routers/)
+	// (GET /api/v1alpha1/sites/{id}/routers/)
 	RoutersBySite(w http.ResponseWriter, r *http.Request, id PathID)
 }
 
@@ -6173,81 +6173,81 @@ func HandlerWithOptions(si ServerInterface, options GorillaServerOptions) http.H
 		ErrorHandlerFunc:   options.ErrorHandlerFunc,
 	}
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/addresses/", wrapper.Addresses).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/addresses/", wrapper.Addresses).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/addresses/{id}/", wrapper.AddressByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/addresses/{id}/", wrapper.AddressByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/addresses/{id}/connections/", wrapper.ConnectionsByAddress).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/addresses/{id}/connections/", wrapper.ConnectionsByAddress).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/addresses/{id}/processes/", wrapper.ProcessesByAddress).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/addresses/{id}/processes/", wrapper.ProcessesByAddress).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/addresses/{id}/processpairs/", wrapper.ProcessPairsByAddress).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/addresses/{id}/processpairs/", wrapper.ProcessPairsByAddress).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/applicationflows/", wrapper.Applicationflows).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/applicationflows/", wrapper.Applicationflows).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/connections/", wrapper.Connections).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/connections/", wrapper.Connections).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/connectors/", wrapper.Connectors).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/connectors/", wrapper.Connectors).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/connectors/{id}/", wrapper.ConnectorByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/connectors/{id}/", wrapper.ConnectorByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/hosts/", wrapper.Hosts).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/hosts/", wrapper.Hosts).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/hosts/{id}/", wrapper.HostsByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/hosts/{id}/", wrapper.HostsByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/links/", wrapper.Links).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/links/", wrapper.Links).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/links/{id}/", wrapper.LinkByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/links/{id}/", wrapper.LinkByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/listeners/", wrapper.Listeners).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/listeners/", wrapper.Listeners).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/listeners/{id}/", wrapper.ListenerByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/listeners/{id}/", wrapper.ListenerByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/processes/", wrapper.Processes).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processes/", wrapper.Processes).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/processes/{id}/", wrapper.ProcessById).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processes/{id}/", wrapper.ProcessById).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/processgrouppairs/", wrapper.Processgrouppairs).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processgrouppairs/", wrapper.Processgrouppairs).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/processgrouppairs/{id}/", wrapper.ProcessgrouppairByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processgrouppairs/{id}/", wrapper.ProcessgrouppairByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/processgroups/", wrapper.Processgroups).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processgroups/", wrapper.Processgroups).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/processgroups/{id}/", wrapper.ProcessgroupByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processgroups/{id}/", wrapper.ProcessgroupByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/processpairs/", wrapper.Processpairs).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processpairs/", wrapper.Processpairs).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/processpairs/{id}/", wrapper.ProcesspairByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processpairs/{id}/", wrapper.ProcesspairByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/routeraccess/", wrapper.Routeraccess).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routeraccess/", wrapper.Routeraccess).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/routeraccess/{id}/", wrapper.RouteraccessByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routeraccess/{id}/", wrapper.RouteraccessByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/routerlinks/", wrapper.Routerlinks).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routerlinks/", wrapper.Routerlinks).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/routerlinks/{id}/", wrapper.RouterlinkByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routerlinks/{id}/", wrapper.RouterlinkByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/routers/", wrapper.Routers).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routers/", wrapper.Routers).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/routers/{id}/", wrapper.RouterByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routers/{id}/", wrapper.RouterByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/routers/{id}/links/", wrapper.LinksByRouter).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routers/{id}/links/", wrapper.LinksByRouter).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/sitepairs/", wrapper.Sitepairs).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sitepairs/", wrapper.Sitepairs).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/sitepairs/{id}/", wrapper.SitepairByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sitepairs/{id}/", wrapper.SitepairByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/sites/", wrapper.Sites).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/", wrapper.Sites).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/sites/{id}/", wrapper.SiteById).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/{id}/", wrapper.SiteById).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/sites/{id}/hosts/", wrapper.HostsBySite).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/{id}/hosts/", wrapper.HostsBySite).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/sites/{id}/links/", wrapper.LinksBySite).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/{id}/links/", wrapper.LinksBySite).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/sites/{id}/processes/", wrapper.ProcessesBySite).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/{id}/processes/", wrapper.ProcessesBySite).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v2alpha1/sites/{id}/routers/", wrapper.RoutersBySite).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/{id}/routers/", wrapper.RoutersBySite).Methods("GET")
 
 	return r
 }

--- a/cmd/network-console-collector/internal/collector/flows.go
+++ b/cmd/network-console-collector/internal/collector/flows.go
@@ -53,7 +53,7 @@ func (r ConnectionRecord) Identity() string {
 func (r ConnectionRecord) GetTypeMeta() vanflow.TypeMeta {
 	return vanflow.TypeMeta{
 		Type:       "ConnectionRecord",
-		APIVersion: "v2alpha1",
+		APIVersion: "v1alpha1",
 	}
 }
 
@@ -126,7 +126,7 @@ func (r RequestRecord) Identity() string {
 func (r RequestRecord) GetTypeMeta() vanflow.TypeMeta {
 	return vanflow.TypeMeta{
 		Type:       "RequestRecord",
-		APIVersion: "v2alpha1",
+		APIVersion: "v1alpha1",
 	}
 }
 

--- a/cmd/network-console-collector/internal/collector/records.go
+++ b/cmd/network-console-collector/internal/collector/records.go
@@ -22,7 +22,7 @@ func (r AddressRecord) Identity() string {
 func (r AddressRecord) GetTypeMeta() vanflow.TypeMeta {
 	return vanflow.TypeMeta{
 		Type:       "AddressRecord",
-		APIVersion: "v2alpha1",
+		APIVersion: "v1alpha1",
 	}
 }
 
@@ -39,7 +39,7 @@ func (r ProcessGroupRecord) Identity() string {
 func (r ProcessGroupRecord) GetTypeMeta() vanflow.TypeMeta {
 	return vanflow.TypeMeta{
 		Type:       "ProcessGroupRecord",
-		APIVersion: "v2alpha1",
+		APIVersion: "v1alpha1",
 	}
 }
 
@@ -57,7 +57,7 @@ func (r SitePairRecord) Identity() string {
 func (r SitePairRecord) GetTypeMeta() vanflow.TypeMeta {
 	return vanflow.TypeMeta{
 		Type:       "SitePairRecord",
-		APIVersion: "v2alpha1",
+		APIVersion: "v1alpha1",
 	}
 }
 
@@ -78,7 +78,7 @@ func (r ProcGroupPairRecord) Identity() string {
 func (r ProcGroupPairRecord) GetTypeMeta() vanflow.TypeMeta {
 	return vanflow.TypeMeta{
 		Type:       "ProcGroupPairRecord",
-		APIVersion: "v2alpha1",
+		APIVersion: "v1alpha1",
 	}
 }
 
@@ -98,7 +98,7 @@ func (r ProcPairRecord) Identity() string {
 func (r ProcPairRecord) GetTypeMeta() vanflow.TypeMeta {
 	return vanflow.TypeMeta{
 		Type:       "ProcPairRecord",
-		APIVersion: "v2alpha1",
+		APIVersion: "v1alpha1",
 	}
 }
 
@@ -118,6 +118,6 @@ func (r FlowSourceRecord) Identity() string {
 func (r FlowSourceRecord) GetTypeMeta() vanflow.TypeMeta {
 	return vanflow.TypeMeta{
 		Type:       "FlowSourceRecord",
-		APIVersion: "v2alpha1",
+		APIVersion: "v1alpha1",
 	}
 }

--- a/cmd/network-console-collector/internal/server/handlers.go
+++ b/cmd/network-console-collector/internal/server/handlers.go
@@ -12,7 +12,7 @@ import (
 
 var _ api.ServerInterface = (*server)(nil)
 
-// (GET /api/v2alpha1/connections/)
+// (GET /api/v1alpha1/connections/)
 func (s *server) Connections(w http.ResponseWriter, r *http.Request) {
 	results := views.NewConnectionsSliceProvider(s.records)(listByType[collector.ConnectionRecord](s.records))
 	if err := handleCollection(w, r, &api.ConnectionListResponse{}, results); err != nil {
@@ -20,7 +20,7 @@ func (s *server) Connections(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// (GET /api/v2alpha1/addresses/{id}/connections/)
+// (GET /api/v1alpha1/addresses/{id}/connections/)
 func (s *server) ConnectionsByAddress(w http.ResponseWriter, r *http.Request, id string) {
 	getExemplar := fetchAndMap(s.records, func(a collector.AddressRecord) store.Entry {
 		return store.Entry{Record: collector.ConnectionRecord{RoutingKey: a.Name, Protocol: a.Protocol}}
@@ -39,7 +39,7 @@ func (s *server) Applicationflows(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// (GET /api/v2alpha1/addresses/)
+// (GET /api/v1alpha1/addresses/)
 func (s *server) Addresses(w http.ResponseWriter, r *http.Request) {
 	results := views.NewAddressSliceProvider(s.records, s.graph)(listByType[collector.AddressRecord](s.records))
 	if err := handleCollection(w, r, &api.AddressListResponse{}, results); err != nil {
@@ -47,7 +47,7 @@ func (s *server) Addresses(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// (GET /api/v2alpha1/addresses/{id}/)
+// (GET /api/v1alpha1/addresses/{id}/)
 func (s *server) AddressByID(w http.ResponseWriter, r *http.Request, id string) {
 	getRecord := fetchAndMap(s.records, views.NewAddressProvider(s.records, s.graph), id)
 	if err := handleSingle(w, r, &api.AddressResponse{}, getRecord); err != nil {
@@ -55,7 +55,7 @@ func (s *server) AddressByID(w http.ResponseWriter, r *http.Request, id string) 
 	}
 }
 
-// (GET /api/v2alpha1/addresses/{id}/processes/)
+// (GET /api/v1alpha1/addresses/{id}/processes/)
 func (s *server) ProcessesByAddress(w http.ResponseWriter, r *http.Request, id string) {
 	//todo(ck) find a way to more directly index this
 	anode := s.graph.Address(id)
@@ -82,7 +82,7 @@ func (s *server) ProcessesByAddress(w http.ResponseWriter, r *http.Request, id s
 
 }
 
-// (GET /api/v2alpha1/addresses/{id}/processpairs/)
+// (GET /api/v1alpha1/addresses/{id}/processpairs/)
 func (s *server) ProcessPairsByAddress(w http.ResponseWriter, r *http.Request, id string) {
 	//todo(ck) find a way to more directly index this
 	addr, ok := s.graph.Address(id).GetRecord()
@@ -122,7 +122,7 @@ func (s *server) ProcessPairsByAddress(w http.ResponseWriter, r *http.Request, i
 	}
 }
 
-// (GET /api/v2alpha1/connectors/)
+// (GET /api/v1alpha1/connectors/)
 func (s *server) Connectors(w http.ResponseWriter, r *http.Request) {
 	results := views.NewConnectorSliceProvider(s.graph)(listByType[vanflow.ConnectorRecord](s.records))
 	if err := handleCollection(w, r, &api.ConnectorListResponse{}, results); err != nil {
@@ -130,7 +130,7 @@ func (s *server) Connectors(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// (GET /api/v2alpha1/connectors/{id}/)
+// (GET /api/v1alpha1/connectors/{id}/)
 func (s *server) ConnectorByID(w http.ResponseWriter, r *http.Request, id string) {
 	getRecord := fetchAndMap(s.records, views.NewConnectorProvider(s.graph), id)
 	if err := handleSingle(w, r, &api.ConnectorResponse{}, getRecord); err != nil {
@@ -139,7 +139,7 @@ func (s *server) ConnectorByID(w http.ResponseWriter, r *http.Request, id string
 }
 
 // Hosts deprecated
-// (GET /api/v2alpha1/hosts/)
+// (GET /api/v1alpha1/hosts/)
 func (s *server) Hosts(w http.ResponseWriter, r *http.Request) {
 	if err := handleCollection(w, r, &api.SiteListResponse{}, []api.SiteRecord{}); err != nil {
 		s.logWriteError(r, err)
@@ -147,7 +147,7 @@ func (s *server) Hosts(w http.ResponseWriter, r *http.Request) {
 }
 
 // HostsByID deprecated
-// (GET /api/v2alpha1/hosts/{id}/)
+// (GET /api/v1alpha1/hosts/{id}/)
 func (s *server) HostsByID(w http.ResponseWriter, r *http.Request, id string) {
 	if err := handleSingle(w, r, &api.SiteResponse{}, func() (r api.SiteRecord, found bool) {
 		return r, false
@@ -156,7 +156,7 @@ func (s *server) HostsByID(w http.ResponseWriter, r *http.Request, id string) {
 	}
 }
 
-// (GET /api/v2alpha1/links/)
+// (GET /api/v1alpha1/links/)
 func (s *server) Links(w http.ResponseWriter, r *http.Request) {
 	results := views.NewLinkSliceProvider(s.graph)(listByType[vanflow.LinkRecord](s.records))
 	if err := handleCollection(w, r, &api.LinkListResponse{}, results); err != nil {
@@ -164,7 +164,7 @@ func (s *server) Links(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// (GET /api/v2alpha1/links/{id}/)
+// (GET /api/v1alpha1/links/{id}/)
 func (s *server) LinkByID(w http.ResponseWriter, r *http.Request, id string) {
 	getRecord := fetchAndConditionalMap(s.records, views.NewLinkProvider(s.graph), id)
 	if err := handleSingle(w, r, &api.LinkResponse{}, getRecord); err != nil {
@@ -172,7 +172,7 @@ func (s *server) LinkByID(w http.ResponseWriter, r *http.Request, id string) {
 	}
 }
 
-// (GET /api/v2alpha1/listeners/)
+// (GET /api/v1alpha1/listeners/)
 func (s *server) Listeners(w http.ResponseWriter, r *http.Request) {
 	results := views.NewListenerSliceProvider(s.graph)(listByType[vanflow.ListenerRecord](s.records))
 	if err := handleCollection(w, r, &api.ListenerListResponse{}, results); err != nil {
@@ -180,7 +180,7 @@ func (s *server) Listeners(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// (GET /api/v2alpha1/listeners/{id}/)
+// (GET /api/v1alpha1/listeners/{id}/)
 func (s *server) ListenerByID(w http.ResponseWriter, r *http.Request, id string) {
 	getRecord := fetchAndMap(s.records, views.NewListenerProvider(s.graph), id)
 	if err := handleSingle(w, r, &api.ListenerResponse{}, getRecord); err != nil {
@@ -188,7 +188,7 @@ func (s *server) ListenerByID(w http.ResponseWriter, r *http.Request, id string)
 	}
 }
 
-// (GET /api/v2alpha1/processes/)
+// (GET /api/v1alpha1/processes/)
 func (s *server) Processes(w http.ResponseWriter, r *http.Request) {
 	results := views.NewProcessSliceProvider(s.records, s.graph)(listByType[vanflow.ProcessRecord](s.records))
 	if err := handleCollection(w, r, &api.ProcessListResponse{}, results); err != nil {
@@ -196,7 +196,7 @@ func (s *server) Processes(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// (GET /api/v2alpha1/processes/{id}/)
+// (GET /api/v1alpha1/processes/{id}/)
 func (s *server) ProcessById(w http.ResponseWriter, r *http.Request, id string) {
 	getRecord := fetchAndMap(s.records, views.NewProcessProvider(s.records, s.graph), id)
 	if err := handleSingle(w, r, &api.ProcessResponse{}, getRecord); err != nil {
@@ -204,7 +204,7 @@ func (s *server) ProcessById(w http.ResponseWriter, r *http.Request, id string) 
 	}
 }
 
-// (GET /api/v2alpha1/processgrouppairs/)
+// (GET /api/v1alpha1/processgrouppairs/)
 func (s *server) Processgrouppairs(w http.ResponseWriter, r *http.Request) {
 	results := views.NewProcessGroupPairSliceProvider()(listByType[collector.ProcGroupPairRecord](s.records))
 	if err := handleCollection(w, r, &api.FlowAggregateListResponse{}, results); err != nil {
@@ -212,7 +212,7 @@ func (s *server) Processgrouppairs(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// (GET /api/v2alpha1/processgrouppairs/{id}/)
+// (GET /api/v1alpha1/processgrouppairs/{id}/)
 func (s *server) ProcessgrouppairByID(w http.ResponseWriter, r *http.Request, id string) {
 	getRecord := fetchAndMap(s.records, views.NewProcessGroupPairProvider(), id)
 	if err := handleSingle(w, r, &api.FlowAggregateResponse{}, getRecord); err != nil {
@@ -220,7 +220,7 @@ func (s *server) ProcessgrouppairByID(w http.ResponseWriter, r *http.Request, id
 	}
 }
 
-// (GET /api/v2alpha1/processgroups/)
+// (GET /api/v1alpha1/processgroups/)
 func (s *server) Processgroups(w http.ResponseWriter, r *http.Request) {
 	results := views.NewProcessGroupSliceProvider(s.records)(listByType[collector.ProcessGroupRecord](s.records))
 	if err := handleCollection(w, r, &api.ProcessGroupListResponse{}, results); err != nil {
@@ -228,7 +228,7 @@ func (s *server) Processgroups(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// (GET /api/v2alpha1/processgroups/{id}/)
+// (GET /api/v1alpha1/processgroups/{id}/)
 func (s *server) ProcessgroupByID(w http.ResponseWriter, r *http.Request, id string) {
 	getRecord := fetchAndMap(s.records, views.NewProcessGroupProvider(s.records), id)
 	if err := handleSingle(w, r, &api.ProcessGroupResponse{}, getRecord); err != nil {
@@ -236,7 +236,7 @@ func (s *server) ProcessgroupByID(w http.ResponseWriter, r *http.Request, id str
 	}
 }
 
-// (GET /api/v2alpha1/processpairs/)
+// (GET /api/v1alpha1/processpairs/)
 func (s *server) Processpairs(w http.ResponseWriter, r *http.Request) {
 	results := views.NewProcessPairSliceProvider(s.graph)(listByType[collector.ProcPairRecord](s.records))
 	if err := handleCollection(w, r, &api.FlowAggregateListResponse{}, results); err != nil {
@@ -244,7 +244,7 @@ func (s *server) Processpairs(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// (GET /api/v2alpha1/processpairs/{id}/)
+// (GET /api/v1alpha1/processpairs/{id}/)
 func (s *server) ProcesspairByID(w http.ResponseWriter, r *http.Request, id string) {
 	getRecord := fetchAndMap(s.records, views.NewProcessPairProvider(s.graph), id)
 	if err := handleSingle(w, r, &api.FlowAggregateResponse{}, getRecord); err != nil {
@@ -252,7 +252,7 @@ func (s *server) ProcesspairByID(w http.ResponseWriter, r *http.Request, id stri
 	}
 }
 
-// (GET /api/v2alpha1/routeraccess/)
+// (GET /api/v1alpha1/routeraccess/)
 func (s *server) Routeraccess(w http.ResponseWriter, r *http.Request) {
 	results := views.RouterAccessList(listByType[vanflow.RouterAccessRecord](s.records))
 	if err := handleCollection(w, r, &api.RouterAccessListResponse{}, results); err != nil {
@@ -260,7 +260,7 @@ func (s *server) Routeraccess(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// (GET /api/v2alpha1/routeraccess/{id}/)
+// (GET /api/v1alpha1/routeraccess/{id}/)
 func (s *server) RouteraccessByID(w http.ResponseWriter, r *http.Request, id string) {
 	getRecord := fetchAndMap(s.records, views.RouterAccess, id)
 	if err := handleSingle(w, r, &api.RouterAccessResponse{}, getRecord); err != nil {
@@ -268,7 +268,7 @@ func (s *server) RouteraccessByID(w http.ResponseWriter, r *http.Request, id str
 	}
 }
 
-// (GET /api/v2alpha1/routerlinks/)
+// (GET /api/v1alpha1/routerlinks/)
 func (s *server) Routerlinks(w http.ResponseWriter, r *http.Request) {
 	results := views.NewRotuerLinkSliceProvider(s.graph)(listByType[vanflow.LinkRecord](s.records))
 	if err := handleCollection(w, r, &api.RouterLinkListResponse{}, results); err != nil {
@@ -276,7 +276,7 @@ func (s *server) Routerlinks(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// (GET /api/v2alpha1/routerlinks/{id}/)
+// (GET /api/v1alpha1/routerlinks/{id}/)
 func (s *server) RouterlinkByID(w http.ResponseWriter, r *http.Request, id string) {
 	getRecord := fetchAndConditionalMap(s.records, views.NewRouterLinkProvider(s.graph), id)
 	if err := handleSingle(w, r, &api.RouterLinkResponse{}, getRecord); err != nil {
@@ -284,7 +284,7 @@ func (s *server) RouterlinkByID(w http.ResponseWriter, r *http.Request, id strin
 	}
 }
 
-// (GET /api/v2alpha1/routers/)
+// (GET /api/v1alpha1/routers/)
 func (s *server) Routers(w http.ResponseWriter, r *http.Request) {
 	results := views.Routers(listByType[vanflow.RouterRecord](s.records))
 	if err := handleCollection(w, r, &api.RouterListResponse{}, results); err != nil {
@@ -292,7 +292,7 @@ func (s *server) Routers(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// (GET /api/v2alpha1/routers/{id}/)
+// (GET /api/v1alpha1/routers/{id}/)
 func (s *server) RouterByID(w http.ResponseWriter, r *http.Request, id string) {
 	getRecord := fetchAndMap(s.records, views.Router, id)
 	if err := handleSingle(w, r, &api.RouterResponse{}, getRecord); err != nil {
@@ -300,7 +300,7 @@ func (s *server) RouterByID(w http.ResponseWriter, r *http.Request, id string) {
 	}
 }
 
-// (GET /api/v2alpha1/routers/{id}/links/)
+// (GET /api/v1alpha1/routers/{id}/links/)
 func (s *server) LinksByRouter(w http.ResponseWriter, r *http.Request, id string) {
 	exemplar := store.Entry{Record: vanflow.LinkRecord{Parent: &id}}
 	results := views.NewLinkSliceProvider(s.graph)(index(s.records, collector.IndexByTypeParent, exemplar))
@@ -309,7 +309,7 @@ func (s *server) LinksByRouter(w http.ResponseWriter, r *http.Request, id string
 	}
 }
 
-// (GET /api/v2alpha1/sitepairs/)
+// (GET /api/v1alpha1/sitepairs/)
 func (s *server) Sitepairs(w http.ResponseWriter, r *http.Request) {
 	results := views.NewSitePairSliceProvider(s.graph)(listByType[collector.SitePairRecord](s.records))
 	if err := handleCollection(w, r, &api.FlowAggregateListResponse{}, results); err != nil {
@@ -317,11 +317,11 @@ func (s *server) Sitepairs(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// (GET /api/v2alpha1/sitepairs/{id}/)
+// (GET /api/v1alpha1/sitepairs/{id}/)
 func (s *server) SitepairByID(w http.ResponseWriter, r *http.Request, id string) {
 }
 
-// (GET /api/v2alpha1/sites/)
+// (GET /api/v1alpha1/sites/)
 func (s *server) Sites(w http.ResponseWriter, r *http.Request) {
 	results := views.NewSiteSliceProvider(s.graph)(listByType[vanflow.SiteRecord](s.records))
 	if err := handleCollection(w, r, &api.SiteListResponse{}, results); err != nil {
@@ -329,7 +329,7 @@ func (s *server) Sites(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// (GET /api/v2alpha1/sites/{id}/)
+// (GET /api/v1alpha1/sites/{id}/)
 func (s *server) SiteById(w http.ResponseWriter, r *http.Request, id string) {
 	getRecord := fetchAndMap(s.records, views.NewSiteProvider(s.graph), id)
 	if err := handleSingle(w, r, &api.SiteResponse{}, getRecord); err != nil {
@@ -337,7 +337,7 @@ func (s *server) SiteById(w http.ResponseWriter, r *http.Request, id string) {
 	}
 }
 
-// (GET /api/v2alpha1/sites/{id}/hosts/)
+// (GET /api/v1alpha1/sites/{id}/hosts/)
 func (s *server) HostsBySite(w http.ResponseWriter, r *http.Request, id string) {
 	//TODO(ck) implement
 	if err := handleCollection(w, r, &api.SiteListResponse{}, []api.SiteRecord{}); err != nil {
@@ -345,7 +345,7 @@ func (s *server) HostsBySite(w http.ResponseWriter, r *http.Request, id string) 
 	}
 }
 
-// (GET /api/v2alpha1/sites/{id}/links/)
+// (GET /api/v1alpha1/sites/{id}/links/)
 func (s *server) LinksBySite(w http.ResponseWriter, r *http.Request, id string) {
 	node := s.graph.Site(id)
 	linkNodes := node.Links()
@@ -361,7 +361,7 @@ func (s *server) LinksBySite(w http.ResponseWriter, r *http.Request, id string) 
 	}
 }
 
-// (GET /api/v2alpha1/sites/{id}/processes/)
+// (GET /api/v1alpha1/sites/{id}/processes/)
 func (s *server) ProcessesBySite(w http.ResponseWriter, r *http.Request, id string) {
 	exemplar := store.Entry{Record: vanflow.ProcessRecord{Parent: &id}}
 	results := views.NewProcessSliceProvider(s.records, s.graph)(index(s.records, collector.IndexByTypeParent, exemplar))
@@ -370,7 +370,7 @@ func (s *server) ProcessesBySite(w http.ResponseWriter, r *http.Request, id stri
 	}
 }
 
-// (GET /api/v2alpha1/sites/{id}/routers/)
+// (GET /api/v1alpha1/sites/{id}/routers/)
 func (s *server) RoutersBySite(w http.ResponseWriter, r *http.Request, id string) {
 	exemplar := store.Entry{Record: vanflow.RouterRecord{Parent: &id}}
 	results := views.Routers(index(s.records, collector.IndexByTypeParent, exemplar))

--- a/cmd/network-console-collector/main.go
+++ b/cmd/network-console-collector/main.go
@@ -53,7 +53,7 @@ func run(cfg Config) error {
 	)
 
 	var mux = mux.NewRouter().StrictSlash(true)
-	promSubrouter := mux.PathPrefix("/api/v2alpha1/internal/prom")
+	promSubrouter := mux.PathPrefix("/api/v1alpha1/internal/prom")
 	mux.Handle("/metrics", handleMetrics(reg))
 	mux.PathPrefix("/swagger").Handler(handleSwagger("/swagger", specFS))
 	apiMux := mux.PathPrefix("/").Subrouter()
@@ -70,9 +70,9 @@ func run(cfg Config) error {
 			return fmt.Errorf("error parsing prometheus-api as URL: %s", err)
 		}
 		// add unspec'd api routes
-		apiMux.Path("/api/v2alpha1/user").Handler(handleNoContent())
-		apiMux.Path("/api/v2alpha1/logout").Handler(handleNoContent())
-		promSubrouter.Handler(handleProxyPrometheusAPI("/api/v2alpha1/internal/prom", promAPI))
+		apiMux.Path("/api/v1alpha1/user").Handler(handleNoContent())
+		apiMux.Path("/api/v1alpha1/logout").Handler(handleNoContent())
+		promSubrouter.Handler(handleProxyPrometheusAPI("/api/v1alpha1/internal/prom", promAPI))
 
 		apiMux.PathPrefix("/").Handler(handleConsoleAssets(cfg.ConsoleLocation))
 	}


### PR DESCRIPTION
The network console api version is v1alpha1 and should not be conflated with the skupper.io CRD resource versions.