### PR TITLE
Update Network Observer API Route Slash Conventions

### DIFF
--- a/cmd/network-observer/internal/api/types_gen.go
+++ b/cmd/network-observer/internal/api/types_gen.go
@@ -1377,7 +1377,7 @@ func NewAddressesRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/addresses/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/addresses")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1411,7 +1411,7 @@ func NewAddressByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/addresses/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/addresses/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1445,7 +1445,7 @@ func NewConnectionsByAddressRequest(server string, id PathID) (*http.Request, er
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/addresses/%s/connections/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/addresses/%s/connections", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1479,7 +1479,7 @@ func NewProcessesByAddressRequest(server string, id PathID) (*http.Request, erro
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/addresses/%s/processes/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/addresses/%s/processes", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1513,7 +1513,7 @@ func NewProcessPairsByAddressRequest(server string, id PathID) (*http.Request, e
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/addresses/%s/processpairs/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/addresses/%s/processpairs", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1540,7 +1540,7 @@ func NewApplicationflowsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/applicationflows/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/applicationflows")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1567,7 +1567,7 @@ func NewConnectionsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/connections/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/connections")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1594,7 +1594,7 @@ func NewConnectorsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/connectors/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/connectors")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1628,7 +1628,7 @@ func NewConnectorByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/connectors/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/connectors/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1655,7 +1655,7 @@ func NewHostsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/hosts/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/hosts")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1689,7 +1689,7 @@ func NewHostsByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/hosts/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/hosts/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1716,7 +1716,7 @@ func NewLinksRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/links/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/links")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1750,7 +1750,7 @@ func NewLinkByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/links/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/links/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1777,7 +1777,7 @@ func NewListenersRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/listeners/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/listeners")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1811,7 +1811,7 @@ func NewListenerByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/listeners/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/listeners/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1838,7 +1838,7 @@ func NewProcessesRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/processes/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/processes")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1872,7 +1872,7 @@ func NewProcessByIdRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/processes/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/processes/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1899,7 +1899,7 @@ func NewProcessgrouppairsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/processgrouppairs/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/processgrouppairs")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1933,7 +1933,7 @@ func NewProcessgrouppairByIDRequest(server string, id PathID) (*http.Request, er
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/processgrouppairs/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/processgrouppairs/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1960,7 +1960,7 @@ func NewProcessgroupsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/processgroups/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/processgroups")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -1994,7 +1994,7 @@ func NewProcessgroupByIDRequest(server string, id PathID) (*http.Request, error)
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/processgroups/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/processgroups/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2021,7 +2021,7 @@ func NewProcesspairsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/processpairs/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/processpairs")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2055,7 +2055,7 @@ func NewProcesspairByIDRequest(server string, id PathID) (*http.Request, error) 
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/processpairs/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/processpairs/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2082,7 +2082,7 @@ func NewRouteraccessRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/routeraccess/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/routeraccess")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2116,7 +2116,7 @@ func NewRouteraccessByIDRequest(server string, id PathID) (*http.Request, error)
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/routeraccess/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/routeraccess/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2143,7 +2143,7 @@ func NewRouterlinksRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/routerlinks/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/routerlinks")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2177,7 +2177,7 @@ func NewRouterlinkByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/routerlinks/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/routerlinks/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2204,7 +2204,7 @@ func NewRoutersRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/routers/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/routers")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2238,7 +2238,7 @@ func NewRouterByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/routers/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/routers/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2272,7 +2272,7 @@ func NewLinksByRouterRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/routers/%s/links/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/routers/%s/links", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2299,7 +2299,7 @@ func NewSitepairsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/sitepairs/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/sitepairs")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2333,7 +2333,7 @@ func NewSitepairByIDRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/sitepairs/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/sitepairs/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2360,7 +2360,7 @@ func NewSitesRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/sites/")
+	operationPath := fmt.Sprintf("/api/v1alpha1/sites")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2394,7 +2394,7 @@ func NewSiteByIdRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/sites/%s/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/sites/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2428,7 +2428,7 @@ func NewHostsBySiteRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/sites/%s/hosts/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/sites/%s/hosts", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2462,7 +2462,7 @@ func NewLinksBySiteRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/sites/%s/links/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/sites/%s/links", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2496,7 +2496,7 @@ func NewProcessesBySiteRequest(server string, id PathID) (*http.Request, error) 
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/sites/%s/processes/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/sites/%s/processes", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2530,7 +2530,7 @@ func NewRoutersBySiteRequest(server string, id PathID) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1alpha1/sites/%s/routers/", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1alpha1/sites/%s/routers", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -5131,118 +5131,118 @@ func ParseRoutersBySiteResponse(rsp *http.Response) (*RoutersBySiteResponse, err
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
 
-	// (GET /api/v1alpha1/addresses/)
+	// (GET /api/v1alpha1/addresses)
 	Addresses(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/addresses/{id}/)
+	// (GET /api/v1alpha1/addresses/{id})
 	AddressByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/addresses/{id}/connections/)
+	// (GET /api/v1alpha1/addresses/{id}/connections)
 	ConnectionsByAddress(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/addresses/{id}/processes/)
+	// (GET /api/v1alpha1/addresses/{id}/processes)
 	ProcessesByAddress(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/addresses/{id}/processpairs/)
+	// (GET /api/v1alpha1/addresses/{id}/processpairs)
 	ProcessPairsByAddress(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/applicationflows/)
+	// (GET /api/v1alpha1/applicationflows)
 	Applicationflows(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/connections/)
+	// (GET /api/v1alpha1/connections)
 	Connections(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/connectors/)
+	// (GET /api/v1alpha1/connectors)
 	Connectors(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/connectors/{id}/)
+	// (GET /api/v1alpha1/connectors/{id})
 	ConnectorByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/hosts/)
+	// (GET /api/v1alpha1/hosts)
 	Hosts(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/hosts/{id}/)
+	// (GET /api/v1alpha1/hosts/{id})
 	HostsByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/links/)
+	// (GET /api/v1alpha1/links)
 	Links(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/links/{id}/)
+	// (GET /api/v1alpha1/links/{id})
 	LinkByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/listeners/)
+	// (GET /api/v1alpha1/listeners)
 	Listeners(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/listeners/{id}/)
+	// (GET /api/v1alpha1/listeners/{id})
 	ListenerByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/processes/)
+	// (GET /api/v1alpha1/processes)
 	Processes(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/processes/{id}/)
+	// (GET /api/v1alpha1/processes/{id})
 	ProcessById(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/processgrouppairs/)
+	// (GET /api/v1alpha1/processgrouppairs)
 	Processgrouppairs(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/processgrouppairs/{id}/)
+	// (GET /api/v1alpha1/processgrouppairs/{id})
 	ProcessgrouppairByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/processgroups/)
+	// (GET /api/v1alpha1/processgroups)
 	Processgroups(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/processgroups/{id}/)
+	// (GET /api/v1alpha1/processgroups/{id})
 	ProcessgroupByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/processpairs/)
+	// (GET /api/v1alpha1/processpairs)
 	Processpairs(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/processpairs/{id}/)
+	// (GET /api/v1alpha1/processpairs/{id})
 	ProcesspairByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/routeraccess/)
+	// (GET /api/v1alpha1/routeraccess)
 	Routeraccess(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/routeraccess/{id}/)
+	// (GET /api/v1alpha1/routeraccess/{id})
 	RouteraccessByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/routerlinks/)
+	// (GET /api/v1alpha1/routerlinks)
 	Routerlinks(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/routerlinks/{id}/)
+	// (GET /api/v1alpha1/routerlinks/{id})
 	RouterlinkByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/routers/)
+	// (GET /api/v1alpha1/routers)
 	Routers(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/routers/{id}/)
+	// (GET /api/v1alpha1/routers/{id})
 	RouterByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/routers/{id}/links/)
+	// (GET /api/v1alpha1/routers/{id}/links)
 	LinksByRouter(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/sitepairs/)
+	// (GET /api/v1alpha1/sitepairs)
 	Sitepairs(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/sitepairs/{id}/)
+	// (GET /api/v1alpha1/sitepairs/{id})
 	SitepairByID(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/sites/)
+	// (GET /api/v1alpha1/sites)
 	Sites(w http.ResponseWriter, r *http.Request)
 
-	// (GET /api/v1alpha1/sites/{id}/)
+	// (GET /api/v1alpha1/sites/{id})
 	SiteById(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/sites/{id}/hosts/)
+	// (GET /api/v1alpha1/sites/{id}/hosts)
 	HostsBySite(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/sites/{id}/links/)
+	// (GET /api/v1alpha1/sites/{id}/links)
 	LinksBySite(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/sites/{id}/processes/)
+	// (GET /api/v1alpha1/sites/{id}/processes)
 	ProcessesBySite(w http.ResponseWriter, r *http.Request, id PathID)
 
-	// (GET /api/v1alpha1/sites/{id}/routers/)
+	// (GET /api/v1alpha1/sites/{id}/routers)
 	RoutersBySite(w http.ResponseWriter, r *http.Request, id PathID)
 }
 
@@ -6180,81 +6180,81 @@ func HandlerWithOptions(si ServerInterface, options GorillaServerOptions) http.H
 		ErrorHandlerFunc:   options.ErrorHandlerFunc,
 	}
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/addresses/", wrapper.Addresses).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/addresses", wrapper.Addresses).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/addresses/{id}/", wrapper.AddressByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/addresses/{id}", wrapper.AddressByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/addresses/{id}/connections/", wrapper.ConnectionsByAddress).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/addresses/{id}/connections", wrapper.ConnectionsByAddress).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/addresses/{id}/processes/", wrapper.ProcessesByAddress).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/addresses/{id}/processes", wrapper.ProcessesByAddress).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/addresses/{id}/processpairs/", wrapper.ProcessPairsByAddress).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/addresses/{id}/processpairs", wrapper.ProcessPairsByAddress).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/applicationflows/", wrapper.Applicationflows).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/applicationflows", wrapper.Applicationflows).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/connections/", wrapper.Connections).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/connections", wrapper.Connections).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/connectors/", wrapper.Connectors).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/connectors", wrapper.Connectors).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/connectors/{id}/", wrapper.ConnectorByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/connectors/{id}", wrapper.ConnectorByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/hosts/", wrapper.Hosts).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/hosts", wrapper.Hosts).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/hosts/{id}/", wrapper.HostsByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/hosts/{id}", wrapper.HostsByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/links/", wrapper.Links).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/links", wrapper.Links).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/links/{id}/", wrapper.LinkByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/links/{id}", wrapper.LinkByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/listeners/", wrapper.Listeners).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/listeners", wrapper.Listeners).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/listeners/{id}/", wrapper.ListenerByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/listeners/{id}", wrapper.ListenerByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processes/", wrapper.Processes).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processes", wrapper.Processes).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processes/{id}/", wrapper.ProcessById).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processes/{id}", wrapper.ProcessById).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processgrouppairs/", wrapper.Processgrouppairs).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processgrouppairs", wrapper.Processgrouppairs).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processgrouppairs/{id}/", wrapper.ProcessgrouppairByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processgrouppairs/{id}", wrapper.ProcessgrouppairByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processgroups/", wrapper.Processgroups).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processgroups", wrapper.Processgroups).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processgroups/{id}/", wrapper.ProcessgroupByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processgroups/{id}", wrapper.ProcessgroupByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processpairs/", wrapper.Processpairs).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processpairs", wrapper.Processpairs).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processpairs/{id}/", wrapper.ProcesspairByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/processpairs/{id}", wrapper.ProcesspairByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routeraccess/", wrapper.Routeraccess).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routeraccess", wrapper.Routeraccess).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routeraccess/{id}/", wrapper.RouteraccessByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routeraccess/{id}", wrapper.RouteraccessByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routerlinks/", wrapper.Routerlinks).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routerlinks", wrapper.Routerlinks).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routerlinks/{id}/", wrapper.RouterlinkByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routerlinks/{id}", wrapper.RouterlinkByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routers/", wrapper.Routers).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routers", wrapper.Routers).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routers/{id}/", wrapper.RouterByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routers/{id}", wrapper.RouterByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routers/{id}/links/", wrapper.LinksByRouter).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/routers/{id}/links", wrapper.LinksByRouter).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sitepairs/", wrapper.Sitepairs).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sitepairs", wrapper.Sitepairs).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sitepairs/{id}/", wrapper.SitepairByID).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sitepairs/{id}", wrapper.SitepairByID).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/", wrapper.Sites).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites", wrapper.Sites).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/{id}/", wrapper.SiteById).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/{id}", wrapper.SiteById).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/{id}/hosts/", wrapper.HostsBySite).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/{id}/hosts", wrapper.HostsBySite).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/{id}/links/", wrapper.LinksBySite).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/{id}/links", wrapper.LinksBySite).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/{id}/processes/", wrapper.ProcessesBySite).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/{id}/processes", wrapper.ProcessesBySite).Methods("GET")
 
-	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/{id}/routers/", wrapper.RoutersBySite).Methods("GET")
+	r.HandleFunc(options.BaseURL+"/api/v1alpha1/sites/{id}/routers", wrapper.RoutersBySite).Methods("GET")
 
 	return r
 }

--- a/cmd/network-observer/spec/openapi.yaml
+++ b/cmd/network-observer/spec/openapi.yaml
@@ -13,7 +13,7 @@ info:
   version: 0.0.1
 
 paths:
-  /api/v1alpha1/sites/:
+  /api/v1alpha1/sites:
     get:
       tags: [site]
       operationId: sites
@@ -22,7 +22,7 @@ paths:
           $ref: '#/components/responses/getSites'
         '400':
           $ref: '#/components/responses/errorBadRequest'
-  /api/v1alpha1/sites/{id}/:
+  /api/v1alpha1/sites/{id}:
     get:
       tags: [site]
       operationId: siteById
@@ -33,7 +33,7 @@ paths:
           $ref: '#/components/responses/getSiteByID'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/processes/:
+  /api/v1alpha1/processes:
     get:
       tags: [process]
       operationId: processes
@@ -42,7 +42,7 @@ paths:
           $ref: '#/components/responses/getProcesses'
         '400':
           $ref: '#/components/responses/errorBadRequest'
-  /api/v1alpha1/processes/{id}/:
+  /api/v1alpha1/processes/{id}:
     get:
       tags: [process]
       operationId: processById
@@ -53,7 +53,7 @@ paths:
           $ref: '#/components/responses/getProcessByID'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/routers/:
+  /api/v1alpha1/routers:
     get:
       tags: [router]
       operationId: routers
@@ -62,7 +62,7 @@ paths:
           $ref: '#/components/responses/getRouters'
         '400':
           $ref: '#/components/responses/errorBadRequest'
-  /api/v1alpha1/routers/{id}/:
+  /api/v1alpha1/routers/{id}:
     get:
       tags: [router]
       operationId: routerByID
@@ -73,7 +73,7 @@ paths:
           $ref: '#/components/responses/getRouterByID'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/listeners/:
+  /api/v1alpha1/listeners:
     get:
       tags: [listener]
       operationId: listeners
@@ -82,7 +82,7 @@ paths:
           $ref: '#/components/responses/getListeners'
         '400':
           $ref: '#/components/responses/errorBadRequest'
-  /api/v1alpha1/listeners/{id}/:
+  /api/v1alpha1/listeners/{id}:
     get:
       tags: [listener]
       operationId: listenerByID
@@ -93,7 +93,7 @@ paths:
           $ref: '#/components/responses/getListenerByID'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/connectors/:
+  /api/v1alpha1/connectors:
     get:
       tags: [connector]
       operationId: connectors
@@ -102,7 +102,7 @@ paths:
           $ref: '#/components/responses/getConnectors'
         '400':
           $ref: '#/components/responses/errorBadRequest'
-  /api/v1alpha1/connectors/{id}/:
+  /api/v1alpha1/connectors/{id}:
     get:
       tags: [connector]
       operationId: connectorByID
@@ -113,7 +113,7 @@ paths:
           $ref: '#/components/responses/getConnectorByID'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/addresses/:
+  /api/v1alpha1/addresses:
     get:
       tags: [address]
       operationId: addresses
@@ -122,7 +122,7 @@ paths:
           $ref: '#/components/responses/getAddresses'
         '400':
           $ref: '#/components/responses/errorBadRequest'
-  /api/v1alpha1/addresses/{id}/:
+  /api/v1alpha1/addresses/{id}:
     get:
       tags: [address]
       operationId: addressByID
@@ -133,7 +133,7 @@ paths:
           $ref: '#/components/responses/getAddressByID'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/processgroups/:
+  /api/v1alpha1/processgroups:
     get:
       tags: ["process group"]
       operationId: processgroups
@@ -142,7 +142,7 @@ paths:
           $ref: '#/components/responses/getProcessGroups'
         '400':
           $ref: '#/components/responses/errorBadRequest'
-  /api/v1alpha1/processgroups/{id}/:
+  /api/v1alpha1/processgroups/{id}:
     get:
       tags: ["process group"]
       operationId: processgroupByID
@@ -153,7 +153,7 @@ paths:
           $ref: '#/components/responses/getProcessGroupByID'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/sitepairs/:
+  /api/v1alpha1/sitepairs:
     get:
       tags: ["flow aggregate"]
       operationId: sitepairs
@@ -162,7 +162,7 @@ paths:
           $ref: '#/components/responses/getFlowAggregates'
         '400':
           $ref: '#/components/responses/errorBadRequest'
-  /api/v1alpha1/sitepairs/{id}/:
+  /api/v1alpha1/sitepairs/{id}:
     get:
       tags: ["flow aggregate"]
       operationId: sitepairByID
@@ -173,7 +173,7 @@ paths:
           $ref: '#/components/responses/getFlowAggregateByID'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/processgrouppairs/:
+  /api/v1alpha1/processgrouppairs:
     get:
       tags: ["flow aggregate"]
       operationId: processgrouppairs
@@ -182,7 +182,7 @@ paths:
           $ref: '#/components/responses/getFlowAggregates'
         '400':
           $ref: '#/components/responses/errorBadRequest'
-  /api/v1alpha1/processgrouppairs/{id}/:
+  /api/v1alpha1/processgrouppairs/{id}:
     get:
       tags: ["flow aggregate"]
       operationId: processgrouppairByID
@@ -193,7 +193,7 @@ paths:
           $ref: '#/components/responses/getFlowAggregateByID'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/processpairs/:
+  /api/v1alpha1/processpairs:
     get:
       tags: ["flow aggregate"]
       operationId: processpairs
@@ -202,7 +202,7 @@ paths:
           $ref: '#/components/responses/getFlowAggregates'
         '400':
           $ref: '#/components/responses/errorBadRequest'
-  /api/v1alpha1/processpairs/{id}/:
+  /api/v1alpha1/processpairs/{id}:
     get:
       tags: ["flow aggregate"]
       operationId: processpairByID
@@ -213,7 +213,7 @@ paths:
           $ref: '#/components/responses/getFlowAggregateByID'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/routerlinks/:
+  /api/v1alpha1/routerlinks:
     get:
       tags: [link]
       operationId: routerlinks
@@ -222,7 +222,7 @@ paths:
           $ref: '#/components/responses/getRouterLinks'
         '400':
           $ref: '#/components/responses/errorBadRequest'
-  /api/v1alpha1/routerlinks/{id}/:
+  /api/v1alpha1/routerlinks/{id}:
     get:
       tags: [link]
       operationId: routerlinkByID
@@ -233,7 +233,7 @@ paths:
           $ref: '#/components/responses/getRouterLinkByID'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/routeraccess/:
+  /api/v1alpha1/routeraccess:
     get:
       tags: [link]
       operationId: routeraccess
@@ -242,7 +242,7 @@ paths:
           $ref: '#/components/responses/getRouterAccess'
         '400':
           $ref: '#/components/responses/errorBadRequest'
-  /api/v1alpha1/routeraccess/{id}/:
+  /api/v1alpha1/routeraccess/{id}:
     get:
       tags: [link]
       operationId: routeraccessByID
@@ -253,7 +253,7 @@ paths:
           $ref: '#/components/responses/getRouterAccessByID'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/links/:
+  /api/v1alpha1/links:
     get:
       tags: [link]
       deprecated: true
@@ -263,7 +263,7 @@ paths:
           $ref: '#/components/responses/getLinks'
         '400':
           $ref: '#/components/responses/errorBadRequest'
-  /api/v1alpha1/links/{id}/:
+  /api/v1alpha1/links/{id}:
     get:
       tags: [link]
       deprecated: true
@@ -275,7 +275,7 @@ paths:
           $ref: '#/components/responses/getLinkByID'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/hosts/:
+  /api/v1alpha1/hosts:
     get:
       tags: [deprecated]
       deprecated: true
@@ -283,7 +283,7 @@ paths:
       responses:
         '410':
           $ref: '#/components/responses/notSupported'
-  /api/v1alpha1/hosts/{id}/:
+  /api/v1alpha1/hosts/{id}:
     get:
       tags: [deprecated]
       deprecated: true
@@ -295,14 +295,14 @@ paths:
           $ref: '#/components/responses/notSupported'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/connections/:
+  /api/v1alpha1/connections:
     get:
       tags: [flows]
       operationId: connections
       responses:
         '200':
           $ref: '#/components/responses/getConnections'
-  /api/v1alpha1/applicationflows/:
+  /api/v1alpha1/applicationflows:
     get:
       tags: [flows]
       operationId: applicationflows
@@ -310,7 +310,7 @@ paths:
         '200':
           $ref: '#/components/responses/getApplicationFlows'
 
-  /api/v1alpha1/sites/{id}/processes/:
+  /api/v1alpha1/sites/{id}/processes:
     get:
       tags: [site, process]
       operationId: processesBySite
@@ -321,7 +321,7 @@ paths:
           $ref: '#/components/responses/getProcesses'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/sites/{id}/routers/:
+  /api/v1alpha1/sites/{id}/routers:
     get:
       tags: [site, router]
       operationId: routersBySite
@@ -332,7 +332,7 @@ paths:
           $ref: '#/components/responses/getRouters'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/sites/{id}/hosts/:
+  /api/v1alpha1/sites/{id}/hosts:
     get:
       tags: [site]
       operationId: hostsBySite
@@ -342,7 +342,7 @@ paths:
       responses:
         '410':
           $ref: '#/components/responses/notSupported'
-  /api/v1alpha1/sites/{id}/links/:
+  /api/v1alpha1/sites/{id}/links:
     get:
       tags: [site]
       operationId: linksBySite
@@ -352,7 +352,7 @@ paths:
       responses:
         '410':
           $ref: '#/components/responses/notSupported'
-  /api/v1alpha1/routers/{id}/links/:
+  /api/v1alpha1/routers/{id}/links:
     get:
       tags: [router]
       operationId: linksByRouter
@@ -362,7 +362,7 @@ paths:
       responses:
         '410':
           $ref: '#/components/responses/notSupported'
-  /api/v1alpha1/addresses/{id}/processes/:
+  /api/v1alpha1/addresses/{id}/processes:
     get:
       tags: [address, process]
       operationId: processesByAddress
@@ -373,7 +373,7 @@ paths:
           $ref: '#/components/responses/getProcesses'
         '400':
           $ref: '#/components/responses/errorBadRequest'
-  /api/v1alpha1/addresses/{id}/processpairs/:
+  /api/v1alpha1/addresses/{id}/processpairs:
     get:
       tags: [address, "flow aggregate"]
       operationId: processPairsByAddress
@@ -384,7 +384,7 @@ paths:
           $ref: '#/components/responses/getFlowAggregates'
         '404':
           $ref: '#/components/responses/errorNotFound'
-  /api/v1alpha1/addresses/{id}/connections/:
+  /api/v1alpha1/addresses/{id}/connections:
     get:
       tags: [address, flows]
       operationId: connectionsByAddress


### PR DESCRIPTION
Previously the network-observer API had opted to include trailing slashes in resource URIs (e.g. `sites/`) and had 301 redirects from `sites` to `sites/`. This change reverses the previous convention. Now the API prefers `sites` over `sites/`, and will redirect from the later to the former.

Closes https://github.com/skupperproject/skupper/issues/1836