### PR TITLE
GetPlatform enhancement to the CLI

### DIFF
--- a/cmd/bootstrap/bootstrap.go
+++ b/cmd/bootstrap/bootstrap.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 
 	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/internal/config"
 	internalbundle "github.com/skupperproject/skupper/internal/nonkube/bundle"
 	internalutils "github.com/skupperproject/skupper/internal/utils"
-	"github.com/skupperproject/skupper/pkg/config"
 	"github.com/skupperproject/skupper/pkg/nonkube/api"
 	"github.com/skupperproject/skupper/pkg/nonkube/bundle"
 	"github.com/skupperproject/skupper/pkg/nonkube/common"

--- a/internal/cmd/skupper/connector/connector.go
+++ b/internal/cmd/skupper/connector/connector.go
@@ -1,13 +1,14 @@
 package connector
 
 import (
+	"time"
+
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/connector/kube"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/connector/nonkube"
-	"github.com/skupperproject/skupper/pkg/config"
+	"github.com/skupperproject/skupper/internal/config"
 	"github.com/spf13/cobra"
-	"time"
 )
 
 func NewCmdConnector() *cobra.Command {

--- a/internal/cmd/skupper/debug/debug.go
+++ b/internal/cmd/skupper/debug/debug.go
@@ -5,8 +5,8 @@ import (
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/debug/kube"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/debug/nonkube"
+	"github.com/skupperproject/skupper/internal/config"
 
-	"github.com/skupperproject/skupper/pkg/config"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/skupper/link/link.go
+++ b/internal/cmd/skupper/link/link.go
@@ -1,13 +1,14 @@
 package link
 
 import (
+	"time"
+
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/link/kube"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/link/nonkube"
-	"github.com/skupperproject/skupper/pkg/config"
+	"github.com/skupperproject/skupper/internal/config"
 	"github.com/spf13/cobra"
-	"time"
 )
 
 func NewCmdLink() *cobra.Command {

--- a/internal/cmd/skupper/listener/listener.go
+++ b/internal/cmd/skupper/listener/listener.go
@@ -1,13 +1,14 @@
 package listener
 
 import (
+	"time"
+
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/listener/kube"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/listener/nonkube"
-	"github.com/skupperproject/skupper/pkg/config"
+	"github.com/skupperproject/skupper/internal/config"
 	"github.com/spf13/cobra"
-	"time"
 )
 
 func NewCmdListener() *cobra.Command {

--- a/internal/cmd/skupper/root/root.go
+++ b/internal/cmd/skupper/root/root.go
@@ -10,7 +10,7 @@ import (
 	"github.com/skupperproject/skupper/internal/cmd/skupper/site"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/token"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/version"
-	"github.com/skupperproject/skupper/pkg/config"
+	"github.com/skupperproject/skupper/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/skupper/site/site.go
+++ b/internal/cmd/skupper/site/site.go
@@ -10,7 +10,7 @@ import (
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/site/kube"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/site/nonkube"
-	"github.com/skupperproject/skupper/pkg/config"
+	"github.com/skupperproject/skupper/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -25,9 +25,9 @@ skupper site status`,
 	}
 
 	cmd.AddCommand(CmdSiteCreateFactory(config.GetPlatform()))
-	cmd.AddCommand(CmdSiteUpdateFactory(config.GetPlatform()))
 	cmd.AddCommand(CmdSiteStatusFactory(config.GetPlatform()))
 	cmd.AddCommand(CmdSiteDeleteFactory(config.GetPlatform()))
+	cmd.AddCommand(CmdSiteUpdateFactory(config.GetPlatform()))
 
 	return cmd
 }

--- a/internal/cmd/skupper/token/token.go
+++ b/internal/cmd/skupper/token/token.go
@@ -7,8 +7,8 @@ import (
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/token/kube"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/token/nonkube"
+	"github.com/skupperproject/skupper/internal/config"
 
-	"github.com/skupperproject/skupper/pkg/config"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/skupper/version/version.go
+++ b/internal/cmd/skupper/version/version.go
@@ -4,10 +4,10 @@ import (
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/version/nonkube"
+	"github.com/skupperproject/skupper/internal/config"
 
 	"github.com/skupperproject/skupper/internal/cmd/skupper/version/kube"
 
-	"github.com/skupperproject/skupper/pkg/config"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/config/platform.go
+++ b/internal/config/platform.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/skupperproject/skupper/api/types"
@@ -146,11 +147,11 @@ func GetPlatform() types.Platform {
 	var platform types.Platform
 	_ = p.Load()
 	for i, arg := range os.Args {
-		if arg == "--platform" && i+1 < len(os.Args) {
+		if slices.Contains([]string{"--platform", "-p"}, arg) && i+1 < len(os.Args) {
 			platformArg := os.Args[i+1]
 			platform = types.Platform(platformArg)
 			break
-		} else if strings.HasPrefix(arg, "--platform=") {
+		} else if strings.HasPrefix(arg, "--platform=") || strings.HasPrefix(arg, "-p=") {
 			platformArg := strings.Split(arg, "=")[1]
 			platform = types.Platform(platformArg)
 			break

--- a/internal/config/platform.go
+++ b/internal/config/platform.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/pkg/utils"
@@ -142,11 +143,25 @@ var (
 // will be returned.
 func GetPlatform() types.Platform {
 	p := &PlatformInfo{}
+	var platform types.Platform
 	_ = p.Load()
-	platform := types.Platform(utils.DefaultStr(Platform,
-		os.Getenv(types.ENV_PLATFORM),
-		string(p.Current),
-		string(types.PlatformKubernetes)))
+	for i, arg := range os.Args {
+		if arg == "--platform" && i+1 < len(os.Args) {
+			platformArg := os.Args[i+1]
+			platform = types.Platform(platformArg)
+			break
+		} else if strings.HasPrefix(arg, "--platform=") {
+			platformArg := strings.Split(arg, "=")[1]
+			platform = types.Platform(platformArg)
+			break
+		}
+	}
+	if platform == "" {
+		platform = types.Platform(utils.DefaultStr(Platform,
+			os.Getenv(types.ENV_PLATFORM),
+			string(p.Current),
+			string(types.PlatformKubernetes)))
+	}
 	switch platform {
 	case types.PlatformPodman:
 		return types.PlatformPodman

--- a/internal/kube/adaptor/collector.go
+++ b/internal/kube/adaptor/collector.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/internal/config"
 	internalclient "github.com/skupperproject/skupper/internal/kube/client"
-	"github.com/skupperproject/skupper/pkg/config"
 	"github.com/skupperproject/skupper/pkg/kube"
 	kubeflow "github.com/skupperproject/skupper/pkg/kube/flow"
 	"github.com/skupperproject/skupper/pkg/vanflow"

--- a/internal/nonkube/client/compat/container_mock.go
+++ b/internal/nonkube/client/compat/container_mock.go
@@ -19,7 +19,7 @@ import (
 	"github.com/skupperproject/skupper-libpod/v4/client/volumes_compat"
 	"github.com/skupperproject/skupper-libpod/v4/models"
 	"github.com/skupperproject/skupper/api/types"
-	"github.com/skupperproject/skupper/pkg/config"
+	"github.com/skupperproject/skupper/internal/config"
 	"github.com/skupperproject/skupper/pkg/container"
 )
 

--- a/pkg/nonkube/api/environment_test.go
+++ b/pkg/nonkube/api/environment_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/skupperproject/skupper/api/types"
+	"github.com/skupperproject/skupper/internal/config"
 	"github.com/skupperproject/skupper/pkg/apis/skupper/v2alpha1"
-	"github.com/skupperproject/skupper/pkg/config"
 	"gopkg.in/yaml.v3"
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/qdr/amqp_mgmt.go
+++ b/pkg/qdr/amqp_mgmt.go
@@ -12,7 +12,7 @@ import (
 
 	amqp "github.com/interconnectedcloud/go-amqp"
 	"github.com/skupperproject/skupper/api/types"
-	"github.com/skupperproject/skupper/pkg/config"
+	"github.com/skupperproject/skupper/internal/config"
 	"github.com/skupperproject/skupper/pkg/utils"
 )
 


### PR DESCRIPTION
Moving GetPlatform function to internal pkg and including os.Args to be evaluated.
This helps the CLI properly getting the platform when `--platform` flag is provided.