### PR TITLE
Minor fixes: update CRDs script and renaming kube-adaptor's environment variable

### DIFF
--- a/pkg/images/image_utils.go
+++ b/pkg/images/image_utils.go
@@ -18,13 +18,13 @@ type SkupperImage struct {
 const (
 	RouterImageEnvKey             string = "SKUPPER_ROUTER_IMAGE"
 	ControllerImageEnvKey         string = "SKUPPER_CONTROLLER_IMAGE"
-	AdaptorImageEnvKey            string = "SKUPPER_ADAPTOR_IMAGE"
+	KubeAdaptorImageEnvKey        string = "SKUPPER_KUBE_ADAPTOR_IMAGE"
 	NetworkObserverImageEnvKey    string = "SKUPPER_NETWORK_OBSERVER_IMAGE"
 	CliImageEnvKey                string = "SKUPPER_CLI_IMAGE"
 	PrometheusServerImageEnvKey   string = "PROMETHEUS_SERVER_IMAGE"
 	OauthProxyImageEnvKey         string = "OAUTH_PROXY_IMAGE"
 	RouterPullPolicyEnvKey        string = "SKUPPER_ROUTER_IMAGE_PULL_POLICY"
-	AdaptorPullPolicyEnvKey       string = "SKUPPER_ADAPTOR_IMAGE_PULL_POLICY"
+	KubeAdaptorPullPolicyEnvKey   string = "SKUPPER_KUBE_ADAPTOR_IMAGE_PULL_POLICY"
 	OauthProxyPullPolicyEnvKey    string = "OAUTH_PROXY_IMAGE_PULL_POLICY"
 	SkupperImageRegistryEnvKey    string = "SKUPPER_IMAGE_REGISTRY"
 	PrometheusImageRegistryEnvKey string = "PROMETHEUS_IMAGE_REGISTRY"
@@ -104,25 +104,25 @@ func GetCliImageName() string {
 	}
 }
 
-func GetAdaptorImageDetails() types.ImageDetails {
+func GetKubeAdaptorImageDetails() types.ImageDetails {
 	return types.ImageDetails{
-		Name:       GetAdaptorImageName(),
-		PullPolicy: GetAdaptorImagePullPolicy(),
+		Name:       GetKubeAdaptorImageName(),
+		PullPolicy: GetKubeAdaptorImagePullPolicy(),
 	}
 }
 
-func GetAdaptorImageName() string {
-	image := os.Getenv(AdaptorImageEnvKey)
+func GetKubeAdaptorImageName() string {
+	image := os.Getenv(KubeAdaptorImageEnvKey)
 	if image == "" {
 		imageRegistry := GetImageRegistry()
-		return strings.Join([]string{imageRegistry, AdaptorImageName}, "/")
+		return strings.Join([]string{imageRegistry, KubeAdaptorImageName}, "/")
 	} else {
 		return image
 	}
 }
 
-func GetAdaptorImagePullPolicy() string {
-	return getPullPolicy(AdaptorPullPolicyEnvKey)
+func GetKubeAdaptorImagePullPolicy() string {
+	return getPullPolicy(KubeAdaptorPullPolicyEnvKey)
 }
 
 func GetPrometheusServerImageName() string {
@@ -242,11 +242,11 @@ func GetImages(component string, enableSHA bool) []SkupperImage {
 			registry = GetImageRegistry()
 		}
 
-		envImage = os.Getenv(AdaptorImageEnvKey)
+		envImage = os.Getenv(KubeAdaptorImageEnvKey)
 		if envImage != "" {
-			names[AdaptorImageEnvKey] = envImage
+			names[KubeAdaptorImageEnvKey] = envImage
 		} else {
-			names[AdaptorImageEnvKey] = AdaptorImageName
+			names[KubeAdaptorImageEnvKey] = KubeAdaptorImageName
 			registry = GetImageRegistry()
 		}
 	case "controller":

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -4,7 +4,7 @@ const (
 	DefaultImageRegistry     string = "quay.io/skupper"
 	RouterImageName          string = "skupper-router:main"
 	ControllerImageName      string = "controller:v2-latest"
-	AdaptorImageName         string = "kube-adaptor:v2-latest"
+	KubeAdaptorImageName     string = "kube-adaptor:v2-latest"
 	NetworkObserverImageName string = "network-observer:v2-latest"
 	CliImageName             string = "cli:v2-latest"
 

--- a/pkg/kube/site/resources/apply.go
+++ b/pkg/kube/site/resources/apply.go
@@ -88,7 +88,7 @@ func getCoreParams(site *skupperv2alpha1.Site, group string) CoreParams {
 		ServiceAccount: site.Spec.GetServiceAccount(),
 		ConfigDigest:   configDigest(&site.Spec),
 		RouterImage:    images.GetRouterImageDetails(),
-		AdaptorImage:   images.GetAdaptorImageDetails(),
+		AdaptorImage:   images.GetKubeAdaptorImageDetails(),
 	}
 }
 

--- a/pkg/utils/configs/manifest.go
+++ b/pkg/utils/configs/manifest.go
@@ -105,9 +105,9 @@ func getEnvironmentVariableMap() *map[string]string {
 		envVariables[images.ControllerImageEnvKey] = controllerImage
 	}
 
-	adaptorImage := os.Getenv(images.AdaptorImageEnvKey)
+	adaptorImage := os.Getenv(images.KubeAdaptorImageEnvKey)
 	if adaptorImage != "" {
-		envVariables[images.AdaptorImageEnvKey] = adaptorImage
+		envVariables[images.KubeAdaptorImageEnvKey] = adaptorImage
 	}
 
 	networkObserverImage := os.Getenv(images.NetworkObserverImageEnvKey)
@@ -141,7 +141,7 @@ func GetRunningImages(component string, enableSHA bool, runningPods map[string]s
 	case "router":
 		// skupper router has two components
 		names[images.RouterImageEnvKey] = runningPods["router"]
-		names[images.AdaptorImageEnvKey] = runningPods["kube-adaptor"]
+		names[images.KubeAdaptorImageEnvKey] = runningPods["kube-adaptor"]
 
 	case "controller":
 		names[images.ControllerImageEnvKey] = runningPods["controller"]

--- a/pkg/utils/configs/manifest_test.go
+++ b/pkg/utils/configs/manifest_test.go
@@ -25,7 +25,7 @@ func TestManifestManager(t *testing.T) {
 			title: "configured manifest has different images that the default manifest",
 			envVariablesWithValue: []string{
 				images.SkupperImageRegistryEnvKey,
-				images.AdaptorImageEnvKey,
+				images.KubeAdaptorImageEnvKey,
 				images.RouterImageEnvKey,
 				images.ControllerImageEnvKey,
 			},
@@ -37,7 +37,7 @@ func TestManifestManager(t *testing.T) {
 							Version:   "main",
 							Images: []images.SkupperImage{
 								{
-									Name: "SKUPPER_ADAPTOR_IMAGE_TESTING",
+									Name: "SKUPPER_KUBE_ADAPTOR_IMAGE_TESTING",
 								},
 								{
 									Name: "SKUPPER_ROUTER_IMAGE_TESTING",
@@ -64,7 +64,7 @@ func TestManifestManager(t *testing.T) {
 							Version:   "",
 							Images: []images.SkupperImage{
 								{
-									Name: strings.Join([]string{images.DefaultImageRegistry, images.AdaptorImageName}, "/"),
+									Name: strings.Join([]string{images.DefaultImageRegistry, images.KubeAdaptorImageName}, "/"),
 								},
 								{
 									Name: strings.Join([]string{images.DefaultImageRegistry, images.RouterImageName}, "/"),
@@ -75,7 +75,7 @@ func TestManifestManager(t *testing.T) {
 				},
 				Variables: &map[string]string{
 					images.SkupperImageRegistryEnvKey: "SKUPPER_IMAGE_REGISTRY_TESTING",
-					images.AdaptorImageEnvKey:         "SKUPPER_ADAPTOR_IMAGE_TESTING",
+					images.KubeAdaptorImageEnvKey:     "SKUPPER_KUBE_ADAPTOR_IMAGE_TESTING",
 					images.RouterImageEnvKey:          "SKUPPER_ROUTER_IMAGE_TESTING",
 					images.ControllerImageEnvKey:      "SKUPPER_CONTROLLER_IMAGE_TESTING",
 				},
@@ -92,7 +92,7 @@ func TestManifestManager(t *testing.T) {
 							Version:   "main",
 							Images: []images.SkupperImage{
 								{
-									Name: strings.Join([]string{images.DefaultImageRegistry, images.AdaptorImageName}, "/"),
+									Name: strings.Join([]string{images.DefaultImageRegistry, images.KubeAdaptorImageName}, "/"),
 								},
 								{
 									Name: strings.Join([]string{images.DefaultImageRegistry, images.RouterImageName}, "/"),
@@ -110,7 +110,7 @@ func TestManifestManager(t *testing.T) {
 							Version:   "main",
 							Images: []images.SkupperImage{
 								{
-									Name: strings.Join([]string{images.DefaultImageRegistry, images.AdaptorImageName}, "/"),
+									Name: strings.Join([]string{images.DefaultImageRegistry, images.KubeAdaptorImageName}, "/"),
 								},
 								{
 									Name: strings.Join([]string{images.DefaultImageRegistry, images.RouterImageName}, "/"),

--- a/scripts/update-helm-crds.sh
+++ b/scripts/update-helm-crds.sh
@@ -4,7 +4,7 @@
 SOURCE_DIR="./api/types/crds"
 
 # Destination directory
-DEST_DIR="./deployments/helm/crds"
+DEST_DIR="./charts/skupper-setup/crds"
 
 # Check if source directory exists
 if [ ! -d "$SOURCE_DIR" ]; then


### PR DESCRIPTION
* Modified `update-helm-crds` script to point to the correct directory.
* Renamed kube-adaptor's environment variable to `SKUPPER_KUBE_ADAPTOR_IMAGE`.