### PR TITLE
Upgrade prometheus and oauth-proxy image versions

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -9,7 +9,7 @@ const (
 	FlowCollectorImageName     string = "flow-collector:main"
 	SiteControllerImageName    string = "site-controller:main"
 	PrometheusImageRegistry    string = "quay.io/prometheus"
-	PrometheusServerImageName  string = "prometheus:v2.42.0"
+	PrometheusServerImageName  string = "prometheus:v2.55.1"
 	OauthProxyImageRegistry    string = "quay.io/openshift"
-	OauthProxyImageName        string = "origin-oauth-proxy:4.14.0"
+	OauthProxyImageName        string = "origin-oauth-proxy:4.18.0"
 )


### PR DESCRIPTION
Upgrade prometheus image from v2.42.0 to v2.55.1
Upgrade origin-auth-proxy image from 4.14.0 to 4.18.0