### PR TITLE
Improve Collector relations Connector to Processes

### DIFF
--- a/cmd/network-console-collector/internal/api/types_gen.go
+++ b/cmd/network-console-collector/internal/api/types_gen.go
@@ -222,6 +222,8 @@ type ConnectorRecord struct {
 	Parent    string `json:"parent"`
 	ProcessId string `json:"processId"`
 	Protocol  string `json:"protocol"`
+	SiteId    string `json:"siteId"`
+	SiteName  string `json:"siteName"`
 
 	// StartTime The creation time in microseconds of the record in Unix timestamp format. The value 0 means that the record is not terminated
 	StartTime uint64  `json:"startTime"`
@@ -338,6 +340,8 @@ type ListenerRecord struct {
 	Name     string `json:"name"`
 	Parent   string `json:"parent"`
 	Protocol string `json:"protocol"`
+	SiteId   string `json:"siteId"`
+	SiteName string `json:"siteName"`
 
 	// StartTime The creation time in microseconds of the record in Unix timestamp format. The value 0 means that the record is not terminated
 	StartTime uint64 `json:"startTime"`

--- a/cmd/network-console-collector/internal/collector/connections.go
+++ b/cmd/network-console-collector/internal/collector/connections.go
@@ -330,7 +330,7 @@ func (c *connectionManager) reconcile(state transportState) (ConnectionRecord, r
 	sourceSiteID := lRouterNode.Parent().ID()
 	sourceSiteHost := dref(record.SourceHost)
 	if sourceSiteID != "" && sourceSiteHost != "" {
-		sourceNode = c.graph.ConnectorTarget(ConnectorTargetID(sourceSiteID, sourceSiteHost)).Process()
+		sourceNode = c.graph.SiteHost(SiteHostID(sourceSiteID, sourceSiteHost)).Process()
 	}
 	sourceproc, ok := c.processAttrs(sourceNode.ID())
 	if !ok {

--- a/cmd/network-console-collector/internal/collector/graph_test.go
+++ b/cmd/network-console-collector/internal/collector/graph_test.go
@@ -1,0 +1,52 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/skupperproject/skupper/pkg/vanflow"
+	"github.com/skupperproject/skupper/pkg/vanflow/store"
+	"gotest.tools/assert"
+)
+
+func TestGraphRelations(t *testing.T) {
+	stor := store.NewSyncMapStore(store.SyncMapStoreConfig{Indexers: RecordIndexers()})
+
+	stor.Replace(wrapRecords(
+		vanflow.SiteRecord{BaseRecord: vanflow.NewBase("s1")},
+		vanflow.RouterRecord{BaseRecord: vanflow.NewBase("r1"), Parent: ptrTo("s1")},
+		vanflow.SiteRecord{BaseRecord: vanflow.NewBase("s2")},
+		vanflow.RouterRecord{BaseRecord: vanflow.NewBase("r2"), Parent: ptrTo("s2")},
+		vanflow.ProcessRecord{BaseRecord: vanflow.NewBase("p1"), Parent: ptrTo("s1"), SourceHost: ptrTo("x.x.x.1")},
+		vanflow.ProcessRecord{BaseRecord: vanflow.NewBase("px"), Parent: ptrTo("sx"), SourceHost: ptrTo("x.x.x.1")},
+		vanflow.ConnectorRecord{BaseRecord: vanflow.NewBase("c1"), Parent: ptrTo("r1"), DestHost: ptrTo("x.x.x.1"), Address: ptrTo("chips"), Protocol: ptrTo("snacks")},
+		vanflow.ProcessRecord{BaseRecord: vanflow.NewBase("p2"), Parent: ptrTo("s2"), SourceHost: ptrTo("x.x.x.2")},
+		vanflow.ConnectorRecord{BaseRecord: vanflow.NewBase("c2-a"), Parent: ptrTo("r2"), DestHost: ptrTo("x.x.x.2"), Address: ptrTo("pizza"), Protocol: ptrTo("snacks")},
+		vanflow.ConnectorRecord{BaseRecord: vanflow.NewBase("c2-b"), Parent: ptrTo("r2"), ProcessID: ptrTo("p2"), Address: ptrTo("pizza"), Protocol: ptrTo("snacks")},
+		vanflow.ConnectorRecord{BaseRecord: vanflow.NewBase("c2-c"), Parent: ptrTo("r2"), ProcessID: ptrTo("doesnotexist"), DestHost: ptrTo("x.x.x.2"), Address: ptrTo("pizza"), Protocol: ptrTo("snacks")},
+		vanflow.ListenerRecord{BaseRecord: vanflow.NewBase("l2"), Parent: ptrTo("r2"), Address: ptrTo("chips"), Protocol: ptrTo("snacks")},
+		AddressRecord{Name: "chips", ID: "adr1", Protocol: "snacks"},
+		AddressRecord{Name: "pizza", ID: "adr2", Protocol: "snacks"},
+	))
+	g := NewGraph(stor).(*graph)
+	g.Reset()
+	for _, r := range stor.List() {
+		g.Reindex(r.Record)
+	}
+	assert.Equal(t, g.Connector("c1").Target().ID(), "p1")
+	assert.Equal(t, g.Connector("c2-a").Target().ID(), "p2")
+	assert.Equal(t, g.Connector("c2-b").Target().ID(), "p2")
+	assert.Equal(t, g.Connector("c2-c").Target().ID(), "p2")
+	listenerConnectors := g.Listener("l2").Address().RoutingKey().Connectors()
+	if len(listenerConnectors) != 1 {
+		t.Errorf("expected examtly one connector for listener l2: %v", listenerConnectors)
+	}
+	assert.Equal(t, listenerConnectors[0].ID(), "c1")
+}
+
+func wrapRecords(records ...vanflow.Record) []store.Entry {
+	entries := make([]store.Entry, len(records))
+	for i := range records {
+		entries[i].Record = records[i]
+	}
+	return entries
+}

--- a/cmd/network-console-collector/internal/server/connections_test.go
+++ b/cmd/network-console-collector/internal/server/connections_test.go
@@ -40,15 +40,7 @@ func TestConnections(t *testing.T) {
 		t0.Add(4 * time.Minute),
 	}
 
-	testcases := []struct {
-		Records              []store.Entry
-		Flows                []store.Entry
-		Parameters           map[string][]string
-		ExpectOK             bool
-		ExpectCount          int
-		ExpectTimeRangeCount int
-		ExpectResults        func(t *testing.T, results []api.ConnectionRecord)
-	}{
+	testcases := []collectionTestCase[api.ConnectionRecord]{
 		{ExpectOK: true},
 		{
 			Records: wrapRecords(
@@ -159,7 +151,7 @@ func TestConnections(t *testing.T) {
 			for _, r := range tc.Records {
 				graph.(reset).Reindex(r.Record)
 			}
-			resp, err := c.ConnectionsWithResponse(context.TODO(), WithParameters(tc.Parameters))
+			resp, err := c.ConnectionsWithResponse(context.TODO(), withParameters(tc.Parameters))
 			assert.Check(t, err)
 			if tc.ExpectOK {
 				assert.Equal(t, resp.StatusCode(), 200)

--- a/cmd/network-console-collector/internal/server/connector_test.go
+++ b/cmd/network-console-collector/internal/server/connector_test.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/skupperproject/skupper/cmd/network-console-collector/internal/api"
+	"github.com/skupperproject/skupper/cmd/network-console-collector/internal/collector"
+	"github.com/skupperproject/skupper/pkg/vanflow"
+	"github.com/skupperproject/skupper/pkg/vanflow/store"
+	"gotest.tools/assert"
+)
+
+func TestConnectors(t *testing.T) {
+	tlog := slog.Default()
+	stor := store.NewSyncMapStore(store.SyncMapStoreConfig{Indexers: collector.RecordIndexers()})
+	graph := collector.NewGraph(stor)
+	srv, c := requireTestClient(t, New(tlog, stor, graph))
+	defer srv.Close()
+	testcases := []collectionTestCase[api.ConnectorRecord]{
+		{ExpectOK: true},
+		{
+			ExpectOK: true,
+			Records: wrapRecords( // totally empty
+				vanflow.ConnectorRecord{
+					BaseRecord: vanflow.NewBase("c1"),
+				},
+			),
+			ExpectCount: 1,
+			ExpectResults: func(t *testing.T, results []api.ConnectorRecord) {
+				assert.Equal(t, len(results), 1)
+				result := results[0]
+				assert.DeepEqual(t, result, api.ConnectorRecord{
+					Identity: "c1", Name: "unknown", Parent: "unknown",
+					SiteName: "unknown", SiteId: "unknown",
+					Protocol: "unknown", Address: "unknown", DestHost: "unknown",
+					ProcessId: "", DestPort: "unknown",
+				})
+			},
+		}, {
+			Records: wrapRecords(
+				vanflow.SiteRecord{BaseRecord: vanflow.NewBase("s1"), Name: ptrTo("one")},
+				vanflow.RouterRecord{BaseRecord: vanflow.NewBase("r1"), Parent: ptrTo("s1")},
+				vanflow.ConnectorRecord{
+					BaseRecord: vanflow.NewBase("c1"), Name: ptrTo("conn-one"),
+					Parent:    ptrTo("r1"),
+					ProcessID: ptrTo("p1"),
+					Protocol:  ptrTo("tp"),
+					Address:   ptrTo("trombone"),
+					DestHost:  ptrTo("10.0.four.two"), DestPort: ptrTo("amqp"),
+				},
+				vanflow.ProcessRecord{BaseRecord: vanflow.NewBase("p1"), Name: ptrTo("proc-one")},
+				vanflow.ListenerRecord{
+					BaseRecord: vanflow.NewBase("l1"),
+					Protocol:   ptrTo("tp"),
+					Address:    ptrTo("trombone"),
+				},
+			),
+			ExpectOK:    true,
+			ExpectCount: 1,
+			ExpectResults: func(t *testing.T, results []api.ConnectorRecord) {
+				assert.Equal(t, len(results), 1)
+				result := results[0]
+				assert.DeepEqual(t, result, api.ConnectorRecord{
+					Identity: "c1", Name: "conn-one", Parent: "r1",
+					SiteName: "one", SiteId: "s1",
+					Protocol: "tp", Address: "trombone", DestHost: "10.0.four.two",
+					ProcessId: "p1", Target: ptrTo("proc-one"), DestPort: "amqp",
+				})
+			},
+		}, {
+			Records: wrapRecords(
+				vanflow.SiteRecord{BaseRecord: vanflow.NewBase("s1"), Name: ptrTo("one")},
+				vanflow.RouterRecord{BaseRecord: vanflow.NewBase("r1"), Parent: ptrTo("s1")},
+				vanflow.ConnectorRecord{
+					BaseRecord: vanflow.NewBase("c1"), Name: ptrTo("conn-one"),
+					Parent:    ptrTo("r1"),
+					ProcessID: ptrTo("does-not-exist"),
+					Protocol:  ptrTo("tp"),
+					Address:   ptrTo("trombone"),
+					DestHost:  ptrTo("10.0.four.two"), DestPort: ptrTo("amqp"),
+				},
+				vanflow.ProcessRecord{
+					BaseRecord: vanflow.NewBase("proc-site"),
+					Name:       ptrTo("my site service"),
+					Parent:     ptrTo("s1"),
+					SourceHost: ptrTo("10.0.four.two")},
+			),
+			ExpectOK:    true,
+			ExpectCount: 1,
+			ExpectResults: func(t *testing.T, results []api.ConnectorRecord) {
+				assert.Equal(t, len(results), 1)
+				result := results[0]
+				assert.Equal(t, result.ProcessId, "proc-site")
+				assert.DeepEqual(t, result.Target, ptrTo("my site service"))
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run("", func(t *testing.T) {
+			stor.Replace(tc.Records)
+			graph.(reset).Reset()
+			for _, r := range tc.Records {
+				graph.(reset).Reindex(r.Record)
+			}
+			resp, err := c.ConnectorsWithResponse(context.TODO(), withParameters(tc.Parameters))
+			assert.Check(t, err)
+			if tc.ExpectOK {
+				assert.Equal(t, resp.StatusCode(), 200)
+				assert.Equal(t, resp.JSON200.Count, int64(tc.ExpectCount))
+				assert.Equal(t, len(resp.JSON200.Results), tc.ExpectCount)
+				if tc.ExpectTimeRangeCount != 0 {
+					assert.Equal(t, resp.JSON200.TimeRangeCount, int64(tc.ExpectTimeRangeCount))
+				}
+				if tc.ExpectResults != nil {
+					tc.ExpectResults(t, resp.JSON200.Results)
+				}
+			} else {
+				assert.Check(t, resp.JSON400 != nil)
+			}
+		})
+	}
+}

--- a/cmd/network-console-collector/internal/server/links_test.go
+++ b/cmd/network-console-collector/internal/server/links_test.go
@@ -31,14 +31,7 @@ func TestRouterlinks(t *testing.T) {
 		vanflow.RouterAccessRecord{BaseRecord: vanflow.NewBase("routeraccess-b-2"), Name: ptrTo("routeraccess b.2"), Parent: ptrTo("router-b-2")},
 	}
 
-	testcases := []struct {
-		Records              []store.Entry
-		Parameters           map[string][]string
-		ExpectOK             bool
-		ExpectCount          int
-		ExpectTimeRangeCount int
-		ExpectResults        func(t *testing.T, results []api.RouterLinkRecord)
-	}{
+	testcases := []collectionTestCase[api.RouterLinkRecord]{
 		{ExpectOK: true},
 		{
 			ExpectOK: true,
@@ -96,7 +89,7 @@ func TestRouterlinks(t *testing.T) {
 			for _, r := range tc.Records {
 				graph.(reset).Reindex(r.Record)
 			}
-			resp, err := c.RouterlinksWithResponse(context.TODO(), WithParameters(tc.Parameters))
+			resp, err := c.RouterlinksWithResponse(context.TODO(), withParameters(tc.Parameters))
 			assert.Check(t, err)
 			if tc.ExpectOK {
 				assert.Equal(t, resp.StatusCode(), 200)

--- a/cmd/network-console-collector/internal/server/process_test.go
+++ b/cmd/network-console-collector/internal/server/process_test.go
@@ -19,14 +19,7 @@ func TestProcesses(t *testing.T) {
 	srv, c := requireTestClient(t, New(tlog, stor, graph))
 	defer srv.Close()
 
-	testcases := []struct {
-		Records              []store.Entry
-		Parameters           map[string][]string
-		ExpectOK             bool
-		ExpectCount          int
-		ExpectTimeRangeCount int
-		ExpectResults        func(t *testing.T, results []api.ProcessRecord)
-	}{
+	testcases := []collectionTestCase[api.ProcessRecord]{
 		{ExpectOK: true},
 		{
 			Records: wrapRecords(
@@ -110,7 +103,7 @@ func TestProcesses(t *testing.T) {
 			for _, r := range tc.Records {
 				graph.(reset).Reindex(r.Record)
 			}
-			resp, err := c.ProcessesWithResponse(context.TODO(), WithParameters(tc.Parameters))
+			resp, err := c.ProcessesWithResponse(context.TODO(), withParameters(tc.Parameters))
 			assert.Check(t, err)
 			if tc.ExpectOK {
 				assert.Equal(t, resp.StatusCode(), 200)

--- a/cmd/network-console-collector/internal/server/processpairs_test.go
+++ b/cmd/network-console-collector/internal/server/processpairs_test.go
@@ -42,7 +42,7 @@ func TestProcessPairsByAddress(t *testing.T) {
 			for _, r := range tc.Records {
 				graph.(reset).Reindex(r.Record)
 			}
-			resp, err := c.ProcessPairsByAddressWithResponse(context.TODO(), tc.ID, WithParameters(tc.Parameters))
+			resp, err := c.ProcessPairsByAddressWithResponse(context.TODO(), tc.ID, withParameters(tc.Parameters))
 			assert.Check(t, err)
 			if tc.ExpectOK {
 				assert.Equal(t, resp.StatusCode(), 200)

--- a/cmd/network-console-collector/internal/server/router_test.go
+++ b/cmd/network-console-collector/internal/server/router_test.go
@@ -30,14 +30,7 @@ func TestRouters(t *testing.T) {
 		vanflow.RouterRecord{BaseRecord: vanflow.NewBase("router-b-2"), Name: ptrTo("router b.2"), Parent: ptrTo("site-b")},
 	}
 
-	testcases := []struct {
-		Records              []store.Entry
-		Parameters           map[string][]string
-		ExpectOK             bool
-		ExpectCount          int
-		ExpectTimeRangeCount int
-		ExpectResults        func(t *testing.T, results []api.RouterRecord)
-	}{
+	testcases := []collectionTestCase[api.RouterRecord]{
 		{ExpectOK: true},
 		{
 			ExpectOK:    true,
@@ -73,7 +66,7 @@ func TestRouters(t *testing.T) {
 			for _, r := range tc.Records {
 				graph.(reset).Reindex(r.Record)
 			}
-			resp, err := c.RoutersWithResponse(context.TODO(), WithParameters(tc.Parameters))
+			resp, err := c.RoutersWithResponse(context.TODO(), withParameters(tc.Parameters))
 			assert.Check(t, err)
 			if tc.ExpectOK {
 				assert.Equal(t, resp.StatusCode(), 200)

--- a/cmd/network-console-collector/internal/server/shared_test.go
+++ b/cmd/network-console-collector/internal/server/shared_test.go
@@ -21,6 +21,17 @@ func requireTestClient(t *testing.T, impl api.ServerInterface) (*httptest.Server
 	return htsrv, client
 }
 
+type collectionTestCase[T api.Record] struct {
+	Records              []store.Entry
+	Flows                []store.Entry
+	Parameters           map[string][]string
+	ExpectOK             bool
+	ExpectCount          int
+	ExpectTimeRangeCount int
+	ExpectError          string
+	ExpectResults        func(t *testing.T, results []T)
+}
+
 func ptrTo[T any](c T) *T {
 	return &c
 }
@@ -38,7 +49,11 @@ type reset interface {
 	Reindex(vanflow.Record)
 }
 
-func WithParameters(params map[string][]string) func(context.Context, *http.Request) error {
+type statusCoder interface {
+	StatusCode() int
+}
+
+func withParameters(params map[string][]string) func(context.Context, *http.Request) error {
 	return func(ctx context.Context, r *http.Request) error {
 		values := r.URL.Query()
 		for k, vs := range params {

--- a/cmd/network-console-collector/internal/server/sites_test.go
+++ b/cmd/network-console-collector/internal/server/sites_test.go
@@ -20,15 +20,7 @@ func TestSites(t *testing.T) {
 	srv, c := requireTestClient(t, New(tlog, stor, graph))
 	defer srv.Close()
 
-	testcases := []struct {
-		Records              []store.Entry
-		Parameters           map[string][]string
-		ExpectOK             bool
-		ExpectCount          int
-		ExpectTimeRangeCount int
-		ExpectResults        func(t *testing.T, results []api.SiteRecord)
-		ExpectError          string
-	}{
+	testcases := []collectionTestCase[api.SiteRecord]{
 		{ExpectOK: true},
 		{
 			Records: wrapRecords(
@@ -79,7 +71,7 @@ func TestSites(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			stor.Replace(tc.Records)
 			graph.(reset).Reset()
-			resp, err := c.SitesWithResponse(context.TODO(), WithParameters(tc.Parameters))
+			resp, err := c.SitesWithResponse(context.TODO(), withParameters(tc.Parameters))
 			assert.Check(t, err)
 			if tc.ExpectOK {
 				assert.Equal(t, resp.StatusCode(), 200)

--- a/cmd/network-console-collector/internal/server/views/views.go
+++ b/cmd/network-console-collector/internal/server/views/views.go
@@ -199,6 +199,7 @@ func NewConnectorProvider(graph collector.Graph) func(vanflow.ConnectorRecord) a
 		}
 		if proc, ok := node.Target().GetRecord(); ok {
 			out.Target = proc.Name
+			out.ProcessId = proc.ID
 		}
 		return out
 	}

--- a/cmd/network-console-collector/internal/server/views/views.go
+++ b/cmd/network-console-collector/internal/server/views/views.go
@@ -150,6 +150,10 @@ func NewListenerProvider(graph collector.Graph) func(vanflow.ListenerRecord) api
 		if addressID := node.Address().ID(); addressID != "" {
 			out.AddressId = &addressID
 		}
+		if site, ok := node.Parent().Parent().GetRecord(); ok {
+			out.SiteId = site.ID
+			setOpt(&out.SiteName, site.Name)
+		}
 		return out
 	}
 }
@@ -163,6 +167,8 @@ func defaultListener(id string) api.ListenerRecord {
 		Address:  unknownStr,
 		DestHost: unknownStr,
 		DestPort: unknownStr,
+		SiteId:   unknownStr,
+		SiteName: unknownStr,
 	}
 }
 
@@ -201,6 +207,10 @@ func NewConnectorProvider(graph collector.Graph) func(vanflow.ConnectorRecord) a
 			out.Target = proc.Name
 			out.ProcessId = proc.ID
 		}
+		if site, ok := node.Parent().Parent().GetRecord(); ok {
+			out.SiteId = site.ID
+			setOpt(&out.SiteName, site.Name)
+		}
 		return out
 	}
 }
@@ -214,6 +224,8 @@ func defaultConnector(id string) api.ConnectorRecord {
 		Address:  unknownStr,
 		DestHost: unknownStr,
 		DestPort: unknownStr,
+		SiteId:   unknownStr,
+		SiteName: unknownStr,
 	}
 }
 

--- a/cmd/network-console-collector/spec/openapi.yaml
+++ b/cmd/network-console-collector/spec/openapi.yaml
@@ -976,6 +976,8 @@ components:
             - destPort
             - protocol
             - address
+            - siteId
+            - siteName
           properties:
             parent:
               type: string
@@ -991,6 +993,10 @@ components:
               type: string
             addressId:
               type: string
+            siteId:
+              type: string
+            siteName:
+              type: string
     ConnectorRecord:
       allOf:
         - $ref: '#/components/schemas/baseRecord'
@@ -1004,6 +1010,8 @@ components:
             - address
             - processId
             - target
+            - siteId
+            - siteName
           properties:
             parent:
               type: string
@@ -1024,6 +1032,10 @@ components:
             target:
               type: string
               nullable: true
+            siteId:
+              type: string
+            siteName:
+              type: string
     AddressRecord:
       allOf:
         - $ref: '#/components/schemas/baseRecord'


### PR DESCRIPTION
Fixes #1787

* Renamed the collector graph's ConnectorTarget to SiteHost to better capture its role in the relation graph.
* Fixed connector.Target() method so that when the process matching the connector.ProcessID is not found, it will fallback to looking for a process based on the connector's Site parent and DestHost in order to match with the inferred "site-server" processes.