### PR TITLE
Cache the configured platform

### DIFF
--- a/internal/cmd/skupper/system/nonkube/system_reload_test.go
+++ b/internal/cmd/skupper/system/nonkube/system_reload_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common/testutils"
+	"github.com/skupperproject/skupper/internal/config"
 	"github.com/skupperproject/skupper/internal/nonkube/bootstrap"
 	"github.com/skupperproject/skupper/pkg/nonkube/api"
 	"gotest.tools/v3/assert"
@@ -68,6 +69,7 @@ func TestCmdSystemReload_InputToOptions(t *testing.T) {
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
 			os.Setenv(types.ENV_PLATFORM, test.platform)
+			config.ClearPlatform()
 
 			cmd := newCmdSystemReloadWithMocks(false, false)
 			cmd.Namespace = test.namespace

--- a/internal/cmd/skupper/system/nonkube/system_setup_test.go
+++ b/internal/cmd/skupper/system/nonkube/system_setup_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common/testutils"
+	"github.com/skupperproject/skupper/internal/config"
 	"github.com/skupperproject/skupper/internal/nonkube/bootstrap"
 	"github.com/skupperproject/skupper/pkg/nonkube/api"
 	"gotest.tools/v3/assert"
@@ -111,6 +112,7 @@ func TestCmdSystemSetup_InputToOptions(t *testing.T) {
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
 			os.Setenv(types.ENV_PLATFORM, test.platform)
+			config.ClearPlatform()
 
 			cmd := newCmdSystemSetupWithMocks(false, false)
 			cmd.Flags = &test.flags

--- a/internal/config/platform.go
+++ b/internal/config/platform.go
@@ -7,11 +7,17 @@ import (
 
 	"github.com/skupperproject/skupper/api/types"
 	"github.com/skupperproject/skupper/internal/utils"
+	"k8s.io/utils/ptr"
 )
 
 var (
-	Platform string
+	Platform           string
+	configuredPlatform *types.Platform
 )
+
+func ClearPlatform() {
+	configuredPlatform = nil
+}
 
 // GetPlatform returns the runtime platform defined,
 // where the lookup goes through the following sequence:
@@ -22,6 +28,10 @@ var (
 // In case the defined platform is invalid, "kubernetes"
 // will be returned.
 func GetPlatform() types.Platform {
+	if configuredPlatform != nil {
+		return *configuredPlatform
+	}
+
 	var platform types.Platform
 	for i, arg := range os.Args {
 		if slices.Contains([]string{"--platform", "-p"}, arg) && i+1 < len(os.Args) {
@@ -41,12 +51,13 @@ func GetPlatform() types.Platform {
 	}
 	switch platform {
 	case types.PlatformPodman:
-		return types.PlatformPodman
+		configuredPlatform = &platform
 	case types.PlatformDocker:
-		return types.PlatformDocker
+		configuredPlatform = &platform
 	case types.PlatformLinux:
-		return types.PlatformLinux
+		configuredPlatform = &platform
 	default:
-		return types.PlatformKubernetes
+		configuredPlatform = ptr.To(types.PlatformKubernetes)
 	}
+	return *configuredPlatform
 }

--- a/pkg/nonkube/api/environment_test.go
+++ b/pkg/nonkube/api/environment_test.go
@@ -150,6 +150,7 @@ func TestGetPlatform(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config.Platform = tt.cliVar
 			t.Setenv(types.ENV_PLATFORM, tt.envVar)
+			config.ClearPlatform()
 			got := config.GetPlatform()
 			if got != tt.want {
 				t.Errorf("GetPlatform() = %v, want %v", got, tt.want)


### PR DESCRIPTION
This avoids attempting to read the configuration file etc. dozens of times during startup.

In tests which change the configured platform, the cached value is cleared.