### PR TITLE
Add Site Version to nonkube router configuration

### DIFF
--- a/pkg/nonkube/api/site_state.go
+++ b/pkg/nonkube/api/site_state.go
@@ -273,6 +273,7 @@ func (s *SiteState) ToRouterConfig(sslProfileBasePath string, platform string) q
 		Name:      routerName,
 		Namespace: s.GetNamespace(),
 		Platform:  platform,
+		Version:   version.Version,
 	}
 
 	// override metadata

--- a/pkg/qdr/qdr.go
+++ b/pkg/qdr/qdr.go
@@ -462,6 +462,7 @@ type SiteConfig struct {
 	Provider  string `json:"provider,omitempty"`
 	Platform  string `json:"platform,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
+	Version   string `json:"version,omitempty"`
 }
 
 func convert(from interface{}, to interface{}) error {


### PR DESCRIPTION
Adds a version field to the skupper router's site configuration.