### PR TITLE
Fix refdog reference and include artifacts for v2-prerelease

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,14 +153,20 @@ workflows:
           context:
             - skupper-org
       - generate-manifest:
+          <<: *run_for_v2_branch
           requires:
             - publish-oci-images
+      - generate-skupper-setup:
+          <<: *run_for_v2_branch
+          requires:
+            - generate-manifest
       - publish-github-prerelease-artifacts:
           <<: *run_for_v2_branch
           version: v2-dev-release
           requires:
             - publish-oci-images
             - generate-manifest
+            - generate-skupper-setup
           context:
             - skupper-org
 
@@ -399,4 +405,5 @@ jobs:
             done
             cd ${BASEDIR}
             cp "${BASEDIR}/skupper-manifest/manifest.json" "${BASEDIR}/archives"
+            cp skupper-setup/*.yaml archives
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace -prerelease ${VERSION} "${BASEDIR}/archives"

--- a/internal/cmd/skupper/root/root.go
+++ b/internal/cmd/skupper/root/root.go
@@ -23,7 +23,7 @@ var rootCmd = &cobra.Command{
 	Use:   "skupper",
 	Short: "Skupper is a tool for secure, cross-cluster Kubernetes communication",
 	Long: `Skupper is an open-source tool that enables secure communication across clusters with no VPNs or special firewall rules.
-For more information visit https://skupperproject.github.io/refdog/index.html`,
+For more information visit https://skupperproject.github.io/refdog/`,
 }
 
 func NewSkupperRootCommand() *cobra.Command {


### PR DESCRIPTION
- Updated Refdog link in the skupper command
- Added skupper setup yaml files as artifacts of the v2 prerelease