### PR TITLE
Considers modified versions as valid

### DIFF
--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -96,7 +96,8 @@ func IsValidFor(actual string, minimum string) bool {
 	}
 	va := ParseVersion(actual)
 	vb := ParseVersion(minimum)
-	return va.IsUndefined() || !va.LessRecentThan(vb)
+	isModified := strings.Contains(va.Qualifier, "-modified")
+	return isModified || va.IsUndefined() || !va.LessRecentThan(vb)
 }
 
 func GetVersionTag(imageDescriptor string) string {


### PR DESCRIPTION
CI executions in branch v1 are now building the CLI on top of the v1-dev-release tag.

This tag is considered as a valid version by `pkg.utils.Version.ParseVersion`.

With that, the version determined by the CI execution is detected as something like:
`1.0.0-dev-release-commit_hash-modified`.

This is causing existing CLI tests to fail and this PR is probably not the best, but seems
to help with local and CI executions, against changes done on top of the v1 branch.