### PR TITLE
Fixes race conditions in network observer graph

### DIFF
--- a/cmd/network-observer/internal/collector/collector.go
+++ b/cmd/network-observer/internal/collector/collector.go
@@ -117,7 +117,11 @@ func (c *Collector) updateGraph(event changeEvent, stor readonly) {
 	if !ok {
 		return
 	}
-	c.graph.Reindex(entry.Record)
+	if _, ok := event.(addEvent); ok {
+		c.graph.Index(entry.Record)
+	} else {
+		c.graph.Reindex(entry.Record)
+	}
 }
 
 func (c *Collector) monitoring(ctx context.Context) func() error {

--- a/cmd/network-observer/internal/server/address_test.go
+++ b/cmd/network-observer/internal/server/address_test.go
@@ -106,9 +106,6 @@ func TestAddresses(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			stor.Replace(tc.Records)
 			graph.(reset).Reset()
-			for _, r := range tc.Records {
-				graph.(reset).Reindex(r.Record)
-			}
 			resp, err := c.ServicesWithResponse(context.TODO(), withParameters(tc.Parameters))
 			assert.Check(t, err)
 			if tc.ExpectOK {

--- a/cmd/network-observer/internal/server/connections_test.go
+++ b/cmd/network-observer/internal/server/connections_test.go
@@ -148,9 +148,6 @@ func TestConnections(t *testing.T) {
 			stor.Replace(tc.Records)
 			flowStor.Replace(tc.Flows)
 			graph.(reset).Reset()
-			for _, r := range tc.Records {
-				graph.(reset).Reindex(r.Record)
-			}
 			resp, err := c.ConnectionsWithResponse(context.TODO(), withParameters(tc.Parameters))
 			assert.Check(t, err)
 			if tc.ExpectOK {

--- a/cmd/network-observer/internal/server/connector_test.go
+++ b/cmd/network-observer/internal/server/connector_test.go
@@ -101,9 +101,6 @@ func TestConnectors(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			stor.Replace(tc.Records)
 			graph.(reset).Reset()
-			for _, r := range tc.Records {
-				graph.(reset).Reindex(r.Record)
-			}
 			resp, err := c.ConnectorsWithResponse(context.TODO(), withParameters(tc.Parameters))
 			assert.Check(t, err)
 			if tc.ExpectOK {

--- a/cmd/network-observer/internal/server/links_test.go
+++ b/cmd/network-observer/internal/server/links_test.go
@@ -86,9 +86,6 @@ func TestRouterlinks(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			stor.Replace(tc.Records)
 			graph.(reset).Reset()
-			for _, r := range tc.Records {
-				graph.(reset).Reindex(r.Record)
-			}
 			resp, err := c.RouterlinksWithResponse(context.TODO(), withParameters(tc.Parameters))
 			assert.Check(t, err)
 			if tc.ExpectOK {

--- a/cmd/network-observer/internal/server/process_test.go
+++ b/cmd/network-observer/internal/server/process_test.go
@@ -144,9 +144,6 @@ func TestProcesses(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			stor.Replace(tc.Records)
 			graph.(reset).Reset()
-			for _, r := range tc.Records {
-				graph.(reset).Reindex(r.Record)
-			}
 			resp, err := c.ProcessesWithResponse(context.TODO(), withParameters(tc.Parameters))
 			assert.Check(t, err)
 			if tc.ExpectOK {

--- a/cmd/network-observer/internal/server/processpairs_test.go
+++ b/cmd/network-observer/internal/server/processpairs_test.go
@@ -39,9 +39,6 @@ func TestProcessPairsByAddress(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			stor.Replace(tc.Records)
 			graph.(reset).Reset()
-			for _, r := range tc.Records {
-				graph.(reset).Reindex(r.Record)
-			}
 			resp, err := c.ProcessPairsByServiceWithResponse(context.TODO(), tc.ID, withParameters(tc.Parameters))
 			assert.Check(t, err)
 			if tc.ExpectOK {

--- a/cmd/network-observer/internal/server/router_test.go
+++ b/cmd/network-observer/internal/server/router_test.go
@@ -63,9 +63,6 @@ func TestRouters(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			stor.Replace(tc.Records)
 			graph.(reset).Reset()
-			for _, r := range tc.Records {
-				graph.(reset).Reindex(r.Record)
-			}
 			resp, err := c.RoutersWithResponse(context.TODO(), withParameters(tc.Parameters))
 			assert.Check(t, err)
 			if tc.ExpectOK {


### PR DESCRIPTION
Adds logic to re-add child to parent record relationships when a parent record is added. Fixes several sorts of problems that arise when parent records, like a SITE record, are deleted and re-added after a disruption. Also resolves a known race condition (TODO) where the relation between a connector's Host and processes in a site cannot be made unless we already have the router record (to complete the relationship between connector->router->site.)

Fixes https://github.com/skupperproject/skupper/issues/1916