### PR TITLE
fix tests in cmd/network-console-collector

### DIFF
--- a/cmd/network-console-collector/internal/collector/graph_test.go
+++ b/cmd/network-console-collector/internal/collector/graph_test.go
@@ -95,11 +95,3 @@ func TestGraphRelations(t *testing.T) {
 		})
 	}
 }
-
-func wrapRecords(records ...vanflow.Record) []store.Entry {
-	entries := make([]store.Entry, len(records))
-	for i := range records {
-		entries[i].Record = records[i]
-	}
-	return entries
-}

--- a/cmd/network-console-collector/internal/server/address_test.go
+++ b/cmd/network-console-collector/internal/server/address_test.go
@@ -108,7 +108,7 @@ func TestAddresses(t *testing.T) {
 			for _, r := range tc.Records {
 				graph.(reset).Reindex(r.Record)
 			}
-			resp, err := c.AddressesWithResponse(context.TODO(), WithParameters(tc.Parameters))
+			resp, err := c.AddressesWithResponse(context.TODO(), withParameters(tc.Parameters))
 			assert.Check(t, err)
 			if tc.ExpectOK {
 				assert.Equal(t, resp.StatusCode(), 200)


### PR DESCRIPTION
Tests were failing because I had two competing changes to test code between #1788, #1785 and #1784

https://app.circleci.com/pipelines/github/skupperproject/skupper/4192/workflows/982be77e-e2bc-4a5a-ae2b-00d80c8a5a7f