### PR TITLE
Updates go build version.Version definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             VERSION="${CIRCLE_TAG:-ci-${CIRCLE_BUILD_NUM}}";
             GOOS=<< parameters.goos >>
             GOARCH=<< parameters.goarch >>
-            go build -ldflags "-X github.com/skupperproject/skupper/pkg/version.Version=${VERSION}"
+            go build -ldflags "-X github.com/skupperproject/skupper/internal/version.Version=${VERSION}"
             -o dist/<< parameters.platform >>/skupper<< parameters.exesuffix >>
             ./cmd/skupper
       - run:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION := $(shell git describe --tags --dirty=-modified --always)
 REVISION := $(shell git rev-parse HEAD)
 
 LDFLAGS_EXTRA ?= -s -w # default to building stripped executables
-LDFLAGS := ${LDFLAGS_EXTRA} -X github.com/skupperproject/skupper/pkg/version.Version=${VERSION}
+LDFLAGS := ${LDFLAGS_EXTRA} -X github.com/skupperproject/skupper/internal/version.Version=${VERSION}
 TESTFLAGS := -v -race -short
 GOOS ?= linux
 GOARCH ?= amd64


### PR DESCRIPTION
Reflect the move from pkg/version.Version to internal/version.Version in the go build flags so that skupper components can correctly report their version.