### PR TITLE
increase node version

### DIFF
--- a/Dockerfile.network-observer
+++ b/Dockerfile.network-observer
@@ -13,7 +13,7 @@ COPY . .
 ENV CGO_ENABLED=0
 RUN make GOARCH=$TARGETARCH build-network-observer
 
-FROM --platform=$BUILDPLATFORM node:20.0.0 AS console-builder
+FROM --platform=$BUILDPLATFORM node:20.9.0 AS console-builder
 
 WORKDIR /skupper-console/
 ADD https://github.com/skupperproject/skupper-console/archive/v2.tar.gz .

--- a/Dockerfile.network-observer
+++ b/Dockerfile.network-observer
@@ -13,7 +13,7 @@ COPY . .
 ENV CGO_ENABLED=0
 RUN make GOARCH=$TARGETARCH build-network-observer
 
-FROM --platform=$BUILDPLATFORM node:18.18.2 AS console-builder
+FROM --platform=$BUILDPLATFORM node:20.0.0 AS console-builder
 
 WORKDIR /skupper-console/
 ADD https://github.com/skupperproject/skupper-console/archive/v2.tar.gz .


### PR DESCRIPTION
Changing node version, this is the log that points out the incompatibility with node 18.18.2

https://app.circleci.com/pipelines/github/skupperproject/skupper/4318/workflows/23a7e113-56fd-48ae-bab2-a35cf01a0ac1/jobs/27428/parallel-runs/0/steps/0-105