### PR TITLE
Fixes AMQP Credits handling in vanflow/session

### DIFF
--- a/pkg/vanflow/session/container.go
+++ b/pkg/vanflow/session/container.go
@@ -22,7 +22,7 @@ type ReceiverOptions struct {
 
 func (o ReceiverOptions) get() amqp.ReceiverOptions {
 	var result amqp.ReceiverOptions
-	if o.Credit <= 0 {
+	if o.Credit > 0 {
 		result.Credit = int32(o.Credit)
 	}
 	return result


### PR DESCRIPTION
Sets the configured credits on the vanflow receiver. Before it was mistakenly only setting credits when they were negative instead of when positive.