### PR TITLE
Minor fixes: site create and site delete --all

### DIFF
--- a/internal/cmd/skupper/site/kube/site_create.go
+++ b/internal/cmd/skupper/site/kube/site_create.go
@@ -65,10 +65,6 @@ func (cmd *CmdSiteCreate) ValidateInput(args []string) []error {
 		validationErrors = append(validationErrors, fmt.Errorf("there is already a site created for this namespace"))
 	}
 
-	if cmd.Flags != nil && cmd.Flags.BindHost != "" {
-		fmt.Println("Warning: --bind-host flag is not supported on this platform")
-	}
-
 	if cmd.Flags != nil && cmd.Flags.SubjectAlternativeNames != nil && len(cmd.Flags.SubjectAlternativeNames) > 0 {
 		fmt.Println("Warning: --subject-alternative-names flag is not supported on this platform")
 	}

--- a/internal/cmd/skupper/site/kube/site_delete.go
+++ b/internal/cmd/skupper/site/kube/site_delete.go
@@ -121,15 +121,7 @@ func (cmd *CmdSiteDelete) Run() error {
 			}
 		}
 
-		links, err := cmd.Client.Links(cmd.Namespace).List(context.TODO(), metav1.ListOptions{})
-		if err == nil && links != nil && len(links.Items) != 0 {
-			for _, link := range links.Items {
-				err = cmd.Client.Links(cmd.Namespace).Delete(context.TODO(), link.Name, metav1.DeleteOptions{})
-				if err != nil {
-					return err
-				}
-			}
-		}
+		//Links are removed after the removal of the site by the controller
 
 		accessTokens, err := cmd.Client.AccessTokens(cmd.Namespace).List(context.TODO(), metav1.ListOptions{})
 		if err == nil && accessTokens != nil && len(accessTokens.Items) != 0 {

--- a/internal/cmd/skupper/site/kube/site_delete_test.go
+++ b/internal/cmd/skupper/site/kube/site_delete_test.go
@@ -397,12 +397,6 @@ func TestCmdSiteDelete_Run(t *testing.T) {
 						Namespace: "test",
 					},
 				},
-				&v2alpha1.Link{
-					ObjectMeta: v1.ObjectMeta{
-						Name:      "my-link",
-						Namespace: "test",
-					},
-				},
 				&v2alpha1.AttachedConnectorBinding{
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "my-attachedConnectorBinding",


### PR DESCRIPTION
site create:
 - Remove bindhost check given that has default value, the kube implementation ignores it.

site delete --all:
- After deleting a site  with --all, the removal of the link was failing because the controller already removes the link resources when a site is deleted, so the CLI will not remove explicitly the links.