### PR TITLE
Fix Unspecified Vanflow SITE Attributes

### DIFF
--- a/pkg/kube/flow/status.go
+++ b/pkg/kube/flow/status.go
@@ -514,7 +514,6 @@ func asSiteInfo(site vanflow.SiteRecord) network.SiteInfo {
 		Namespace: dref(site.Namespace),
 		Platform:  dref(site.Platform),
 		Version:   dref(site.Version),
-		Policy:    dref(site.Policy),
 	}
 }
 

--- a/pkg/vanflow/records.go
+++ b/pkg/vanflow/records.go
@@ -32,8 +32,7 @@ type SiteRecord struct {
 	Platform  *string `vflow:"11"`
 	Namespace *string `vflow:"12"`
 	Name      *string `vflow:"30"` //unspeced
-	Version   *string `vflow:"52"`
-	Policy    *string `vflow:"53"`
+	Version   *string `vflow:"32"`
 }
 
 func (r SiteRecord) GetTypeMeta() TypeMeta {


### PR DESCRIPTION
Previously the vanflow SITE record was using an unspecified attributes to denote the site version and policy status. This breaking change moves the SITE Version attribute to the specified buildVersion attribute (code point 32) in the spec and removes the now-deprecated Policy attribute. Versions running the old unspecified version attribute (2.0.0-previews 1 and 2) will not observe the site version from sites with the corrected attribute and vice versa. The Policy attribute has been unused since 1.x.