### PR TITLE
Nonkube claim redeemer to set namespace in link and secret

### DIFF
--- a/pkg/nonkube/common/claim_redeemer.go
+++ b/pkg/nonkube/common/claim_redeemer.go
@@ -83,9 +83,11 @@ func redeemAccessToken(claim *skupperv2alpha1.AccessToken, siteState *api.SiteSt
 	}
 
 	siteState.Secrets[decoder.secret.ObjectMeta.Name] = &decoder.secret
+	decoder.secret.ObjectMeta.Namespace = siteState.GetNamespace()
 
 	for _, link := range decoder.links {
 		siteState.Links[link.ObjectMeta.Name] = &link
+		link.ObjectMeta.Namespace = siteState.GetNamespace()
 	}
 
 	return nil


### PR DESCRIPTION
Without it teardown (which load site state) was rejecting the `runtime/resources` as the secret
and link(s) have an empty (default) namespace.