### PR TITLE
Use regexp.MustCompile instead of handling errors

### DIFF
--- a/pkg/utils/validator/simple_validator.go
+++ b/pkg/utils/validator/simple_validator.go
@@ -13,67 +13,42 @@ type Validator interface {
 
 //
 
-type StringValidator struct {
+type stringValidator struct {
 	Expression *regexp.Regexp
 }
 
-func NewStringValidator() *StringValidator {
-	re, err := regexp.Compile("^\\S*$")
-	if err != nil {
-		fmt.Printf("Error compiling regex: %v", err)
-		return nil
-	}
-	return &StringValidator{
-		Expression: re,
+func NewStringValidator() *stringValidator {
+	return &stringValidator{
+		Expression: regexp.MustCompile(`^\S*$`),
 	}
 }
 
-func NewHostStringValidator() *StringValidator {
-	re, err := regexp.Compile(`^[a-z0-9]+([-.]{1}[a-z0-9]+)*$`)
-	if err != nil {
-		fmt.Printf("Error compiling regex: %v", err)
-		return nil
-	}
-	return &StringValidator{
-		Expression: re,
+func NewHostStringValidator() *stringValidator {
+	return &stringValidator{
+		Expression: regexp.MustCompile(`^[a-z0-9]+([-.]{1}[a-z0-9]+)*$`),
 	}
 }
 
-func NewResourceStringValidator() *StringValidator {
-	re, err := regexp.Compile("^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$")
-	if err != nil {
-		fmt.Printf("Error compiling regex: %v", err)
-		return nil
-	}
-	return &StringValidator{
-		Expression: re,
+func NewResourceStringValidator() *stringValidator {
+	return &stringValidator{
+		Expression: regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$`),
 	}
 }
 
 // TBD what are valid characters for selector field
-func NewSelectorStringValidator() *StringValidator {
-	re, err := regexp.Compile("^[A-Za-z0-9=:./-]+$")
-	if err != nil {
-		fmt.Printf("Error compiling regex: %v", err)
-		return nil
-	}
-	return &StringValidator{
-		Expression: re,
+func NewSelectorStringValidator() *stringValidator {
+	return &stringValidator{
+		Expression: regexp.MustCompile(`^[A-Za-z0-9=:./-]+$`),
 	}
 }
 
-func NewFilePathStringValidator() *StringValidator {
-	re, err := regexp.Compile("^[A-Za-z0-9./~-]+$")
-	if err != nil {
-		fmt.Printf("Error compiling regex: %v", err)
-		return nil
-	}
-	return &StringValidator{
-		Expression: re,
+func NewFilePathStringValidator() *stringValidator {
+	return &stringValidator{
+		Expression: regexp.MustCompile(`^[A-Za-z0-9./~-]+$`),
 	}
 }
 
-func (s StringValidator) Evaluate(value interface{}) (bool, error) {
+func (s stringValidator) Evaluate(value interface{}) (bool, error) {
 	v, ok := value.(string)
 
 	if !ok {

--- a/pkg/utils/validator/simple_validator_test.go
+++ b/pkg/utils/validator/simple_validator_test.go
@@ -13,8 +13,8 @@ func TestNewStringValidator(t *testing.T) {
 
 	t.Run("Test String Validator constructor", func(t *testing.T) {
 
-		validRegexp, _ := regexp.Compile("^\\S*$")
-		expectedResult := &StringValidator{validRegexp}
+		validRegexp := regexp.MustCompile(`^\S*$`)
+		expectedResult := &stringValidator{validRegexp}
 		actualResult := NewStringValidator()
 		assert.Assert(t, reflect.DeepEqual(actualResult, expectedResult))
 	})
@@ -149,8 +149,8 @@ func TestNewResourceStringValidator(t *testing.T) {
 
 	t.Run("Test New Resource String Validator constructor", func(t *testing.T) {
 
-		validRegexp, _ := regexp.Compile("^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$")
-		expectedResult := &StringValidator{validRegexp}
+		validRegexp := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$`)
+		expectedResult := &stringValidator{validRegexp}
 		actualResult := NewResourceStringValidator()
 		assert.Assert(t, reflect.DeepEqual(actualResult, expectedResult))
 	})
@@ -188,8 +188,8 @@ func TestNewSelectorStringValidator(t *testing.T) {
 
 	t.Run("Test New Selector String Validator constructor", func(t *testing.T) {
 
-		validRegexp, _ := regexp.Compile("^[A-Za-z0-9=:./-]+$")
-		expectedResult := &StringValidator{validRegexp}
+		validRegexp := regexp.MustCompile("^[A-Za-z0-9=:./-]+$")
+		expectedResult := &stringValidator{validRegexp}
 		actualResult := NewSelectorStringValidator()
 		assert.Assert(t, reflect.DeepEqual(actualResult, expectedResult))
 	})
@@ -229,8 +229,8 @@ func TestNewFilePathStringValidator(t *testing.T) {
 
 	t.Run("Test New File Path String Validator constructor", func(t *testing.T) {
 
-		validRegexp, _ := regexp.Compile("^[A-Za-z0-9./~-]+$")
-		expectedResult := &StringValidator{validRegexp}
+		validRegexp := regexp.MustCompile("^[A-Za-z0-9./~-]+$")
+		expectedResult := &stringValidator{validRegexp}
 		actualResult := NewFilePathStringValidator()
 		assert.Assert(t, reflect.DeepEqual(actualResult, expectedResult))
 	})
@@ -271,7 +271,7 @@ func TestNewWorkloadStringValidator(t *testing.T) {
 
 	t.Run("Test New Workload String Validator constructor", func(t *testing.T) {
 
-		validRegexp, _ := regexp.Compile("^[A-Za-z0-9.-_]+$")
+		validRegexp := regexp.MustCompile("^[A-Za-z0-9.-_]+$")
 		expectedResult := &WorkloadValidator{validRegexp, []string{"a", "b"}}
 		actualResult := NewWorkloadStringValidator([]string{"a", "b"})
 		assert.Assert(t, reflect.DeepEqual(actualResult, expectedResult))


### PR DESCRIPTION
Invalid constant REs are a fatal error, there's no point in handling them explicitly at runtime; it's best to use MustCompile which panics on errors. Those errors will be caught during development.

StringValidator doesn't need to be public, make it private.

Use raw strings for REs to avoid having to escape twice.