### PR TITLE
add init container to get initial config

### DIFF
--- a/internal/kube/adaptor/collector.go
+++ b/internal/kube/adaptor/collector.go
@@ -1,4 +1,4 @@
-package main
+package adaptor
 
 import (
 	"context"
@@ -142,7 +142,7 @@ func runLeaderElection(lock *resourcelock.LeaseLock, id string, cli *internalcli
 	})
 }
 
-func startCollector(cli *internalclient.KubeClient) {
+func StartCollector(cli *internalclient.KubeClient) {
 	lockname := types.SiteLeaderLockName
 	namespace := cli.Namespace
 	podname, _ := os.Hostname()

--- a/internal/kube/adaptor/config_init.go
+++ b/internal/kube/adaptor/config_init.go
@@ -1,0 +1,51 @@
+package adaptor
+
+import (
+	"context"
+	"log"
+	"os"
+	paths "path"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/skupperproject/skupper/pkg/qdr"
+)
+
+func InitialiseConfig(client kubernetes.Interface, namespace string, path string, routerConfigMap string) error {
+	ctxt := context.Background()
+	current, err := client.CoreV1().ConfigMaps(namespace).Get(ctxt, routerConfigMap, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	config, err := qdr.GetRouterConfigFromConfigMap(current)
+	if err != nil {
+		return err
+	}
+
+	value, err := qdr.MarshalRouterConfig(*config)
+	if err != nil {
+		return err
+	}
+	configFile := paths.Join(path, "skrouterd.json")
+	if err := os.WriteFile(configFile, []byte(value), 0777); err != nil {
+		return err
+	}
+	log.Printf("Router configuration written to %s", configFile)
+
+	profileSyncer := newSslProfileSyncer(path)
+	for _, profile := range config.SslProfiles {
+		target, _ := profileSyncer.get(profile.Name)
+
+		secret, err := client.CoreV1().Secrets(namespace).Get(ctxt, target.name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if err := target.sync(secret); err != nil {
+			return err
+		}
+		log.Printf("Resources for SslProfile %s written to %s", profile.Name, target.path)
+	}
+	return nil
+}

--- a/internal/kube/adaptor/profile.go
+++ b/internal/kube/adaptor/profile.go
@@ -1,0 +1,83 @@
+package adaptor
+
+import (
+	"os"
+	paths "path"
+	"reflect"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type SslProfileSyncer struct {
+	profiles map[string]*SslProfile
+	path     string
+}
+
+func newSslProfileSyncer(path string) *SslProfileSyncer {
+	return &SslProfileSyncer{
+		profiles: map[string]*SslProfile{},
+		path:     path,
+	}
+}
+
+func (s SslProfileSyncer) get(profile string) (*SslProfile, bool) {
+	secret := profile
+	if strings.HasSuffix(profile, "-profile") {
+		secret = strings.TrimSuffix(profile, "-profile")
+	}
+	if current, ok := s.profiles[secret]; ok {
+		return current, false
+	}
+	target := &SslProfile{
+		name: secret,
+		path: paths.Join(s.path, profile),
+	}
+	s.profiles[secret] = target
+	return target, true
+}
+
+func (s SslProfileSyncer) bySecretName(secret string) (*SslProfile, bool) {
+	current, ok := s.profiles[secret]
+	return current, ok
+}
+
+type SslProfile struct {
+	name   string
+	path   string
+	secret *corev1.Secret
+}
+
+func (s *SslProfile) sync(secret *corev1.Secret) error {
+	if s.secret != nil && reflect.DeepEqual(s.secret.Data, secret.Data) {
+		return nil
+	}
+	if err := writeSecretToPath(secret, s.path); err != nil {
+		return err
+	}
+	s.secret = secret
+	return nil
+}
+
+func writeSecretToPath(secret *corev1.Secret, path string) error {
+	if err := mkdir(path); err != nil {
+		return err
+	}
+	for key, value := range secret.Data {
+		if err := os.WriteFile(paths.Join(path, key), value, 0777); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mkdir(path string) error {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		err = os.Mkdir(path, 0777)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/kube/site/resources/skupper-router-deployment.yaml
+++ b/pkg/kube/site/resources/skupper-router-deployment.yaml
@@ -34,22 +34,8 @@ spec:
     spec:
       containers:
       - env:
-        - name: APPLICATION_NAME
-          value: skupper-router
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: QDROUTERD_AUTO_MESH_DISCOVERY
-          value: QUERY
         - name: QDROUTERD_CONF
-          value: /etc/skupper-router/config/skrouterd.json
+          value: /etc/skupper-router-certs/skrouterd.json
         - name: QDROUTERD_CONF_TYPE
           value: json
         - name: SKUPPER_SITE_ID
@@ -93,8 +79,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/skupper-router-certs/skupper-amqps/
           name: skupper-local-server
-        - mountPath: /etc/skupper-router/config/
-          name: router-config
         - mountPath: /etc/skupper-router-certs
           name: skupper-router-certs
       - env:
@@ -107,7 +91,7 @@ spec:
           value: {{ .SiteId }}
         - name: SKUPPER_SITE_NAME
           value: {{ .SiteName }}
-        - name: SKUPPER_CONFIG
+        - name: SKUPPER_ROUTER_CONFIG
           value: {{ .Group }}
         - name: SKUPPER_ROUTER_DEPLOYMENT
           value: {{ .Group }}
@@ -127,15 +111,22 @@ spec:
         volumeMounts:
         - mountPath: /etc/skupper-router-certs
           name: skupper-router-certs
+      initContainers:
+      - env:
+        - name: SKUPPER_ROUTER_CONFIG
+          value: {{ .Group }}
+        image: {{ .ConfigSyncImage.Name }}
+        imagePullPolicy: {{ .ConfigSyncImage.PullPolicy }}
+        name: config-init
+        command: ["/app/config-sync", "-init"]
+        volumeMounts:
+        - mountPath: /etc/skupper-router-certs
+          name: skupper-router-certs
       serviceAccount: {{ .ServiceAccount }}
       volumes:
       - name: skupper-local-server
         secret:
           defaultMode: 420
           secretName: skupper-local-server
-      - configMap:
-          defaultMode: 420
-          name: {{ .Group }}
-        name: router-config
       - emptyDir: {}
         name: skupper-router-certs

--- a/pkg/kube/site/site.go
+++ b/pkg/kube/site/site.go
@@ -117,7 +117,20 @@ func (s *Site) reconcile(siteDef *skupperv2alpha1.Site) error {
 				Prefix:       "mc",
 				Distribution: "multicast",
 			})
-			rc.SetNormalListeners(SSL_PROFILE_PATH)
+			rc.AddHealthAndMetricsListener(9090)
+			rc.AddListener(qdr.Listener{
+				Name: "amqp",
+				Host: "localhost",
+				Port: 5672,
+			})
+			rc.AddSslProfile(qdr.ConfigureSslProfile("skupper-local-server", SSL_PROFILE_PATH, true))
+			rc.AddListener(qdr.Listener{
+				Name:             "amqps",
+				Port:             5671,
+				SslProfile:       "skupper-local-server",
+				SaslMechanisms:   "EXTERNAL",
+				AuthenticatePeer: true,
+			})
 			routerConfig = &rc
 		}
 		s.initialised = true

--- a/pkg/kube/site/site_test.go
+++ b/pkg/kube/site/site_test.go
@@ -1058,7 +1058,6 @@ func createRouterConfigMock(s *Site) error {
 		Prefix:       "mc",
 		Distribution: "multicast",
 	})
-	rc.SetNormalListeners(SSL_PROFILE_PATH)
 
 	err := s.createRouterConfig(&rc)
 	if err != nil {

--- a/pkg/qdr/qdr_test.go
+++ b/pkg/qdr/qdr_test.go
@@ -47,35 +47,6 @@ func TestInitialConfig(t *testing.T) {
 	}
 }
 
-func TestInitialConfigSkupperRouter(t *testing.T) {
-	routerOptions := types.RouterOptions{
-		MaxFrameSize:     1518,
-		LoadBalancerIp:   "1.2.3.4",
-		DisableMutualTLS: true,
-		Logging: []types.RouterLogConfig{
-			{
-				Module: "PROTOCOL",
-				Level:  "trace",
-			},
-		},
-	}
-	path := "/tmp/skupper-router"
-	routerConfig := InitialConfigSkupperRouter("foo", "bar", "1.2.3", false, 10, routerOptions, path)
-
-	if routerConfig.Metadata.Id != "foo" {
-		t.Errorf("Invalid id, expected 'foo' got %q", routerConfig.Metadata.Id)
-	}
-	if len(routerConfig.LogConfig) != 1 {
-		t.Errorf("Expect one log entry")
-	}
-	if routerConfig.Addresses["mc"].Distribution != "multicast" {
-		t.Errorf("Expect address to configured as multicast")
-	}
-	if routerConfig.IsEdge() {
-		t.Errorf("Expected interior mode")
-	}
-}
-
 func TestAddRemoveListener(t *testing.T) {
 	config := InitialConfig("foo", "bar", "undefined", true, 3)
 	config.AddListener(Listener{

--- a/pkg/site/link_test.go
+++ b/pkg/site/link_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/skupperproject/skupper/api/types"
 	skupperv2alpha1 "github.com/skupperproject/skupper/pkg/apis/skupper/v2alpha1"
 	"github.com/skupperproject/skupper/pkg/qdr"
 	"gotest.tools/assert"
@@ -15,11 +14,8 @@ func TestLink_Apply(t *testing.T) {
 	id := "router-1"
 	siteId := "site-1"
 	version := "v2.0"
-	isEdge := true
 	notEdge := false
 	helloAge := 10
-	sslPath := ""
-	options := types.RouterOptions{}
 
 	type fields struct {
 		name        string
@@ -43,7 +39,7 @@ func TestLink_Apply(t *testing.T) {
 				definition:  nil,
 			},
 			args: args{
-				current: qdr.InitialConfigSkupperRouter(id, siteId, version, notEdge, helloAge, options, sslPath),
+				current: qdr.InitialConfig(id, siteId, version, notEdge, helloAge),
 			},
 			want: false,
 		},
@@ -61,7 +57,7 @@ func TestLink_Apply(t *testing.T) {
 				},
 			},
 			args: args{
-				current: qdr.InitialConfigSkupperRouter(id, siteId, version, notEdge, helloAge, options, sslPath),
+				current: qdr.InitialConfig(id, siteId, version, notEdge, helloAge),
 			},
 			want: false,
 		},
@@ -87,7 +83,7 @@ func TestLink_Apply(t *testing.T) {
 				},
 			},
 			args: args{
-				current: qdr.InitialConfigSkupperRouter(id, siteId, version, notEdge, helloAge, options, sslPath),
+				current: qdr.InitialConfig(id, siteId, version, notEdge, helloAge),
 			},
 			want: true,
 		},
@@ -113,7 +109,7 @@ func TestLink_Apply(t *testing.T) {
 				},
 			},
 			args: args{
-				current: qdr.InitialConfigSkupperRouter(id, siteId, version, isEdge, helloAge, options, sslPath),
+				current: qdr.InitialConfig(id, siteId, version, true, helloAge),
 			},
 			want: true,
 		},
@@ -136,8 +132,6 @@ func TestLinkMap_Apply(t *testing.T) {
 	//	isEdge := true
 	notEdge := false
 	helloAge := 10
-	sslPath := ""
-	options := types.RouterOptions{}
 
 	type fields struct {
 		name        string
@@ -301,7 +295,7 @@ func TestLinkMap_Apply(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		routerConfig := qdr.InitialConfigSkupperRouter(id, siteId, version, notEdge, helloAge, options, sslPath)
+		routerConfig := qdr.InitialConfig(id, siteId, version, notEdge, helloAge)
 		linkMap := make(LinkMap)
 		t.Run(tt.name, func(t *testing.T) {
 			for i, link := range tt.links {


### PR DESCRIPTION
Add 'init' mode for config-sync that downloads initial config and ssl artefacts and use this in an init container to avoid races between config being loaded by router and ssl artefacts being downloaded. Fixes #1716 .