### PR TITLE
Ammed network observer chart presets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,8 +226,8 @@ jobs:
           command: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
       - run: make generate-skupper-deployment-cluster-scoped
       - run: make generate-skupper-deployment-namespace-scoped
-      - run: make generate-network-observer-generic
-      - run: make generate-network-observer-openshift
+      - run: make generate-network-observer
+      - run: make generate-network-observer-httpbasic
       - run: mkdir skupper-setup
       - run: cp ./*.yaml skupper-setup
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ manifest.json
 oci-archives/
 skupper-setup-cluster-scope.yaml
 skupper-setup-namespace-scope.yaml
-skupper-network-observer-*.yaml
+skupper-network-observer*.yaml

--- a/Makefile
+++ b/Makefile
@@ -129,19 +129,18 @@ generate-skupper-deployment-namespace-scoped:
 generate-bundle:
 	./scripts/generate-bundle.sh
 
-generate-network-observer-generic:
+generate-network-observer:
 	helm template skupper-network-observer ./charts/network-observer/ \
-		--set skipManagementLabels=true > skupper-network-observer-generic.yaml
-
-generate-network-observer-openshift:
-	helm template skupper-network-observer \
-		./charts/network-observer/ \
 		--set skipManagementLabels=true \
-		--set tls.skupperIssued=false \
-		--set tls.openshiftIssued=true \
-		--set route.enabled=true \
-		--set prometheus.securityContext=null \
-		> skupper-network-observer-openshift.yaml
+		--set auth.strategy=none \
+		> skupper-network-observer.yaml
+
+generate-network-observer-httpbasic:
+	helm template skupper-network-observer ./charts/network-observer/ \
+		--set skipManagementLabels=true \
+		--set auth.strategy=basic \
+		--set auth.basic.htpasswd="" \
+		> skupper-network-observer-httpbasic.yaml
 
 generate-network-observer-devel:
 	helm template skupper-network-observer ./charts/network-observer/ \

--- a/charts/network-observer/templates/_deployment.yaml
+++ b/charts/network-observer/templates/_deployment.yaml
@@ -32,13 +32,11 @@ ports:
 volumeMounts:
   - mountPath: /etc/certificates/
     name: {{ include "network-observer.tlsSecretName" . }}
-  - mountPath: /etc/nginx/nginx.conf
+  - mountPath: /etc/nginx
     name: nginx-config
-    subPath: nginx.conf
 {{- if eq .Values.auth.strategy "basic" }}
-  - mountPath: /etc/nginx/.htpasswd
+  - mountPath: /etc/httpusers
     name: nginx-htpasswd
-    subPath: htpasswd
 {{- end }}
 {{- end -}}
 

--- a/charts/network-observer/templates/nginx_config.yaml
+++ b/charts/network-observer/templates/nginx_config.yaml
@@ -27,7 +27,7 @@ data:
             {{- if eq .Values.auth.strategy "basic" }}
             location /api/ {
               auth_basic           "Skupper";
-              auth_basic_user_file /etc/nginx/.htpasswd;
+              auth_basic_user_file /etc/httpusers/htpasswd;
               proxy_pass  http://localhost:8080;
             }
             {{- end }}


### PR DESCRIPTION
Drops the openshift variant of the network observer until openshift auth can be declaratively configured.

Adds an unsecured option for demo environments.

Adds a httpbasic option WITHOUT a static user defined.

Updates the nginx configuration so that it can be dynamically reloaded from kuberentes secrets.