### PR TITLE
Rename Network Observer API parent fields

### DIFF
--- a/cmd/network-observer/internal/api/types_gen.go
+++ b/cmd/network-observer/internal/api/types_gen.go
@@ -211,9 +211,9 @@ type ConnectorRecord struct {
 	// Identity The unique identifier for the record.
 	Identity   string  `json:"identity"`
 	Name       string  `json:"name"`
-	Parent     string  `json:"parent"`
 	ProcessId  string  `json:"processId"`
 	Protocol   string  `json:"protocol"`
+	RouterId   string  `json:"routerId"`
 	RoutingKey string  `json:"routingKey"`
 	ServiceId  *string `json:"serviceId,omitempty"`
 	SiteId     string  `json:"siteId"`
@@ -295,8 +295,8 @@ type ListenerRecord struct {
 	// Identity The unique identifier for the record.
 	Identity   string  `json:"identity"`
 	Name       string  `json:"name"`
-	Parent     string  `json:"parent"`
 	Protocol   string  `json:"protocol"`
+	RouterId   string  `json:"routerId"`
 	RoutingKey string  `json:"routingKey"`
 	ServiceId  *string `json:"serviceId,omitempty"`
 	SiteId     string  `json:"siteId"`
@@ -326,7 +326,7 @@ type ProcessRecord struct {
 	// Binding Indicates whether a process is exposed or not in a skupper network
 	Binding ProcessBindingType `json:"binding"`
 
-	// ComponentId Id of the component associated to the process. this is a parent of the process
+	// ComponentId Id of the component associated to the process.
 	ComponentId   string `json:"componentId"`
 	ComponentName string `json:"componentName"`
 
@@ -341,13 +341,13 @@ type ProcessRecord struct {
 	ImageName *string `json:"imageName"`
 	Name      string  `json:"name"`
 
-	// Parent Id of the site associated to the process. this is a parent of the process
-	Parent     string `json:"parent"`
-	ParentName string `json:"parentName"`
-
 	// Role Internal processes are processes related to Skupper. Remote processes are processes indirectly connected, such as a proxy
 	Role     ProcessRecordRole        `json:"role"`
 	Services *[]ServiceIdentifierType `json:"services"`
+
+	// SiteId Id of the site associated to the process.
+	SiteId   string `json:"siteId"`
+	SiteName string `json:"siteName"`
 
 	// SourceHost The IP address of the node where the pod is running
 	SourceHost string `json:"sourceHost"`
@@ -476,7 +476,7 @@ type RouterRecord struct {
 	Mode         string  `json:"mode"`
 	Name         string  `json:"name"`
 	Namespace    *string `json:"namespace,omitempty"`
-	Parent       string  `json:"parent"`
+	SiteId       string  `json:"siteId"`
 
 	// StartTime The creation time in microseconds of the record in Unix timestamp format. The value 0 means that the record is not terminated
 	StartTime uint64 `json:"startTime"`

--- a/cmd/network-observer/internal/server/connector_test.go
+++ b/cmd/network-observer/internal/server/connector_test.go
@@ -32,7 +32,7 @@ func TestConnectors(t *testing.T) {
 				assert.Equal(t, len(results), 1)
 				result := results[0]
 				assert.DeepEqual(t, result, api.ConnectorRecord{
-					Identity: "c1", Name: "unknown", Parent: "unknown",
+					Identity: "c1", Name: "unknown", RouterId: "unknown",
 					SiteName: "unknown", SiteId: "unknown",
 					Protocol: "unknown", RoutingKey: "unknown", DestHost: "unknown",
 					ProcessId: "", DestPort: "unknown",
@@ -63,7 +63,7 @@ func TestConnectors(t *testing.T) {
 				assert.Equal(t, len(results), 1)
 				result := results[0]
 				assert.DeepEqual(t, result, api.ConnectorRecord{
-					Identity: "c1", Name: "conn-one", Parent: "r1",
+					Identity: "c1", Name: "conn-one", RouterId: "r1",
 					SiteName: "one", SiteId: "s1",
 					Protocol: "tp", RoutingKey: "trombone", DestHost: "10.0.four.two",
 					ProcessId: "p1", Target: ptrTo("proc-one"), DestPort: "amqp",

--- a/cmd/network-observer/internal/server/process_test.go
+++ b/cmd/network-observer/internal/server/process_test.go
@@ -51,8 +51,8 @@ func TestProcesses(t *testing.T) {
 				r := results[0]
 				assert.DeepEqual(t, r, api.ProcessRecord{
 					Identity:      "1",
-					Parent:        "s1",
-					ParentName:    "unknown",
+					SiteId:        "s1",
+					SiteName:      "unknown",
 					ComponentName: "unknown",
 					ComponentId:   "unknown",
 					Binding:       api.Unbound,
@@ -69,8 +69,8 @@ func TestProcesses(t *testing.T) {
 				r := results[0]
 				assert.DeepEqual(t, r, api.ProcessRecord{
 					Identity:      "1",
-					Parent:        "site-1",
-					ParentName:    "site one",
+					SiteId:        "site-1",
+					SiteName:      "site one",
 					Services:      ptrTo([]api.AtmarkDelimitedString{api.AtmarkDelimitedString("icecream@icecream-addr-id@tcp"), api.AtmarkDelimitedString("pizza@pizza-addr-id@tcp")}),
 					ComponentName: "group-one",
 					ComponentId:   "group-1-id",
@@ -94,8 +94,8 @@ func TestProcesses(t *testing.T) {
 				r := results[0]
 				assert.DeepEqual(t, r, api.ProcessRecord{
 					Identity:      "1",
-					Parent:        "site-1",
-					ParentName:    "site one",
+					SiteId:        "site-1",
+					SiteName:      "site one",
 					Services:      ptrTo([]api.AtmarkDelimitedString{api.AtmarkDelimitedString("icecream@icecream-addr-id@tcp"), api.AtmarkDelimitedString("pizza@pizza-addr-id@tcp")}),
 					ComponentName: "group-one",
 					ComponentId:   "group-1-id",

--- a/cmd/network-observer/internal/server/router_test.go
+++ b/cmd/network-observer/internal/server/router_test.go
@@ -48,7 +48,7 @@ func TestRouters(t *testing.T) {
 								ImageName:    "unknown",
 								ImageVersion: "unknown",
 								Mode:         "inter-router",
-								Parent:       "site-a",
+								SiteId:       "site-a",
 							},
 						)
 

--- a/cmd/network-observer/internal/server/views/views.go
+++ b/cmd/network-observer/internal/server/views/views.go
@@ -140,7 +140,7 @@ func NewListenerProvider(graph collector.Graph) func(vanflow.ListenerRecord) api
 		out := defaultListener(record.ID)
 		out.StartTime, out.EndTime = vanflowTimes(record.BaseRecord)
 		setOpt(&out.Name, record.Name)
-		setOpt(&out.Parent, record.Parent)
+		setOpt(&out.RouterId, record.Parent)
 		setOpt(&out.Protocol, record.Protocol)
 		setOpt(&out.DestHost, record.DestHost)
 		setOpt(&out.DestPort, record.DestPort)
@@ -162,7 +162,7 @@ func defaultListener(id string) api.ListenerRecord {
 	return api.ListenerRecord{
 		Identity:   id,
 		Name:       unknownStr,
-		Parent:     unknownStr,
+		RouterId:   unknownStr,
 		Protocol:   unknownStr,
 		RoutingKey: unknownStr,
 		DestHost:   unknownStr,
@@ -192,7 +192,7 @@ func NewConnectorProvider(graph collector.Graph) func(vanflow.ConnectorRecord) a
 		out := defaultConnector(record.ID)
 		out.StartTime, out.EndTime = vanflowTimes(record.BaseRecord)
 		setOpt(&out.Name, record.Name)
-		setOpt(&out.Parent, record.Parent)
+		setOpt(&out.RouterId, record.Parent)
 		setOpt(&out.Protocol, record.Protocol)
 		setOpt(&out.DestHost, record.DestHost)
 		setOpt(&out.DestPort, record.DestPort)
@@ -219,7 +219,7 @@ func defaultConnector(id string) api.ConnectorRecord {
 	return api.ConnectorRecord{
 		Identity:   id,
 		Name:       unknownStr,
-		Parent:     unknownStr,
+		RouterId:   unknownStr,
 		Protocol:   unknownStr,
 		RoutingKey: unknownStr,
 		DestHost:   unknownStr,
@@ -305,12 +305,12 @@ func NewProcessProvider(stor store.Interface, graph collector.Graph) func(vanflo
 		if !ok {
 			return out, false
 		}
-		setOpt(&out.ParentName, site.Name)
+		setOpt(&out.SiteName, site.Name)
 		out.StartTime, out.EndTime = vanflowTimes(record.BaseRecord)
 		out.ImageName = record.ImageName
 		out.HostName = record.Hostname
 		setOpt(&out.Name, record.Name)
-		setOpt(&out.Parent, record.Parent)
+		setOpt(&out.SiteId, record.Parent)
 		setOpt(&out.SourceHost, record.SourceHost)
 		if record.Mode != nil {
 			mode := *record.Mode
@@ -370,8 +370,8 @@ func defaultProcess(id string) api.ProcessRecord {
 	return api.ProcessRecord{
 		Identity:      id,
 		Name:          unknownStr,
-		Parent:        unknownStr,
-		ParentName:    unknownStr,
+		SiteId:        unknownStr,
+		SiteName:      unknownStr,
 		ComponentId:   unknownStr,
 		ComponentName: unknownStr,
 		SourceHost:    unknownStr,
@@ -581,7 +581,7 @@ func Router(record vanflow.RouterRecord) api.RouterRecord {
 	out := defaultRouter(record.ID)
 	out.StartTime, out.EndTime = vanflowTimes(record.BaseRecord)
 	out.Namespace = record.Namespace
-	setOpt(&out.Parent, record.Parent)
+	setOpt(&out.SiteId, record.Parent)
 	setOpt(&out.HostName, record.Hostname)
 	setOpt(&out.ImageName, record.ImageName)
 	setOpt(&out.ImageVersion, record.ImageVersion)
@@ -599,7 +599,7 @@ func defaultRouter(id string) api.RouterRecord {
 		ImageVersion: unknownStr,
 		Mode:         unknownStr,
 		Name:         unknownStr,
-		Parent:       unknownStr,
+		SiteId:       unknownStr,
 	}
 }
 

--- a/cmd/network-observer/spec/openapi.yaml
+++ b/cmd/network-observer/spec/openapi.yaml
@@ -819,8 +819,8 @@ components:
         - type: object
           required:
               - name
-              - parent
-              - parentName
+              - siteId
+              - siteName
               - imageName
               - componentId
               - componentName
@@ -832,14 +832,14 @@ components:
           properties:
             name:
               type: string
-            parent:
+            siteId:
               type: string
-              description: Id of the site associated to the process. this is a parent of the process
-            parentName:
+              description: Id of the site associated to the process.
+            siteName:
               type: string
             componentId:
               type: string
-              description: Id of the component associated to the process. this is a parent of the process
+              description: Id of the component associated to the process.
             componentName:
               type: string
             hostName:
@@ -871,7 +871,7 @@ components:
         - $ref: '#/components/schemas/baseRecord'
         - type: object
           required:
-            - parent
+            - siteId
             - name
             - mode
             - imageName
@@ -879,7 +879,7 @@ components:
             - hostName
             - buildVersion
           properties:
-            parent:
+            siteId:
               type: string
             name:
               type: string
@@ -900,7 +900,7 @@ components:
         - $ref: '#/components/schemas/baseRecord'
         - type: object
           required:
-            - parent
+            - routerId
             - name
             - destHost
             - destPort
@@ -909,7 +909,7 @@ components:
             - siteId
             - siteName
           properties:
-            parent:
+            routerId:
               type: string
             name:
               type: string
@@ -932,7 +932,7 @@ components:
         - $ref: '#/components/schemas/baseRecord'
         - type: object
           required:
-            - parent
+            - routerId
             - name
             - destHost
             - destPort
@@ -943,7 +943,7 @@ components:
             - siteId
             - siteName
           properties:
-            parent:
+            routerId:
               type: string
             name:
               type: string


### PR DESCRIPTION
Renames Connector and Listener parent to routerId. Renames Process parent and parentName to siteId and siteName. Renames Router parent to siteId.