### PR TITLE
Collector API filtering changes

### DIFF
--- a/cmd/network-console-collector/internal/api/types_gen.go
+++ b/cmd/network-console-collector/internal/api/types_gen.go
@@ -75,6 +75,9 @@ type AddressRecord struct {
 	// EndTime The end time in microseconds of the record in Unix timestamp format.
 	EndTime uint64 `json:"endTime"`
 
+	// HasListener true when there is at least one listener for this address
+	HasListener bool `json:"hasListener"`
+
 	// Identity The unique identifier for the record.
 	Identity string `json:"identity"`
 

--- a/cmd/network-console-collector/internal/server/address_test.go
+++ b/cmd/network-console-collector/internal/server/address_test.go
@@ -52,6 +52,7 @@ func TestAddresses(t *testing.T) {
 							Name:                         "pizza",
 							ConnectorCount:               2,
 							ListenerCount:                2,
+							HasListener:                  true,
 							IsBound:                      true,
 							Protocol:                     "tcp",
 							ObservedApplicationProtocols: []string{"yodel"},

--- a/cmd/network-console-collector/internal/server/handlers.go
+++ b/cmd/network-console-collector/internal/server/handlers.go
@@ -198,7 +198,7 @@ func (s *server) Processes(w http.ResponseWriter, r *http.Request) {
 
 // (GET /api/v1alpha1/processes/{id}/)
 func (s *server) ProcessById(w http.ResponseWriter, r *http.Request, id string) {
-	getRecord := fetchAndMap(s.records, views.NewProcessProvider(s.records, s.graph), id)
+	getRecord := fetchAndConditionalMap(s.records, views.NewProcessProvider(s.records, s.graph), id)
 	if err := handleSingle(w, r, &api.ProcessResponse{}, getRecord); err != nil {
 		s.logWriteError(r, err)
 	}

--- a/cmd/network-console-collector/spec/openapi.yaml
+++ b/cmd/network-console-collector/spec/openapi.yaml
@@ -1047,6 +1047,7 @@ components:
             - listenerCount
             - connectorCount
             - isBound
+            - hasListener
           properties:
             name:
               type: string
@@ -1064,6 +1065,9 @@ components:
             isBound:
               type: boolean
               description: true when there are both listeners and connectors configured
+            hasListener:
+              type: boolean
+              description: true when there is at least one listener for this address
     ProcessGroupRecord:
       allOf:
         - $ref: '#/components/schemas/baseRecord'


### PR DESCRIPTION
* Adds a hasListener attribute to addresses to enable filtering.
* Processes are omitted from the API when the parent site is unknown.
* A process is bound only when there is a listener and connector present.