### PR TITLE
Fixes grant server updating grant status before site is ready

### DIFF
--- a/pkg/kube/grants/grants.go
+++ b/pkg/kube/grants/grants.go
@@ -286,7 +286,7 @@ func (g *Grants) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	grant := g.get(key)
 	if grant == nil {
 		log.Printf("No such claim: %s", key)
-		http.Error(w, fmt.Sprintf("No such claim: %s", key), http.StatusBadRequest)
+		httpError("No such claim", http.StatusNotFound).write(w)
 		return
 	}
 	name := r.Header.Get("name")

--- a/pkg/kube/site/site.go
+++ b/pkg/kube/site/site.go
@@ -679,7 +679,7 @@ func (s *Site) updateConnectorConfiguredStatusWithSelectedPods(connector *skuppe
 
 func (s *Site) CheckConnector(name string, connector *skupperv2alpha1.Connector) error {
 	update := s.bindings.UpdateConnector(name, connector)
-	if s.site == nil {
+	if s.site == nil && connector != nil {
 		return s.updateConnectorConfiguredStatus(connector, stderrors.New("No active site in namespace"))
 	}
 	if update == nil {
@@ -705,7 +705,7 @@ func (s *Site) updateListenerStatus(listener *skupperv2alpha1.Listener, err erro
 
 func (s *Site) CheckListener(name string, listener *skupperv2alpha1.Listener) error {
 	update, err1 := s.bindings.UpdateListener(name, listener)
-	if s.site == nil {
+	if s.site == nil && listener != nil {
 		return s.updateListenerStatus(listener, stderrors.New("No active site in namespace"))
 	}
 	if update == nil {


### PR DESCRIPTION
* AccessGrant status.redeemed count was being increased before generateLinkConfig was able to resolve endpoints, returning the "Could not resolve any endpoints for requested link" error and exhausting the AccessGrant before it is actually consumed
* Fixed null pointer issue found (eventually) while deleting a namespace for an active site