### PR TITLE
Add stability to TestGateway and TestBasic tests

### DIFF
--- a/test/integration/acceptance/custom/basic/basic.go
+++ b/test/integration/acceptance/custom/basic/basic.go
@@ -232,6 +232,7 @@ func (r *BasicTestRunner) Run(ctx context.Context, t *testing.T) {
 			skip:       base.MultipleClusters(),
 			skipReason: SkipReasonIngressNone,
 			testSync:   true,
+			tokenType:  "claim",
 			createOptsPublic: types.SiteConfigSpec{
 				SkupperName:         "",
 				RouterMode:          string(types.TransportModeInterior),
@@ -297,9 +298,10 @@ func (r *BasicTestRunner) Run(ctx context.Context, t *testing.T) {
 			},
 		},
 		{
-			id:       "interiors-ingress-default",
-			doc:      "Connecting two interiors with ingress=default (route if available or loadbalancer)",
-			testSync: false,
+			id:        "interiors-ingress-default",
+			doc:       "Connecting two interiors with ingress=default (route if available or loadbalancer)",
+			testSync:  false,
+			tokenType: "claim",
 			createOptsPublic: types.SiteConfigSpec{
 				SkupperName:         "",
 				RouterMode:          string(types.TransportModeInterior),

--- a/test/integration/acceptance/custom/basic/basic.go
+++ b/test/integration/acceptance/custom/basic/basic.go
@@ -76,20 +76,20 @@ func (r *BasicTestRunner) Setup(ctx context.Context, createOptsPublic types.Site
 
 	const secretFile = "/tmp/public_basic_1_secret.yaml"
 	if tokenType == "claim" {
-		err = utils.Retry(time.Second, 15, func() (bool, error) {
+		err = utils.RetryError(3*time.Second, 5, func() error {
 			err := pub1Cluster.VanClient.TokenClaimCreateFile(ctx, types.DefaultVanName, []byte(createOptsPublic.Password), 15*time.Minute, 1, secretFile)
 			if err == nil {
-				return true, nil
+				return nil
 			}
-			return false, err
+			return err
 		})
 	} else {
-		err = utils.Retry(time.Second, 15, func() (bool, error) {
+		err = utils.RetryError(3*time.Second, 5, func() error {
 			err := pub1Cluster.VanClient.ConnectorTokenCreateFile(ctx, types.DefaultVanName, secretFile)
 			if err == nil {
-				return true, nil
+				return nil
 			}
-			return false, err
+			return err
 		})
 	}
 	assert.Assert(t, err)

--- a/test/integration/acceptance/custom/basic/basic.go
+++ b/test/integration/acceptance/custom/basic/basic.go
@@ -76,9 +76,21 @@ func (r *BasicTestRunner) Setup(ctx context.Context, createOptsPublic types.Site
 
 	const secretFile = "/tmp/public_basic_1_secret.yaml"
 	if tokenType == "claim" {
-		err = pub1Cluster.VanClient.TokenClaimCreateFile(ctx, types.DefaultVanName, []byte(createOptsPublic.Password), 15*time.Minute, 1, secretFile)
+		err = utils.Retry(time.Second, 15, func() (bool, error) {
+			err := pub1Cluster.VanClient.TokenClaimCreateFile(ctx, types.DefaultVanName, []byte(createOptsPublic.Password), 15*time.Minute, 1, secretFile)
+			if err == nil {
+				return true, nil
+			}
+			return false, err
+		})
 	} else {
-		err = pub1Cluster.VanClient.ConnectorTokenCreateFile(ctx, types.DefaultVanName, secretFile)
+		err = utils.Retry(time.Second, 15, func() (bool, error) {
+			err := pub1Cluster.VanClient.ConnectorTokenCreateFile(ctx, types.DefaultVanName, secretFile)
+			if err == nil {
+				return true, nil
+			}
+			return false, err
+		})
 	}
 	assert.Assert(t, err)
 

--- a/test/integration/acceptance/gateway_test.go
+++ b/test/integration/acceptance/gateway_test.go
@@ -156,7 +156,10 @@ func testServices(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer cluster.VanClient.KubeClient.BatchV1().Jobs(cluster.Namespace).Delete(context.TODO(), job.Name, v12.DeleteOptions{})
+		deletePolicy := v12.DeletePropagationBackground
+		defer cluster.VanClient.KubeClient.BatchV1().Jobs(cluster.Namespace).Delete(context.TODO(), job.Name, v12.DeleteOptions{
+			PropagationPolicy: &deletePolicy,
+		})
 
 		_, err = k8s.WaitForJob(cluster.Namespace, cluster.VanClient.KubeClient, name, time.Minute)
 		if err != nil {

--- a/test/integration/acceptance/gateway_test.go
+++ b/test/integration/acceptance/gateway_test.go
@@ -161,7 +161,7 @@ func testServices(t *testing.T) {
 			PropagationPolicy: &deletePolicy,
 		})
 
-		_, err = k8s.WaitForJob(cluster.Namespace, cluster.VanClient.KubeClient, name, time.Minute)
+		_, err = k8s.WaitForJob(cluster.Namespace, cluster.VanClient.KubeClient, name, 5*time.Minute)
 		if err != nil {
 			_, _ = cluster.KubectlExec("logs job/" + name)
 			testRunner.DumpTestInfo(name)

--- a/test/integration/acceptance/gateway_test.go
+++ b/test/integration/acceptance/gateway_test.go
@@ -156,12 +156,9 @@ func testServices(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		deletePolicy := v12.DeletePropagationBackground
-		defer cluster.VanClient.KubeClient.BatchV1().Jobs(cluster.Namespace).Delete(context.TODO(), job.Name, v12.DeleteOptions{
-			PropagationPolicy: &deletePolicy,
-		})
+		defer cluster.VanClient.KubeClient.BatchV1().Jobs(cluster.Namespace).Delete(context.TODO(), job.Name, v12.DeleteOptions{})
 
-		_, err = k8s.WaitForJob(cluster.Namespace, cluster.VanClient.KubeClient, name, 5*time.Minute)
+		_, err = k8s.WaitForJob(cluster.Namespace, cluster.VanClient.KubeClient, name, time.Minute)
 		if err != nil {
 			_, _ = cluster.KubectlExec("logs job/" + name)
 			testRunner.DumpTestInfo(name)

--- a/test/utils/k8s/job.go
+++ b/test/utils/k8s/job.go
@@ -173,7 +173,7 @@ func WaitForJob(ns string, kubeClient kubernetes.Interface, jobName string, time
 	for {
 		select {
 		case <-timeoutCh:
-			return nil, fmt.Errorf("Timeout: Job is still active: %s, %v", jobName)
+			return nil, fmt.Errorf("Timeout: Job is still active: %s", jobName)
 		case <-tick:
 			job, err := jobsClient.Get(context.TODO(), jobName, metav1.GetOptions{})
 

--- a/test/utils/k8s/job.go
+++ b/test/utils/k8s/job.go
@@ -184,16 +184,25 @@ func WaitForJob(ns string, kubeClient kubernetes.Interface, jobName string, time
 			if job.Status.Active > 0 {
 				fmt.Println("Job is still active")
 			} else if len(job.Status.Conditions) > 0 {
+				jobComplete := false
+				jobFailed := false
 				for _, condition := range job.Status.Conditions {
 					if condition.Type == batchv1.JobComplete {
-						fmt.Println("Job Successful!")
-						return job, nil
+						jobComplete = true
 					} else if condition.Type == batchv1.JobFailed {
-						statusJson, _ := json.Marshal(job.Status)
-						fmt.Printf("Job failed?, status = %v\n", string(statusJson))
-						return job, fmt.Errorf("Job failed. Status: %s", string(statusJson))
+						jobFailed = true
 					}
 				}
+
+				if jobComplete {
+					fmt.Println("Job Successful!")
+					return job, nil
+				} else if jobFailed {
+					statusJson, _ := json.Marshal(job.Status)
+					fmt.Printf("Job failed?, status = %v\n", string(statusJson))
+					return job, fmt.Errorf("Job failed. Status: %s", string(statusJson))
+				}
+
 			} else {
 				fmt.Println("Waiting on job condition")
 			}

--- a/test/utils/k8s/job.go
+++ b/test/utils/k8s/job.go
@@ -173,7 +173,10 @@ func WaitForJob(ns string, kubeClient kubernetes.Interface, jobName string, time
 	for {
 		select {
 		case <-timeoutCh:
-			return nil, fmt.Errorf("Timeout: Job is still active: %s", jobName)
+			///
+			debugJob, _ := jobsClient.Get(context.TODO(), jobName, metav1.GetOptions{})
+			///
+			return nil, fmt.Errorf("Timeout: Job is still active: %s, %v", jobName, debugJob)
 		case <-tick:
 			job, _ := jobsClient.Get(context.TODO(), jobName, metav1.GetOptions{})
 


### PR DESCRIPTION
TestGateway was failing while the job was being completed and executed successfully. 
- the test was waiting for the first condition on the job to be `Complete`, but the conditions are not stored in order in the job resource. So, now all the conditions are checked.

TestBasic was failing because the generation of the token file was failing, getting the incoming links from the policy API was timing out.
- the test retries the generation of the token if it has failed.