### PR TITLE
Change waiting message when  status condition is false

### DIFF
--- a/internal/cmd/skupper/connector/kube/connector_create.go
+++ b/internal/cmd/skupper/connector/kube/connector_create.go
@@ -328,7 +328,7 @@ func (cmd *CmdConnectorCreate) WaitUntil() error {
 	if err != nil && connectorCondition == nil {
 		return fmt.Errorf("Connector %q is not %s yet, check the status for more information\n", cmd.name, cmd.status)
 	} else if err != nil && connectorCondition.Status == metav1.ConditionFalse {
-		return fmt.Errorf("Connector %q is %s with errors, check the status for more information\n", cmd.name, cmd.status)
+		return fmt.Errorf("Connector %q has reached the status %s but its condition is not true yet, check the status for more information\n", cmd.name, cmd.status)
 	}
 
 	fmt.Printf("Connector %q is %s.\n", cmd.name, cmd.status)

--- a/internal/cmd/skupper/connector/kube/connector_create.go
+++ b/internal/cmd/skupper/connector/kube/connector_create.go
@@ -326,9 +326,9 @@ func (cmd *CmdConnectorCreate) WaitUntil() error {
 	})
 
 	if err != nil && connectorCondition == nil {
-		return fmt.Errorf("Connector %q is not %s yet, check the status for more information\n", cmd.name, cmd.status)
+		return fmt.Errorf("Connector %q is not yet %s, check the status for more information\n", cmd.name, cmd.status)
 	} else if err != nil && connectorCondition.Status == metav1.ConditionFalse {
-		return fmt.Errorf("Connector %q has reached the status %s but its condition is not true yet, check the status for more information\n", cmd.name, cmd.status)
+		return fmt.Errorf("Connector %q is not yet %s: %s\n", cmd.name, cmd.status, connectorCondition.Message)
 	}
 
 	fmt.Printf("Connector %q is %s.\n", cmd.name, cmd.status)

--- a/internal/cmd/skupper/connector/kube/connector_update.go
+++ b/internal/cmd/skupper/connector/kube/connector_update.go
@@ -330,9 +330,9 @@ func (cmd *CmdConnectorUpdate) WaitUntil() error {
 	})
 
 	if err != nil && connectorCondition == nil {
-		return fmt.Errorf("Connector %q is not %s yet, check the status for more information\n", cmd.name, cmd.status)
+		return fmt.Errorf("Connector %q is not yet %s, check the status for more information\n", cmd.name, cmd.status)
 	} else if err != nil && connectorCondition.Status == metav1.ConditionFalse {
-		return fmt.Errorf("Connector %q has reached the status %s but its condition is not true yet, check the status for more information\n", cmd.name, cmd.status)
+		return fmt.Errorf("Connector %q is not yet %s: %s\n", cmd.name, cmd.status, connectorCondition.Message)
 	}
 
 	fmt.Printf("Connector %q is %s.\n", cmd.name, cmd.status)

--- a/internal/cmd/skupper/connector/kube/connector_update.go
+++ b/internal/cmd/skupper/connector/kube/connector_update.go
@@ -332,7 +332,7 @@ func (cmd *CmdConnectorUpdate) WaitUntil() error {
 	if err != nil && connectorCondition == nil {
 		return fmt.Errorf("Connector %q is not %s yet, check the status for more information\n", cmd.name, cmd.status)
 	} else if err != nil && connectorCondition.Status == metav1.ConditionFalse {
-		return fmt.Errorf("Connector %q is %s with errors, check the status for more information\n", cmd.name, cmd.status)
+		return fmt.Errorf("Connector %q has reached the status %s but its condition is not true yet, check the status for more information\n", cmd.name, cmd.status)
 	}
 
 	fmt.Printf("Connector %q is %s.\n", cmd.name, cmd.status)

--- a/internal/cmd/skupper/link/kube/link_update.go
+++ b/internal/cmd/skupper/link/kube/link_update.go
@@ -218,7 +218,7 @@ func (cmd *CmdLinkUpdate) WaitUntil() error {
 	if err != nil && linkCondition == nil {
 		return fmt.Errorf("Link %q is not %s yet, check the status for more information\n", cmd.linkName, cmd.status)
 	} else if err != nil && linkCondition.Status == metav1.ConditionFalse {
-		return fmt.Errorf("Link %q is %s with errors, check the status for more information\n", cmd.linkName, cmd.status)
+		return fmt.Errorf("Link %q has reached the status %s but its condition is not true yet, check the status for more information\n", cmd.linkName, cmd.status)
 	}
 
 	fmt.Printf("Link %q is updated\n", cmd.linkName)

--- a/internal/cmd/skupper/link/kube/link_update.go
+++ b/internal/cmd/skupper/link/kube/link_update.go
@@ -216,9 +216,9 @@ func (cmd *CmdLinkUpdate) WaitUntil() error {
 	})
 
 	if err != nil && linkCondition == nil {
-		return fmt.Errorf("Link %q is not %s yet, check the status for more information\n", cmd.linkName, cmd.status)
+		return fmt.Errorf("Link %q is not yet %s, check the status for more information\n", cmd.linkName, cmd.status)
 	} else if err != nil && linkCondition.Status == metav1.ConditionFalse {
-		return fmt.Errorf("Link %q has reached the status %s but its condition is not true yet, check the status for more information\n", cmd.linkName, cmd.status)
+		return fmt.Errorf("Link %q is not yet %s: %s\n", cmd.linkName, cmd.status, linkCondition.Message)
 	}
 
 	fmt.Printf("Link %q is updated\n", cmd.linkName)

--- a/internal/cmd/skupper/listener/kube/listener_create.go
+++ b/internal/cmd/skupper/listener/kube/listener_create.go
@@ -241,7 +241,7 @@ func (cmd *CmdListenerCreate) WaitUntil() error {
 	if err != nil && listenerCondition == nil {
 		return fmt.Errorf("Listener %q is not %s yet, check the status for more information\n", cmd.name, cmd.status)
 	} else if err != nil && listenerCondition.Status == metav1.ConditionFalse {
-		return fmt.Errorf("Listener %q is %s with errors, check the status for more information\n", cmd.name, cmd.status)
+		return fmt.Errorf("Listener %q has reached the status %s but its condition is not true yet, check the status for more information\n", cmd.name, cmd.status)
 	}
 
 	fmt.Printf("Listener %q is %s.\n", cmd.name, cmd.status)

--- a/internal/cmd/skupper/listener/kube/listener_create.go
+++ b/internal/cmd/skupper/listener/kube/listener_create.go
@@ -239,9 +239,9 @@ func (cmd *CmdListenerCreate) WaitUntil() error {
 	})
 
 	if err != nil && listenerCondition == nil {
-		return fmt.Errorf("Listener %q is not %s yet, check the status for more information\n", cmd.name, cmd.status)
+		return fmt.Errorf("Listener %q is not yet %s, check the status for more information\n", cmd.name, cmd.status)
 	} else if err != nil && listenerCondition.Status == metav1.ConditionFalse {
-		return fmt.Errorf("Listener %q has reached the status %s but its condition is not true yet, check the status for more information\n", cmd.name, cmd.status)
+		return fmt.Errorf("Listener %q is not yet %s: %s\n", cmd.name, cmd.status, listenerCondition.Message)
 	}
 
 	fmt.Printf("Listener %q is %s.\n", cmd.name, cmd.status)

--- a/internal/cmd/skupper/listener/kube/listener_update.go
+++ b/internal/cmd/skupper/listener/kube/listener_update.go
@@ -232,9 +232,9 @@ func (cmd *CmdListenerUpdate) WaitUntil() error {
 	})
 
 	if err != nil && listenerCondition == nil {
-		return fmt.Errorf("Listener %q is not %s yet, check the status for more information\n", cmd.name, cmd.status)
+		return fmt.Errorf("Listener %q is not yet %s, check the status for more information\n", cmd.name, cmd.status)
 	} else if err != nil && listenerCondition.Status == metav1.ConditionFalse {
-		return fmt.Errorf("Listener %q has reached the status %s but its condition is not true yet, check the status for more information\n", cmd.name, cmd.status)
+		return fmt.Errorf("Listener %q is not yet %s: %s\n", cmd.name, cmd.status, listenerCondition.Message)
 	}
 
 	fmt.Printf("Listener %q is updated\n", cmd.name)

--- a/internal/cmd/skupper/listener/kube/listener_update.go
+++ b/internal/cmd/skupper/listener/kube/listener_update.go
@@ -234,7 +234,7 @@ func (cmd *CmdListenerUpdate) WaitUntil() error {
 	if err != nil && listenerCondition == nil {
 		return fmt.Errorf("Listener %q is not %s yet, check the status for more information\n", cmd.name, cmd.status)
 	} else if err != nil && listenerCondition.Status == metav1.ConditionFalse {
-		return fmt.Errorf("Listener %q is %s with errors, check the status for more information\n", cmd.name, cmd.status)
+		return fmt.Errorf("Listener %q has reached the status %s but its condition is not true yet, check the status for more information\n", cmd.name, cmd.status)
 	}
 
 	fmt.Printf("Listener %q is updated\n", cmd.name)

--- a/internal/cmd/skupper/listener/kube/listener_update_test.go
+++ b/internal/cmd/skupper/listener/kube/listener_update_test.go
@@ -460,13 +460,13 @@ func TestCmdListenerUpdate_WaitUntil(t *testing.T) {
 				},
 			},
 			expectError:  true,
-			errorMessage: "Listener \"my-listener\" is not ready yet, check the status for more information\n",
+			errorMessage: "Listener \"my-listener\" is not yet ready, check the status for more information\n",
 		},
 		{
 			name:         "listener is not returned",
 			status:       "ready",
 			expectError:  true,
-			errorMessage: "Listener \"my-listener\" is not ready yet, check the status for more information\n",
+			errorMessage: "Listener \"my-listener\" is not yet ready, check the status for more information\n",
 		},
 		{
 			name:   "listener is ready",
@@ -588,7 +588,7 @@ func TestCmdListenerUpdate_WaitUntil(t *testing.T) {
 				},
 			},
 			expectError:  true,
-			errorMessage: "Listener \"my-listener\" is configured with errors, check the status for more information\n",
+			errorMessage: "Listener \"my-listener\" is not yet configured: Error\n",
 		},
 	}
 

--- a/internal/cmd/skupper/site/kube/site_create.go
+++ b/internal/cmd/skupper/site/kube/site_create.go
@@ -227,7 +227,7 @@ func (cmd *CmdSiteCreate) WaitUntil() error {
 	if err != nil && siteCondition == nil {
 		return fmt.Errorf("Site %q is not %s yet, check the status for more information\n", cmd.siteName, cmd.status)
 	} else if err != nil && siteCondition.Status == metav1.ConditionFalse {
-		return fmt.Errorf("Site %q is %s with errors, check the status for more information\n", cmd.siteName, cmd.status)
+		return fmt.Errorf("Site %q has reached the status %s but its condition is not true yet, check the status for more information\n", cmd.siteName, cmd.status)
 	}
 
 	fmt.Printf("Site %q is %s.\n", cmd.siteName, cmd.status)

--- a/internal/cmd/skupper/site/kube/site_create.go
+++ b/internal/cmd/skupper/site/kube/site_create.go
@@ -225,9 +225,9 @@ func (cmd *CmdSiteCreate) WaitUntil() error {
 	})
 
 	if err != nil && siteCondition == nil {
-		return fmt.Errorf("Site %q is not %s yet, check the status for more information\n", cmd.siteName, cmd.status)
+		return fmt.Errorf("Site %q is not yet %s, check the status for more information\n", cmd.siteName, cmd.status)
 	} else if err != nil && siteCondition.Status == metav1.ConditionFalse {
-		return fmt.Errorf("Site %q has reached the status %s but its condition is not true yet, check the status for more information\n", cmd.siteName, cmd.status)
+		return fmt.Errorf("Site %q is not yet %s: %s\n", cmd.siteName, cmd.status, siteCondition.Message)
 	}
 
 	fmt.Printf("Site %q is %s.\n", cmd.siteName, cmd.status)

--- a/internal/cmd/skupper/site/kube/site_update.go
+++ b/internal/cmd/skupper/site/kube/site_update.go
@@ -246,7 +246,7 @@ func (cmd *CmdSiteUpdate) WaitUntil() error {
 	if err != nil && siteCondition == nil {
 		return fmt.Errorf("Site %q is not %s yet, check the status for more information\n", cmd.siteName, cmd.status)
 	} else if err != nil && siteCondition.Status == metav1.ConditionFalse {
-		return fmt.Errorf("Site %q is %s with errors, check the status for more information\n", cmd.siteName, cmd.status)
+		return fmt.Errorf("Site %q has reached the status %s but its condition is not true yet, check the status for more information\n", cmd.siteName, cmd.status)
 	}
 
 	fmt.Printf("Site %q is updated\n", cmd.siteName)

--- a/internal/cmd/skupper/site/kube/site_update.go
+++ b/internal/cmd/skupper/site/kube/site_update.go
@@ -244,9 +244,9 @@ func (cmd *CmdSiteUpdate) WaitUntil() error {
 	})
 
 	if err != nil && siteCondition == nil {
-		return fmt.Errorf("Site %q is not %s yet, check the status for more information\n", cmd.siteName, cmd.status)
+		return fmt.Errorf("Site %q is not yet %s, check the status for more information\n", cmd.siteName, cmd.status)
 	} else if err != nil && siteCondition.Status == metav1.ConditionFalse {
-		return fmt.Errorf("Site %q has reached the status %s but its condition is not true yet, check the status for more information\n", cmd.siteName, cmd.status)
+		return fmt.Errorf("Site %q is not yet %s: %s\n", cmd.siteName, cmd.status, siteCondition.Message)
 	}
 
 	fmt.Printf("Site %q is updated\n", cmd.siteName)

--- a/internal/cmd/skupper/site/kube/site_update_test.go
+++ b/internal/cmd/skupper/site/kube/site_update_test.go
@@ -574,7 +574,7 @@ func TestCmdSiteUpdate_WaitUntil(t *testing.T) {
 			},
 			siteName:     "my-site",
 			skupperError: "",
-			errorMessage: "Site \"my-site\" is not ready yet, check the status for more information\n",
+			errorMessage: "Site \"my-site\" is not yet ready, check the status for more information\n",
 			expectError:  true,
 		},
 		{
@@ -662,7 +662,7 @@ func TestCmdSiteUpdate_WaitUntil(t *testing.T) {
 			siteName:     "my-site",
 			skupperError: "",
 			expectError:  true,
-			errorMessage: "Site \"my-site\" is configured with errors, check the status for more information\n",
+			errorMessage: "Site \"my-site\" is not yet configured: Error\n",
 		},
 	}
 


### PR DESCRIPTION
With a timeout of 30 seconds by default, sometimes the waiting status by default (ready) is reached but the condition is not true at the moment. After checking the status, the site is ready without any type of error, so with this PR the wait status message will change for one that is less alarming to the user and more accurate.