### PR TITLE
Rename miscelanious networkobserver api fields

### DIFF
--- a/cmd/network-observer/internal/api/types_gen.go
+++ b/cmd/network-observer/internal/api/types_gen.go
@@ -73,8 +73,8 @@ type ApplicationFlowRecord struct {
 	// Identity The unique identifier for the record.
 	Identity          string `json:"identity"`
 	Method            string `json:"method"`
-	Octets            uint64 `json:"octets"`
-	OctetsReverse     uint64 `json:"octetsReverse"`
+	OctetCount        uint64 `json:"octetCount"`
+	OctetReverseCount uint64 `json:"octetReverseCount"`
 	Protocol          string `json:"protocol"`
 	RoutingKey        string `json:"routingKey"`
 	SourceProcessId   string `json:"sourceProcessId"`
@@ -165,8 +165,8 @@ type ConnectionRecord struct {
 	LatencyReverse    uint64  `json:"latencyReverse"`
 	ListenerError     *string `json:"listenerError"`
 	ListenerId        string  `json:"listenerId"`
-	Octets            uint64  `json:"octets"`
-	OctetsReverse     uint64  `json:"octetsReverse"`
+	OctetCount        uint64  `json:"octetCount"`
+	OctetReverseCount uint64  `json:"octetReverseCount"`
 	ProcessPairId     *string `json:"processPairId"`
 	Protocol          string  `json:"protocol"`
 	ProxyHost         string  `json:"proxyHost"`
@@ -323,6 +323,9 @@ type ProcessListResponse struct {
 
 // ProcessRecord defines model for ProcessRecord.
 type ProcessRecord struct {
+	// Binding Indicates whether a process is exposed or not in a skupper network
+	Binding ProcessBindingType `json:"binding"`
+
 	// ComponentId Id of the component associated to the process. this is a parent of the process
 	ComponentId   string `json:"componentId"`
 	ComponentName string `json:"componentName"`
@@ -341,9 +344,6 @@ type ProcessRecord struct {
 	// Parent Id of the site associated to the process. this is a parent of the process
 	Parent     string `json:"parent"`
 	ParentName string `json:"parentName"`
-
-	// ProcessBinding Indicates whether a process is exposed or not in a skupper network
-	ProcessBinding ProcessBindingType `json:"processBinding"`
 
 	// Role Internal processes are processes related to Skupper. Remote processes are processes indirectly connected, such as a proxy
 	Role     ProcessRecordRole        `json:"role"`
@@ -426,10 +426,10 @@ type RouterLinkRecord struct {
 	EndTime uint64 `json:"endTime"`
 
 	// Identity The unique identifier for the record.
-	Identity      string `json:"identity"`
-	Name          string `json:"name"`
-	Octets        uint64 `json:"octets"`
-	OctetsReverse uint64 `json:"octetsReverse"`
+	Identity          string `json:"identity"`
+	Name              string `json:"name"`
+	OctetCount        uint64 `json:"octetCount"`
+	OctetReverseCount uint64 `json:"octetReverseCount"`
 
 	// Role The class of skupper link
 	Role LinkRoleType `json:"role"`
@@ -546,7 +546,7 @@ type SiteRecord struct {
 	// Identity The unique identifier for the record.
 	Identity  string  `json:"identity"`
 	Name      string  `json:"name"`
-	NameSpace *string `json:"nameSpace"`
+	Namespace *string `json:"namespace"`
 
 	// Platform The platform used for the site.
 	Platform SitePlatformType `json:"platform"`
@@ -555,11 +555,11 @@ type SiteRecord struct {
 	Provider    string `json:"provider"`
 	RouterCount int    `json:"routerCount"`
 
-	// SiteVersion The current skupper version installed. Can be any string or 'unknown'
-	SiteVersion string `json:"siteVersion"`
-
 	// StartTime The creation time in microseconds of the record in Unix timestamp format. The value 0 means that the record is not terminated
 	StartTime uint64 `json:"startTime"`
+
+	// Version The current skupper version installed. Can be any string or 'unknown'
+	Version string `json:"version"`
 }
 
 // SiteResponse defines model for SiteResponse.

--- a/cmd/network-observer/internal/server/connections_test.go
+++ b/cmd/network-observer/internal/server/connections_test.go
@@ -85,7 +85,7 @@ func TestConnections(t *testing.T) {
 					DestSiteId:        "site-b",
 					Protocol:          "tcp",
 
-					Octets:       33,
+					OctetCount:   33,
 					TraceRouters: []string{"router a.1", "router b.1", "router b.2"},
 					TraceSites:   []string{"site a", "site b"},
 				})

--- a/cmd/network-observer/internal/server/process_test.go
+++ b/cmd/network-observer/internal/server/process_test.go
@@ -50,15 +50,15 @@ func TestProcesses(t *testing.T) {
 			ExpectResults: func(t *testing.T, results []api.ProcessRecord) {
 				r := results[0]
 				assert.DeepEqual(t, r, api.ProcessRecord{
-					Identity:       "1",
-					Parent:         "s1",
-					ParentName:     "unknown",
-					ComponentName:  "unknown",
-					ComponentId:    "unknown",
-					ProcessBinding: api.Unbound,
-					Name:           "unknown",
-					Role:           api.External,
-					SourceHost:     "unknown",
+					Identity:      "1",
+					Parent:        "s1",
+					ParentName:    "unknown",
+					ComponentName: "unknown",
+					ComponentId:   "unknown",
+					Binding:       api.Unbound,
+					Name:          "unknown",
+					Role:          api.External,
+					SourceHost:    "unknown",
 				})
 			},
 		}, {
@@ -68,16 +68,16 @@ func TestProcesses(t *testing.T) {
 			ExpectResults: func(t *testing.T, results []api.ProcessRecord) {
 				r := results[0]
 				assert.DeepEqual(t, r, api.ProcessRecord{
-					Identity:       "1",
-					Parent:         "site-1",
-					ParentName:     "site one",
-					Services:       ptrTo([]api.AtmarkDelimitedString{api.AtmarkDelimitedString("icecream@icecream-addr-id@tcp"), api.AtmarkDelimitedString("pizza@pizza-addr-id@tcp")}),
-					ComponentName:  "group-one",
-					ComponentId:    "group-1-id",
-					ProcessBinding: api.Unbound,
-					Name:           "processone",
-					Role:           api.Internal,
-					SourceHost:     "10.99.99.2",
+					Identity:      "1",
+					Parent:        "site-1",
+					ParentName:    "site one",
+					Services:      ptrTo([]api.AtmarkDelimitedString{api.AtmarkDelimitedString("icecream@icecream-addr-id@tcp"), api.AtmarkDelimitedString("pizza@pizza-addr-id@tcp")}),
+					ComponentName: "group-one",
+					ComponentId:   "group-1-id",
+					Binding:       api.Unbound,
+					Name:          "processone",
+					Role:          api.Internal,
+					SourceHost:    "10.99.99.2",
 				})
 			},
 		}, {
@@ -93,16 +93,16 @@ func TestProcesses(t *testing.T) {
 			ExpectResults: func(t *testing.T, results []api.ProcessRecord) {
 				r := results[0]
 				assert.DeepEqual(t, r, api.ProcessRecord{
-					Identity:       "1",
-					Parent:         "site-1",
-					ParentName:     "site one",
-					Services:       ptrTo([]api.AtmarkDelimitedString{api.AtmarkDelimitedString("icecream@icecream-addr-id@tcp"), api.AtmarkDelimitedString("pizza@pizza-addr-id@tcp")}),
-					ComponentName:  "group-one",
-					ComponentId:    "group-1-id",
-					ProcessBinding: api.Bound,
-					Name:           "processone",
-					Role:           api.Internal,
-					SourceHost:     "10.99.99.2",
+					Identity:      "1",
+					Parent:        "site-1",
+					ParentName:    "site one",
+					Services:      ptrTo([]api.AtmarkDelimitedString{api.AtmarkDelimitedString("icecream@icecream-addr-id@tcp"), api.AtmarkDelimitedString("pizza@pizza-addr-id@tcp")}),
+					ComponentName: "group-one",
+					ComponentId:   "group-1-id",
+					Binding:       api.Bound,
+					Name:          "processone",
+					Role:          api.Internal,
+					SourceHost:    "10.99.99.2",
 				})
 			},
 		}, {
@@ -117,7 +117,7 @@ func TestProcesses(t *testing.T) {
 			ExpectOK:    true,
 			ExpectCount: 2,
 			Parameters: map[string][]string{
-				"sortBy": {"processBinding.asc"},
+				"sortBy": {"binding.asc"},
 			},
 			ExpectResults: func(t *testing.T, results []api.ProcessRecord) {
 				assert.Equal(t, results[0].Identity, "1")

--- a/cmd/network-observer/internal/server/sites_test.go
+++ b/cmd/network-observer/internal/server/sites_test.go
@@ -59,7 +59,7 @@ func TestSites(t *testing.T) {
 				assert.Equal(t, results[0].Identity, "site-2")
 				assert.Equal(t, results[0].RouterCount, 3)
 			},
-			Parameters: map[string][]string{"nameSpace": {"testns"}},
+			Parameters: map[string][]string{"namespace": {"testns"}},
 		},
 		{
 			Parameters:  map[string][]string{"fizz": {"baz", "buz"}},
@@ -118,10 +118,10 @@ func TestSiteByID(t *testing.T) {
 			ExpectOK: true,
 			ExpectResult: func(t *testing.T, results api.SiteRecord) {
 				assert.DeepEqual(t, results, api.SiteRecord{
-					Identity:    "site-1",
-					Name:        "unknown",
-					Platform:    "unknown",
-					SiteVersion: "unknown",
+					Identity: "site-1",
+					Name:     "unknown",
+					Platform: "unknown",
+					Version:  "unknown",
 				})
 			},
 		},

--- a/cmd/network-observer/internal/server/views/flows.go
+++ b/cmd/network-observer/internal/server/views/flows.go
@@ -41,8 +41,8 @@ func NewConnectionsProvider(stor store.Interface) func(collector.ConnectionRecor
 		out.StartTime, out.EndTime = vanflowTimes(record.BaseRecord)
 		out.ConnectorError = record.ErrorConnector
 		out.ListenerError = record.ErrorListener
-		setOpt(&out.Octets, record.Octets)
-		setOpt(&out.OctetsReverse, record.OctetsReverse)
+		setOpt(&out.OctetCount, record.Octets)
+		setOpt(&out.OctetReverseCount, record.OctetsReverse)
 		setOpt(&out.Latency, record.Latency)
 		setOpt(&out.LatencyReverse, record.LatencyReverse)
 		setOpt(&out.SourceHost, record.SourceHost)
@@ -200,8 +200,8 @@ func NewRequestProvider(stor store.Interface) func(collector.RequestRecord) (api
 		out.StartTime, out.EndTime = vanflowTimes(record.BaseRecord)
 		setOpt(&out.Method, record.Method)
 		setOpt(&out.Status, record.Result)
-		setOpt(&out.Octets, record.Octets)
-		setOpt(&out.OctetsReverse, record.OctetsReverse)
+		setOpt(&out.OctetCount, record.Octets)
+		setOpt(&out.OctetReverseCount, record.OctetsReverse)
 
 		if record.EndTime != nil && record.StartTime != nil && record.EndTime.After(record.StartTime.Time) {
 			if record.EndTime != nil && record.StartTime != nil {

--- a/cmd/network-observer/internal/server/views/views.go
+++ b/cmd/network-observer/internal/server/views/views.go
@@ -352,7 +352,7 @@ func NewProcessProvider(stor store.Interface, graph collector.Graph) func(vanflo
 
 		if len(addresses) > 0 {
 			if hasListeners && hasConnectors {
-				out.ProcessBinding = api.Bound
+				out.Binding = api.Bound
 			}
 			addressList := make([]api.AtmarkDelimitedString, 0, len(addresses))
 			for addr := range addresses {
@@ -368,15 +368,15 @@ func NewProcessProvider(stor store.Interface, graph collector.Graph) func(vanflo
 
 func defaultProcess(id string) api.ProcessRecord {
 	return api.ProcessRecord{
-		Identity:       id,
-		Name:           unknownStr,
-		Parent:         unknownStr,
-		ParentName:     unknownStr,
-		ComponentId:    unknownStr,
-		ComponentName:  unknownStr,
-		SourceHost:     unknownStr,
-		ProcessBinding: api.Unbound,
-		Role:           api.External,
+		Identity:      id,
+		Name:          unknownStr,
+		Parent:        unknownStr,
+		ParentName:    unknownStr,
+		ComponentId:   unknownStr,
+		ComponentName: unknownStr,
+		SourceHost:    unknownStr,
+		Binding:       api.Unbound,
+		Role:          api.External,
 	}
 }
 func RouterAccessList(entries []store.Entry) []api.RouterAccessRecord {
@@ -622,11 +622,11 @@ func NewSiteProvider(graph collector.Graph) func(vanflow.SiteRecord) api.SiteRec
 	return func(site vanflow.SiteRecord) api.SiteRecord {
 		s := defaultSite(site.ID)
 		s.StartTime, s.EndTime = vanflowTimes(site.BaseRecord)
-		s.NameSpace = site.Namespace
+		s.Namespace = site.Namespace
 
 		setOpt(&s.Name, site.Name)
 		setOpt(&s.Provider, site.Provider)
-		setOpt(&s.SiteVersion, site.Version)
+		setOpt(&s.Version, site.Version)
 		if site.Platform != nil {
 			platform := *site.Platform
 			switch {
@@ -647,10 +647,10 @@ func NewSiteProvider(graph collector.Graph) func(vanflow.SiteRecord) api.SiteRec
 
 func defaultSite(id string) api.SiteRecord {
 	return api.SiteRecord{
-		Identity:    id,
-		Name:        unknownStr,
-		Platform:    api.SitePlatformTypeUnknown,
-		SiteVersion: unknownStr,
+		Identity: id,
+		Name:     unknownStr,
+		Platform: api.SitePlatformTypeUnknown,
+		Version:  unknownStr,
 	}
 }
 

--- a/cmd/network-observer/spec/openapi.yaml
+++ b/cmd/network-observer/spec/openapi.yaml
@@ -793,8 +793,8 @@ components:
             - provider
             - platform
             - name
-            - nameSpace
-            - siteVersion
+            - namespace
+            - version
             - policy
             - routerCount
           properties:
@@ -805,10 +805,10 @@ components:
               $ref: '#/components/schemas/sitePlatformType'
             name:
               type: string
-            nameSpace:
+            namespace:
               type: string
               nullable: true
-            siteVersion:
+            version:
               type: string
               description: The current skupper version installed. Can be any string or 'unknown'
             routerCount:
@@ -827,7 +827,7 @@ components:
               - sourceHost
               - hostName
               - role
-              - processBinding
+              - binding
               - services
           properties:
             name:
@@ -859,7 +859,7 @@ components:
                 - external
                 - remote
               description: Internal processes are processes related to Skupper. Remote processes are processes indirectly connected, such as a proxy
-            processBinding:
+            binding:
               $ref: '#/components/schemas/processBindingType'
             services:
               type: array
@@ -1071,8 +1071,8 @@ components:
             - cost
             - role
             - status
-            - octets
-            - octetsReverse
+            - octetCount
+            - octetReverseCount
             - sourceSiteId
             - sourceSiteName
             - destinationSiteId
@@ -1096,10 +1096,10 @@ components:
               $ref: '#/components/schemas/linkRoleType'
             status:
               $ref: '#/components/schemas/operStatusType'
-            octets:
+            octetCount:
               type: integer
               format: uint64
-            octetsReverse:
+            octetReverseCount:
               type: integer
               format: uint64
             routerAccessId:
@@ -1172,8 +1172,8 @@ components:
             - destPort
             - proxyHost
             - proxyPort
-            - octets
-            - octetsReverse
+            - octetCount
+            - octetReverseCount
             - latency
             - latencyReverse
             - listenerError
@@ -1231,10 +1231,10 @@ components:
               type: string
             proxyPort:
               type: string
-            octets:
+            octetCount:
               type: integer
               format: uint64
-            octetsReverse:
+            octetReverseCount:
               type: integer
               format: uint64
             latency:
@@ -1280,8 +1280,8 @@ components:
             - status
             - traceRouters
             - traceSites
-            - octets
-            - octetsReverse
+            - octetCount
+            - octetReverseCount
           properties:
             connectionId:
               type: string
@@ -1316,10 +1316,10 @@ components:
             status:
               type: string
               example: 200
-            octets:
+            octetCount:
               type: integer
               format: uint64
-            octetsReverse:
+            octetReverseCount:
               type: integer
               format: uint64
             traceRouters:


### PR DESCRIPTION
Changes nameSpace to namespace. Adds a Count suffix to counts (octets and octetsReverse.) Drops stutter prefixes (process.processBinding to process.binding, stie.siteVersion to site.version.)