### PR TITLE
add means of configuring site sizing

### DIFF
--- a/internal/kube/site/resources/skupper-router-deployment.yaml
+++ b/internal/kube/site/resources/skupper-router-deployment.yaml
@@ -1,3 +1,18 @@
+{{- define "resources" }}
+        resources:
+{{- if .Requests }}
+          requests:
+{{- range $key, $value := .Requests }}
+            {{ $key }}: "{{$value -}}"
+{{- end }}
+{{- end }}
+{{- if .Limits }}
+          limits:
+{{- range $key, $value := .Limits }}
+            {{ $key }}: "{{$value -}}"
+{{- end -}}
+{{- end -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -79,6 +94,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/skupper-router-certs
           name: skupper-router-certs
+{{- if .Sizing.Router.NotEmpty -}}
+        {{- template "resources" .Sizing.Router -}}
+{{- end }}
       - env:
         - name: SKUPPER_NAMESPACE
           valueFrom:
@@ -109,6 +127,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/skupper-router-certs
           name: skupper-router-certs
+{{- if .Sizing.Adaptor.NotEmpty -}}
+        {{- template "resources" .Sizing.Adaptor -}}
+{{- end }}
       initContainers:
       - env:
         - name: SKUPPER_ROUTER_CONFIG
@@ -120,6 +141,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/skupper-router-certs
           name: skupper-router-certs
+{{- if .Sizing.Adaptor.NotEmpty -}}
+        {{- template "resources" .Sizing.Adaptor -}}
+{{- end }}
       serviceAccount: {{ .ServiceAccount }}
       volumes:
       - emptyDir: {}

--- a/internal/kube/site/sizing/sizing.go
+++ b/internal/kube/site/sizing/sizing.go
@@ -1,0 +1,163 @@
+package sizing
+
+import (
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	skupperv2alpha1 "github.com/skupperproject/skupper/pkg/apis/skupper/v2alpha1"
+)
+
+const (
+	SiteSizingLabel             = "skupper.io/site-sizing"
+	DefaultSiteSizingAnnotation = "skupper.io/default-site-sizing"
+)
+
+type Registry struct {
+	sizes       map[string]*corev1.ConfigMap //keyed on size name
+	names       map[string]string            //ConfigMap key -> size name
+	defaultSize string
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		sizes: map[string]*corev1.ConfigMap{},
+		names: map[string]string{},
+	}
+}
+
+func (r *Registry) Update(key string, cm *corev1.ConfigMap) error {
+	if name, ok := getSizeName(cm); ok {
+		if existing, ok := r.names[key]; ok {
+			delete(r.sizes, existing)
+		}
+		r.names[key] = name
+		r.sizes[name] = cm
+		if isDefault(cm) {
+			r.defaultSize = name
+		}
+	} else {
+		if name, ok := r.names[key]; ok {
+			delete(r.names, key)
+			delete(r.sizes, name)
+		}
+	}
+	return nil
+}
+
+func getSizeName(cm *corev1.ConfigMap) (string, bool) {
+	if cm == nil || cm.ObjectMeta.Labels == nil {
+		return "", false
+	}
+	name, ok := cm.ObjectMeta.Labels[SiteSizingLabel]
+	return name, ok
+}
+
+func isDefault(cm *corev1.ConfigMap) bool {
+	if cm == nil || cm.ObjectMeta.Annotations == nil {
+		return false
+	}
+	_, ok := cm.ObjectMeta.Annotations[DefaultSiteSizingAnnotation]
+	return ok
+}
+
+func (r *Registry) GetSizing(site *skupperv2alpha1.Site) (Sizing, error) {
+	if config := r.getSizeConfiguration(desiredSize(site)); config != nil {
+		return parse(config)
+	}
+	return Sizing{}, nil
+}
+
+func desiredSize(site *skupperv2alpha1.Site) string {
+	if site.Spec.Settings == nil {
+		return ""
+	}
+	return site.Spec.Settings["size"]
+}
+
+func (r *Registry) getSizeConfiguration(name string) *corev1.ConfigMap {
+	if conf, ok := r.sizes[name]; ok {
+		return conf
+	}
+	return r.sizes[r.defaultSize]
+}
+
+type Sizing struct {
+	Router  ContainerResources
+	Adaptor ContainerResources
+}
+
+func parse(cm *corev1.ConfigMap) (Sizing, error) {
+	var errs []error
+	sizing := Sizing{
+		Router: ContainerResources{
+			Requests: map[string]string{},
+			Limits:   map[string]string{},
+		},
+		Adaptor: ContainerResources{
+			Requests: map[string]string{},
+			Limits:   map[string]string{},
+		},
+	}
+	for key, value := range cm.Data {
+		if err := verify(value); err != nil {
+			errs = append(errs, fmt.Errorf("Bad value for %s in %s/%s: %s", key, cm.Namespace, cm.Name, err))
+			continue
+		}
+		switch key {
+		case "router-cpu-request":
+			sizing.Router.setCpuRequest(value)
+		case "router-cpu-limit":
+			sizing.Router.setCpuLimit(value)
+		case "router-memory-request":
+			sizing.Router.setMemoryRequest(value)
+		case "router-memory-limit":
+			sizing.Router.setMemoryLimit(value)
+		case "adaptor-cpu-request":
+			sizing.Adaptor.setCpuRequest(value)
+		case "adaptor-cpu-limit":
+			sizing.Adaptor.setCpuLimit(value)
+		case "adaptor-memory-request":
+			sizing.Adaptor.setMemoryRequest(value)
+		case "adaptor-memory-limit":
+			sizing.Adaptor.setMemoryLimit(value)
+		default:
+			errs = append(errs, fmt.Errorf("Ignoring key %s in %s/%s", key, cm.Namespace, cm.Name))
+		}
+	}
+	return sizing, errors.Join(errs...)
+}
+
+type ContainerResources struct {
+	Requests map[string]string
+	Limits   map[string]string
+}
+
+func (r ContainerResources) NotEmpty() bool {
+	return len(r.Requests) > 0 || len(r.Limits) > 0
+}
+
+func (r *ContainerResources) setCpuRequest(value string) {
+	r.Requests[string(corev1.ResourceCPU)] = value
+}
+
+func (r *ContainerResources) setCpuLimit(value string) {
+	r.Limits[string(corev1.ResourceCPU)] = value
+}
+
+func (r *ContainerResources) setMemoryRequest(value string) {
+	r.Requests[string(corev1.ResourceMemory)] = value
+}
+
+func (r *ContainerResources) setMemoryLimit(value string) {
+	r.Limits[string(corev1.ResourceMemory)] = value
+}
+
+func verify(value string) error {
+	_, err := resource.ParseQuantity(value)
+	return err
+}
+
+//How is change in sizing handled? Need to reconcile every site (could wait until the next site timeout event...)

--- a/internal/kube/site/sizing/sizing_test.go
+++ b/internal/kube/site/sizing/sizing_test.go
@@ -1,0 +1,332 @@
+package sizing
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"gotest.tools/v3/assert"
+
+	skupperv2alpha1 "github.com/skupperproject/skupper/pkg/apis/skupper/v2alpha1"
+)
+
+func TestSizing(t *testing.T) {
+	type Update struct {
+		key    string
+		config *corev1.ConfigMap
+	}
+	type Expectation struct {
+		site   *skupperv2alpha1.Site
+		sizing Sizing
+		err    string
+	}
+	tests := []struct {
+		name         string
+		config       []Update
+		expectations []Expectation
+	}{
+		{
+			name: "no sizing config supplied",
+			expectations: []Expectation{
+				{
+					site: f.site(""),
+				},
+			},
+		},
+		{
+			name: "simple match",
+			config: []Update{
+				{
+					key:    "foo/bar",
+					config: f.config("mysize", false).entry("router-cpu-request", "0.5").configmap("bar", "foo"),
+				},
+			},
+			expectations: []Expectation{
+				{
+					site:   f.site("mysize"),
+					sizing: f.sizing().routerRequest("cpu", "0.5").sizing,
+				},
+			},
+		},
+		{
+			name: "all values",
+			config: []Update{
+				{
+					key: "foo/bar",
+					config: f.config("mysize", false).entry(
+						"router-cpu-request", "0.5",
+					).entry(
+						"router-cpu-limit", "0.6",
+					).entry(
+						"router-memory-request", "300M",
+					).entry(
+						"router-memory-limit", "400M",
+					).entry(
+						"adaptor-cpu-request", "0.3",
+					).entry(
+						"adaptor-cpu-limit", "0.4",
+					).entry(
+						"adaptor-memory-request", "100M",
+					).entry(
+						"adaptor-memory-limit", "200M",
+					).configmap("bar", "foo"),
+				},
+			},
+			expectations: []Expectation{
+				{
+					site: f.site("mysize"),
+					sizing: f.sizing().routerRequest(
+						"cpu", "0.5",
+					).routerRequest(
+						"memory", "300M",
+					).routerLimit(
+						"cpu", "0.6",
+					).routerLimit(
+						"memory", "400M",
+					).adaptorRequest(
+						"cpu", "0.3",
+					).adaptorRequest(
+						"memory", "100M",
+					).adaptorLimit(
+						"cpu", "0.4",
+					).adaptorLimit(
+						"memory", "200M",
+					).sizing,
+				},
+			},
+		},
+		{
+			name: "default config",
+			config: []Update{
+				{
+					key:    "foo/bar",
+					config: f.config("mysize", false).entry("router-cpu-request", "0.5").configmap("bar", "foo"),
+				},
+				{
+					key:    "foo/baz",
+					config: f.config("anothersize", true).entry("router-cpu-limit", "4").configmap("baz", "foo"),
+				},
+			},
+			expectations: []Expectation{
+				{
+					site:   f.site(""),
+					sizing: f.sizing().routerLimit("cpu", "4").sizing,
+				},
+			},
+		},
+		{
+			name: "bad value",
+			config: []Update{
+				{
+					key:    "foo/bar",
+					config: f.config("mysize", false).entry("router-cpu-request", "0.5").entry("router-cpu-limit", "1xyz").configmap("bar", "foo"),
+				},
+			},
+			expectations: []Expectation{
+				{
+					site:   f.site("mysize"),
+					sizing: f.sizing().routerRequest("cpu", "0.5").sizing,
+					err:    "Bad value for router-cpu-limit in foo/bar",
+				},
+			},
+		},
+		{
+			name: "unknown key",
+			config: []Update{
+				{
+					key:    "foo/bar",
+					config: f.config("mysize", false).entry("router-cpu-request", "0.5").entry("flibbertygibbet", "500M").configmap("bar", "foo"),
+				},
+			},
+			expectations: []Expectation{
+				{
+					site:   f.site("mysize"),
+					sizing: f.sizing().routerRequest("cpu", "0.5").sizing,
+					err:    "Ignoring key flibbertygibbet in foo/bar",
+				},
+			},
+		},
+		{
+			name: "config changed",
+			config: []Update{
+				{
+					key:    "foo/bar",
+					config: f.config("mysize", false).entry("router-cpu-request", "0.5").configmap("bar", "foo"),
+				},
+				{
+					key:    "foo/bar",
+					config: f.config("mysize", false).entry("router-cpu-request", "0.6").configmap("bar", "foo"),
+				},
+			},
+			expectations: []Expectation{
+				{
+					site:   f.site("mysize"),
+					sizing: f.sizing().routerRequest("cpu", "0.6").sizing,
+				},
+			},
+		},
+		{
+			name: "config deleted",
+			config: []Update{
+				{
+					key:    "foo/bar",
+					config: f.config("mysize", false).entry("router-cpu-request", "0.5").configmap("bar", "foo"),
+				},
+				{
+					key: "foo/bar",
+				},
+			},
+			expectations: []Expectation{
+				{
+					site: f.site("mysize"),
+				},
+			},
+		},
+		{
+			name: "label removed",
+			config: []Update{
+				{
+					key:    "foo/bar",
+					config: f.config("mysize", false).entry("router-cpu-request", "0.5").configmap("bar", "foo"),
+				},
+				{
+					key:    "foo/bar",
+					config: f.config("", false).entry("router-cpu-request", "0.5").configmap("bar", "foo"),
+				},
+			},
+			expectations: []Expectation{
+				{
+					site: f.site("mysize"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := NewRegistry()
+			for _, update := range tt.config {
+				registry.Update(update.key, update.config)
+			}
+			for _, expectation := range tt.expectations {
+				actual, err := registry.GetSizing(expectation.site)
+				if expectation.err != "" {
+					assert.ErrorContains(t, err, expectation.err)
+				} else {
+					assert.Assert(t, err)
+				}
+				assert.DeepEqual(t, expectation.sizing, actual)
+				assert.Equal(t, expectation.sizing.Router.NotEmpty(), actual.Router.NotEmpty())
+				assert.Equal(t, expectation.sizing.Adaptor.NotEmpty(), actual.Adaptor.NotEmpty())
+			}
+		})
+	}
+}
+
+type factory struct{}
+
+func (*factory) site(size string) *skupperv2alpha1.Site {
+	if size == "" {
+		return &skupperv2alpha1.Site{}
+	}
+	return &skupperv2alpha1.Site{
+		Spec: skupperv2alpha1.SiteSpec{
+			Settings: map[string]string{
+				"size": size,
+			},
+		},
+	}
+}
+
+type ConfigBuilder struct {
+	labels      map[string]string
+	annotations map[string]string
+	data        map[string]string
+}
+
+func (*factory) config(size string, isDefault bool) *ConfigBuilder {
+	config := &ConfigBuilder{
+		data: map[string]string{},
+	}
+	if size != "" {
+		config.label(SiteSizingLabel, size)
+	}
+	if isDefault {
+		config.annotation(DefaultSiteSizingAnnotation, "")
+	}
+	return config
+}
+
+func (c *ConfigBuilder) entry(key string, value string) *ConfigBuilder {
+	c.data[key] = value
+	return c
+}
+
+func (c *ConfigBuilder) label(key string, value string) *ConfigBuilder {
+	if c.labels == nil {
+		c.labels = map[string]string{}
+	}
+	c.labels[key] = value
+	return c
+}
+
+func (c *ConfigBuilder) annotation(key string, value string) *ConfigBuilder {
+	if c.annotations == nil {
+		c.annotations = map[string]string{}
+	}
+	c.annotations[key] = value
+	return c
+}
+
+func (c *ConfigBuilder) configmap(name string, namespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      c.labels,
+			Annotations: c.annotations,
+		},
+		Data: c.data,
+	}
+}
+
+type SizingBuilder struct {
+	sizing Sizing
+}
+
+func (*factory) sizing() *SizingBuilder {
+	return &SizingBuilder{
+		sizing: Sizing{
+			Router: ContainerResources{
+				Requests: map[string]string{},
+				Limits:   map[string]string{},
+			},
+			Adaptor: ContainerResources{
+				Requests: map[string]string{},
+				Limits:   map[string]string{},
+			},
+		},
+	}
+}
+
+func (s *SizingBuilder) routerRequest(key string, value string) *SizingBuilder {
+	s.sizing.Router.Requests[key] = value
+	return s
+}
+
+func (s *SizingBuilder) routerLimit(key string, value string) *SizingBuilder {
+	s.sizing.Router.Limits[key] = value
+	return s
+}
+
+func (s *SizingBuilder) adaptorRequest(key string, value string) *SizingBuilder {
+	s.sizing.Adaptor.Requests[key] = value
+	return s
+}
+
+func (s *SizingBuilder) adaptorLimit(key string, value string) *SizingBuilder {
+	s.sizing.Adaptor.Limits[key] = value
+	return s
+}
+
+var f factory


### PR DESCRIPTION
This adds a mechanism for configuring the container resources in the skupper-router pod for sites based on a 'size' concept.

Sizes are defined by configmaps with a `skupper.io/site-sizing` label whose value is the name of the size. It is the users responsibility to sure that size names are unique. The valid keys in the map are , `router-cpu-request`, `router-cpu-limit`, `router-memory-request`, `router-memory-limit`, `adaptor-cpu-request`, `adaptor-cpu-limit`, `adaptor-memory-request` and `adaptor-memory-limit`.

A site definition can specify an explicit `size` in the `settings` map within the spec. If a seize has been configured for that name, then any of the defined resource settings within that size will be applied to the skupper-router deployment for the site.

If one of the defined sizes has the annotation `skupper.io/default-site-sizing`, that is considered the default size to be used for any site where there is not an explicit size specified (or the explicit size specified does not match a configured size).