### PR TITLE
Fixes #1717 - Change the syntax of the 'oneOf' clause

### DIFF
--- a/api/types/crds/skupper_connector_crd.yaml
+++ b/api/types/crds/skupper_connector_crd.yaml
@@ -37,12 +37,10 @@ spec:
               - routingKey
               - port
               oneOf:
-                - properties:
-                  required:
-                  - selector
-                - properties:
-                  required:
-                  - host
+              - required:
+                - selector
+              - required:
+                - host
             status:
               type: object
               properties:


### PR DESCRIPTION
This change matches the syntax of the 'oneOf' clause (for validation) to the syntax that is returned when you use the `kubectl get crd connectors.skupper.io -o yaml` command.

Even though the two syntaxes are semantically equivalent (I believe), `kubectl apply -f` detects a mismatch and will patch the CRD with no effect.
