### PR TITLE
Change naming of tcpConnector and tcpListener elements in the router config

### DIFF
--- a/pkg/kube/site/bindings_test.go
+++ b/pkg/kube/site/bindings_test.go
@@ -284,8 +284,8 @@ func TestBindingAdaptor_updateBridgeConfigForConnector(t *testing.T) {
 				config: qdr.BridgeConfig{
 					TcpListeners: map[string]qdr.TcpEndpoint{},
 					TcpConnectors: map[string]qdr.TcpEndpoint{
-						"backend-192.168.1.1": qdr.TcpEndpoint{
-							Name:   "backend-192.168.1.1",
+						"backend@192.168.1.1": qdr.TcpEndpoint{
+							Name:   "backend@192.168.1.1",
 							Host:   "192.168.1.1",
 							Port:   "8080",
 							SiteId: "00000000-0000-0000-0000-000000000001",
@@ -325,8 +325,8 @@ func TestBindingAdaptor_updateBridgeConfigForConnector(t *testing.T) {
 				config: qdr.BridgeConfig{
 					TcpListeners: map[string]qdr.TcpEndpoint{},
 					TcpConnectors: map[string]qdr.TcpEndpoint{
-						"backend-10.244.0.9": qdr.TcpEndpoint{
-							Name:      "backend-10.244.0.9",
+						"backend@10.244.0.9": qdr.TcpEndpoint{
+							Name:      "backend@10.244.0.9",
 							Host:      "10.244.0.9",
 							Port:      "0",
 							SiteId:    "00000000-0000-0000-0000-000000000001",

--- a/pkg/kube/site/per_target_listener.go
+++ b/pkg/kube/site/per_target_listener.go
@@ -105,7 +105,7 @@ func (p *PerTargetListener) updateBridgeConfig(siteId string, config *qdr.Bridge
 	for target, port := range p.targets {
 		if p.definition.Spec.Type == "tcp" || p.definition.Spec.Type == "" {
 			config.AddTcpListener(qdr.TcpEndpoint{
-				Name:       p.definition.Name + "-" + target,
+				Name:       p.definition.Name + "@" + target,
 				SiteId:     siteId,
 				Host:       "0.0.0.0",
 				Port:       strconv.Itoa(port),

--- a/pkg/site/bindings_test.go
+++ b/pkg/site/bindings_test.go
@@ -101,8 +101,8 @@ func TestBindings_Apply(t *testing.T) {
 			expected: expected{
 				tcpListeners: qdr.TcpEndpointMap{},
 				tcpConnectors: qdr.TcpEndpointMap{
-					"connector1-10.10.10.1": {
-						Name:    "connector1-10.10.10.1",
+					"connector1@10.10.10.1": {
+						Name:    "connector1@10.10.10.1",
 						Host:    "10.10.10.1",
 						Port:    "9090",
 						Address: "echo:9090",
@@ -243,8 +243,8 @@ func TestBindings_Apply(t *testing.T) {
 			expected: expected{
 				tcpListeners: qdr.TcpEndpointMap{},
 				tcpConnectors: qdr.TcpEndpointMap{
-					"connector1-10.10.10.1": {
-						Name:           "connector1-10.10.10.1",
+					"connector1@10.10.10.1": {
+						Name:           "connector1@10.10.10.1",
 						Host:           "10.10.10.1",
 						Port:           "9090",
 						Address:        "echo:9090",
@@ -294,8 +294,8 @@ func TestBindings_Apply(t *testing.T) {
 			expected: expected{
 				tcpListeners: qdr.TcpEndpointMap{},
 				tcpConnectors: qdr.TcpEndpointMap{
-					"connector1-10.10.10.1": {
-						Name:           "connector1-10.10.10.1",
+					"connector1@10.10.10.1": {
+						Name:           "connector1@10.10.10.1",
 						Host:           "10.10.10.1",
 						Port:           "9090",
 						Address:        "echo:9090",
@@ -350,16 +350,16 @@ func TestBindings_Apply(t *testing.T) {
 			expected: expected{
 				tcpListeners: qdr.TcpEndpointMap{},
 				tcpConnectors: qdr.TcpEndpointMap{
-					"connector1-11.5.6.21": {
-						Name:      "connector1-11.5.6.21",
+					"connector1@11.5.6.21": {
+						Name:      "connector1@11.5.6.21",
 						Host:      "11.5.6.21",
 						Port:      "9090",
 						Address:   "echo:9090",
 						SiteId:    "site-1",
 						ProcessID: "pod1",
 					},
-					"connector1-11.5.6.22": {
-						Name:      "connector1-11.5.6.22",
+					"connector1@11.5.6.22": {
+						Name:      "connector1@11.5.6.22",
 						Host:      "11.5.6.22",
 						Port:      "9090",
 						Address:   "echo:9090",
@@ -482,8 +482,8 @@ func TestBindings_Apply(t *testing.T) {
 			expected: expected{
 				tcpListeners: qdr.TcpEndpointMap{},
 				tcpConnectors: qdr.TcpEndpointMap{
-					"connector1-10.10.10.1": {
-						Name:    "connector1-10.10.10.1",
+					"connector1@10.10.10.1": {
+						Name:    "connector1@10.10.10.1",
 						Host:    "10.10.10.1",
 						Port:    "9090",
 						Address: "foo",

--- a/pkg/site/connector.go
+++ b/pkg/site/connector.go
@@ -9,14 +9,14 @@ import (
 
 func UpdateBridgeConfigForConnector(siteId string, connector *skupperv2alpha1.Connector, config *qdr.BridgeConfig) {
 	if connector.Spec.Host != "" {
-		updateBridgeConfigForConnector(connector.Name+"-"+connector.Spec.Host, siteId, connector, connector.Spec.Host, "", connector.Spec.RoutingKey, config)
+		updateBridgeConfigForConnector(connector.Name+"@"+connector.Spec.Host, siteId, connector, connector.Spec.Host, "", connector.Spec.RoutingKey, config)
 	}
 }
 
 func UpdateBridgeConfigForConnectorToPod(siteId string, connector *skupperv2alpha1.Connector, pod skupperv2alpha1.PodDetails, addQualifiedAddress bool, config *qdr.BridgeConfig) {
-	updateBridgeConfigForConnector(connector.Name+"-"+pod.IP, siteId, connector, pod.IP, pod.UID, connector.Spec.RoutingKey, config)
+	updateBridgeConfigForConnector(connector.Name+"@"+pod.IP, siteId, connector, pod.IP, pod.UID, connector.Spec.RoutingKey, config)
 	if addQualifiedAddress {
-		updateBridgeConfigForConnector(connector.Name+"-"+pod.Name, siteId, connector, pod.IP, pod.UID, connector.Spec.RoutingKey+"."+pod.Name, config)
+		updateBridgeConfigForConnector(connector.Name+"@"+pod.Name, siteId, connector, pod.IP, pod.UID, connector.Spec.RoutingKey+"."+pod.Name, config)
 	}
 }
 


### PR DESCRIPTION
This makes it simpler and less brittle to derive the name of the kuberenetes resource with which the config element originates.