### PR TITLE
fix bindings recovery

### DIFF
--- a/pkg/kube/site/site_test.go
+++ b/pkg/kube/site/site_test.go
@@ -83,7 +83,7 @@ func TestSite_Recover(t *testing.T) {
 			s, err := newSiteMocks("test", tt.k8sObjects, tt.skupperObjects, tt.skupperErrorMessage, false)
 			assert.Assert(t, err)
 
-			if err := s.Recover(tt.args.site); (err != nil) != tt.wantErr {
+			if err := s.StartRecovery(tt.args.site); (err != nil) != tt.wantErr {
 				t.Errorf("Site.Reconcile() error = %v", err)
 			}
 		})


### PR DESCRIPTION
Fixes #1661 by ensuring that the controller does not update the router configmap on restarting until any previous bindings have been recovered.