### PR TITLE
show running pods version

### DIFF
--- a/internal/cmd/skupper/version/kube/version.go
+++ b/internal/cmd/skupper/version/kube/version.go
@@ -65,7 +65,7 @@ func (cmd *CmdVersion) InputToOptions() {
 	mapRunningPods := make(map[string]string)
 
 	if cmd.KubeClient != nil {
-		// search for running pods in all namespaces
+		// search for running pods in the current namespace
 		runningPodList, err := cmd.KubeClient.CoreV1().Pods(cmd.namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "app.kubernetes.io/part-of in (skupper, skupper-network-observer)"})
 		if err != nil {
 			return

--- a/internal/cmd/skupper/version/kube/version.go
+++ b/internal/cmd/skupper/version/kube/version.go
@@ -66,7 +66,7 @@ func (cmd *CmdVersion) InputToOptions() {
 
 	if cmd.KubeClient != nil {
 		// search for running pods in all namespaces
-		runningPodList, err := cmd.KubeClient.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{LabelSelector: "app.kubernetes.io/part-of=skupper"})
+		runningPodList, err := cmd.KubeClient.CoreV1().Pods(cmd.namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "app.kubernetes.io/part-of in (skupper, skupper-network-observer)"})
 		if err != nil {
 			return
 		}

--- a/pkg/images/image_utils.go
+++ b/pkg/images/image_utils.go
@@ -235,41 +235,38 @@ func GetImages(component string, enableSHA bool, runningPods map[string]string) 
 		// skupper router has two components
 		runningImage := runningPods["router"]
 		envImage := os.Getenv(RouterImageEnvKey)
-		defaultImage := RouterImageName
 
 		if runningImage != "" {
 			names[RouterImageEnvKey] = runningImage
 		} else if envImage != "" {
 			names[RouterImageEnvKey] = envImage
 		} else {
-			names[RouterImageEnvKey] = defaultImage
+			names[RouterImageEnvKey] = RouterImageName
 			registry = GetImageRegistry()
 		}
 
 		// skupper router has two components
 		runningImage = runningPods["kube-adaptor"]
 		envImage = os.Getenv(AdaptorImageEnvKey)
-		defaultImage = AdaptorImageName
 
 		if runningImage != "" {
 			names[AdaptorImageEnvKey] = runningImage
 		} else if envImage != "" {
 			names[AdaptorImageEnvKey] = envImage
 		} else {
-			names[AdaptorImageEnvKey] = defaultImage
+			names[AdaptorImageEnvKey] = AdaptorImageName
 			registry = GetImageRegistry()
 		}
 	case "controller":
 		runningImage := runningPods["controller"]
 		envImage := os.Getenv(ControllerImageEnvKey)
-		defaultImage := ControllerImageName
 
 		if runningImage != "" {
 			names[ControllerImageEnvKey] = runningImage
 		} else if envImage != "" {
 			names[ControllerImageEnvKey] = envImage
 		} else {
-			names[ControllerImageEnvKey] = defaultImage
+			names[ControllerImageEnvKey] = ControllerImageName
 			registry = GetImageRegistry()
 		}
 
@@ -277,14 +274,13 @@ func GetImages(component string, enableSHA bool, runningPods map[string]string) 
 
 		runningImage := runningPods["network-observer"]
 		envImage := os.Getenv(NetworkObserverImageEnvKey)
-		defaultImage := NetworkObserverImageName
 
 		if runningImage != "" {
 			names[NetworkObserverImageEnvKey] = runningImage
 		} else if envImage != "" {
 			names[NetworkObserverImageEnvKey] = envImage
 		} else {
-			names[NetworkObserverImageEnvKey] = defaultImage
+			names[NetworkObserverImageEnvKey] = NetworkObserverImageName
 			registry = GetImageRegistry()
 		}
 
@@ -313,40 +309,37 @@ func GetImageVersion(component string, runningPods map[string]string) string {
 	case "router":
 		runningImage := runningPods["router"]
 		envImage := os.Getenv(RouterImageEnvKey)
-		defaultImage := RouterImageName
 
 		if runningImage != "" {
 			image = runningImage
 		} else if envImage != "" {
 			image = envImage
 		} else {
-			image = defaultImage
+			image = RouterImageName
 		}
 
 	case "controller":
 		runningImage := runningPods["controller"]
 		envImage := os.Getenv(ControllerImageEnvKey)
-		defaultImage := ControllerImageName
 
 		if runningImage != "" {
 			image = runningImage
 		} else if envImage != "" {
 			image = envImage
 		} else {
-			image = defaultImage
+			image = ControllerImageName
 		}
 
 	case "network-observer":
 		runningImage := runningPods["network-observer"]
 		envImage := os.Getenv(NetworkObserverImageEnvKey)
-		defaultImage := NetworkObserverImageName
 
 		if runningImage != "" {
 			image = runningImage
 		} else if envImage != "" {
 			image = envImage
 		} else {
-			image = defaultImage
+			image = NetworkObserverImageName
 		}
 	case "cli":
 		image = os.Getenv(CliImageName)

--- a/pkg/images/image_utils.go
+++ b/pkg/images/image_utils.go
@@ -225,7 +225,7 @@ func GetImage(imageNames map[string]string, imageRegistry string, enableSHA bool
 	return skupperImage
 }
 
-func GetImages(component string, enableSHA bool, runningPods map[string]string) []SkupperImage {
+func GetImages(component string, enableSHA bool) []SkupperImage {
 	//var names map[string]string
 	var registry string
 
@@ -233,37 +233,26 @@ func GetImages(component string, enableSHA bool, runningPods map[string]string) 
 	switch component {
 	case "router":
 		// skupper router has two components
-		runningImage := runningPods["router"]
 		envImage := os.Getenv(RouterImageEnvKey)
 
-		if runningImage != "" {
-			names[RouterImageEnvKey] = runningImage
-		} else if envImage != "" {
+		if envImage != "" {
 			names[RouterImageEnvKey] = envImage
 		} else {
 			names[RouterImageEnvKey] = RouterImageName
 			registry = GetImageRegistry()
 		}
 
-		// skupper router has two components
-		runningImage = runningPods["kube-adaptor"]
 		envImage = os.Getenv(AdaptorImageEnvKey)
-
-		if runningImage != "" {
-			names[AdaptorImageEnvKey] = runningImage
-		} else if envImage != "" {
+		if envImage != "" {
 			names[AdaptorImageEnvKey] = envImage
 		} else {
 			names[AdaptorImageEnvKey] = AdaptorImageName
 			registry = GetImageRegistry()
 		}
 	case "controller":
-		runningImage := runningPods["controller"]
 		envImage := os.Getenv(ControllerImageEnvKey)
 
-		if runningImage != "" {
-			names[ControllerImageEnvKey] = runningImage
-		} else if envImage != "" {
+		if envImage != "" {
 			names[ControllerImageEnvKey] = envImage
 		} else {
 			names[ControllerImageEnvKey] = ControllerImageName
@@ -272,12 +261,9 @@ func GetImages(component string, enableSHA bool, runningPods map[string]string) 
 
 	case "network-observer":
 
-		runningImage := runningPods["network-observer"]
 		envImage := os.Getenv(NetworkObserverImageEnvKey)
 
-		if runningImage != "" {
-			names[NetworkObserverImageEnvKey] = runningImage
-		} else if envImage != "" {
+		if envImage != "" {
 			names[NetworkObserverImageEnvKey] = envImage
 		} else {
 			names[NetworkObserverImageEnvKey] = NetworkObserverImageName
@@ -302,41 +288,34 @@ func GetImages(component string, enableSHA bool, runningPods map[string]string) 
 	}
 }
 
-func GetImageVersion(component string, runningPods map[string]string) string {
+func GetImageVersion(component string) string {
 	var image string
 
 	switch component {
 	case "router":
-		runningImage := runningPods["router"]
 		envImage := os.Getenv(RouterImageEnvKey)
 
-		if runningImage != "" {
-			image = runningImage
-		} else if envImage != "" {
+		if envImage != "" {
 			image = envImage
 		} else {
 			image = RouterImageName
 		}
 
 	case "controller":
-		runningImage := runningPods["controller"]
+
 		envImage := os.Getenv(ControllerImageEnvKey)
 
-		if runningImage != "" {
-			image = runningImage
-		} else if envImage != "" {
+		if envImage != "" {
 			image = envImage
 		} else {
 			image = ControllerImageName
 		}
 
 	case "network-observer":
-		runningImage := runningPods["network-observer"]
+
 		envImage := os.Getenv(NetworkObserverImageEnvKey)
 
-		if runningImage != "" {
-			image = runningImage
-		} else if envImage != "" {
+		if envImage != "" {
 			image = envImage
 		} else {
 			image = NetworkObserverImageName
@@ -358,10 +337,15 @@ func GetImageVersion(component string, runningPods map[string]string) string {
 		}
 	}
 	if image != "" {
-		parts := strings.Split(image, ":")
-		if len(parts) == 2 {
-			return parts[1]
-		}
+		return GetVersionFromTag(image)
+	}
+	return ""
+}
+
+func GetVersionFromTag(image string) string {
+	parts := strings.Split(image, ":")
+	if len(parts) == 2 {
+		return parts[1]
 	}
 
 	return ""

--- a/pkg/utils/configs/manifest.go
+++ b/pkg/utils/configs/manifest.go
@@ -22,8 +22,9 @@ type Manifest struct {
 }
 
 type ManifestManager struct {
-	EnableSHA  bool
-	Components []string
+	EnableSHA   bool
+	Components  []string
+	RunningPods map[string]string
 }
 
 type ManifestGenerator interface {
@@ -32,7 +33,7 @@ type ManifestGenerator interface {
 }
 
 func (manager *ManifestManager) GetConfiguredManifest() SkupperManifest {
-	return getSkupperConfiguredImages(manager.Components, manager.EnableSHA)
+	return getSkupperConfiguredImages(manager.Components, manager.EnableSHA, manager.RunningPods)
 }
 
 func (manager *ManifestManager) GetDefaultManifestWithEnv() Manifest {
@@ -42,14 +43,14 @@ func (manager *ManifestManager) GetDefaultManifestWithEnv() Manifest {
 	}
 }
 
-func getSkupperConfiguredImages(components []string, enableSHA bool) SkupperManifest {
+func getSkupperConfiguredImages(components []string, enableSHA bool, runningPods map[string]string) SkupperManifest {
 	var manifest SkupperManifest
 
 	for _, component := range components {
 		var image SkupperComponent
 		image.Component = component
-		image.Version = images.GetImageVersion(component)
-		image.Images = images.GetImages(component, enableSHA)
+		image.Version = images.GetImageVersion(component, runningPods)
+		image.Images = images.GetImages(component, enableSHA, runningPods)
 		manifest.Components = append(manifest.Components, image)
 	}
 
@@ -62,8 +63,8 @@ func getSkupperDefaultImages() SkupperManifest {
 	for _, component := range images.DefaultComponents {
 		var image SkupperComponent
 		image.Component = component
-		image.Version = images.GetImageVersion(component)
-		image.Images = images.GetImages(component, false)
+		image.Version = images.GetImageVersion(component, map[string]string{})
+		image.Images = images.GetImages(component, false, map[string]string{})
 		manifest.Components = append(manifest.Components, image)
 	}
 


### PR DESCRIPTION
The user can deploy declarative any version of the skupper controller/network-observer without specifying environment variables. For that reason, with this change the kube flavor of the version command will check the skupper components that are running (in ~all namespaces~ the current namespace) to get the version that the component is actually running.

The priority order is as follows:
  Running pod > Environment variable > Constant (images.go)

Affected components:
- controller
- kube-adaptor
- router
- network-observer
