### PR TITLE
Remove the name flag from skupper token issue command

### DIFF
--- a/internal/cmd/skupper/common/flags.go
+++ b/internal/cmd/skupper/common/flags.go
@@ -43,8 +43,6 @@ for other Kubernetes flavors, loadbalancer is the default.`
 	FlagDescRedemptionsAllowed = "The number of times an access token for this grant can be redeemed."
 	FlagNameExpirationWindow   = "expiration-window"
 	FlagDescExpirationWindow   = "The period of time in which an access token for this grant can be redeemed."
-	FlagNameToken              = "name"
-	FlagDescToken              = "The name of token issued"
 
 	FlagNameRoutingKey          = "routing-key"
 	FlagDescRoutingKey          = "The identifier used to route traffic from listeners to connectors"

--- a/internal/cmd/skupper/token/kube/token_issue.go
+++ b/internal/cmd/skupper/token/kube/token_issue.go
@@ -46,7 +46,6 @@ func (cmd *CmdTokenIssue) NewClient(cobraCommand *cobra.Command, args []string) 
 
 func (cmd *CmdTokenIssue) ValidateInput(args []string) error {
 	var validationErrors []error
-	resourceStringValidator := validator.NewResourceStringValidator()
 	tokenStringValidator := validator.NewFilePathStringValidator()
 	timeoutValidator := validator.NewTimeoutInSecondsValidator()
 	expirationValidator := validator.NewExpirationInSecondsValidator()
@@ -81,17 +80,7 @@ func (cmd *CmdTokenIssue) ValidateInput(args []string) error {
 		if !ok {
 			validationErrors = append(validationErrors, fmt.Errorf("there is no active skupper site in this namespace"))
 		} else {
-			// used configured name or generate a grant name
-			if cmd.Flags.Name != "" {
-				ok, err := resourceStringValidator.Evaluate(cmd.Flags.Name)
-				if !ok {
-					validationErrors = append(validationErrors, fmt.Errorf("token name is not valid: %s", err))
-				} else {
-					cmd.grantName = cmd.Flags.Name
-				}
-			} else {
-				cmd.grantName = siteName + "-" + uuid.New().String()
-			}
+			cmd.grantName = siteName + "-" + uuid.New().String()
 		}
 	}
 

--- a/internal/cmd/skupper/token/kube/token_issue_test.go
+++ b/internal/cmd/skupper/token/kube/token_issue_test.go
@@ -28,68 +28,6 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 
 	testTable := []test{
 		{
-			name: "token is not issued because there is already the same token in the namespace",
-			args: []string{"~/token.yaml"},
-			flags: common.CommandTokenIssueFlags{
-				ExpirationWindow:   15 * time.Minute,
-				RedemptionsAllowed: 1,
-				Timeout:            60 * time.Second,
-				Name:               "my-token",
-				Cost:               "1",
-			},
-			skupperObjects: []runtime.Object{
-				&v2alpha1.SiteList{
-					Items: []v2alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "the-site",
-								Namespace: "test",
-							},
-							Status: v2alpha1.SiteStatus{
-								Status: v2alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-										{
-											Type:   "Running",
-											Status: "True",
-										},
-										{
-											Type:   "Ready",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				&v2alpha1.AccessGrant{
-					ObjectMeta: v1.ObjectMeta{
-						Name:      "my-token",
-						Namespace: "test",
-					},
-					Spec: v2alpha1.AccessGrantSpec{
-						RedemptionsAllowed: 1,
-						ExpirationWindow:   "15m0s",
-					},
-					Status: v2alpha1.AccessGrantStatus{
-						Status: v2alpha1.Status{
-							Conditions: []v1.Condition{
-								{
-									Type:   "Ready",
-									Status: "True",
-								},
-							},
-						},
-					},
-				},
-			},
-			expectedError: "there is already a token my-token created in namespace test",
-		},
-		{
 			name: "token no site",
 			args: []string{"filename"},
 			flags: common.CommandTokenIssueFlags{
@@ -272,48 +210,6 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 				},
 			},
 			expectedError: "only one argument is allowed for this command",
-		},
-		{
-			name: "token name is not valid.",
-			args: []string{"~/token.yaml"},
-			flags: common.CommandTokenIssueFlags{
-				ExpirationWindow:   15 * time.Minute,
-				RedemptionsAllowed: 1,
-				Timeout:            60 * time.Second,
-				Name:               "my new token",
-				Cost:               "1",
-			},
-			skupperObjects: []runtime.Object{
-				&v2alpha1.SiteList{
-					Items: []v2alpha1.Site{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "site1",
-								Namespace: "test",
-							},
-							Status: v2alpha1.SiteStatus{
-								Status: v2alpha1.Status{
-									Conditions: []v1.Condition{
-										{
-											Type:   "Configured",
-											Status: "True",
-										},
-										{
-											Type:   "Running",
-											Status: "True",
-										},
-										{
-											Type:   "Ready",
-											Status: "True",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			expectedError: "token name is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$",
 		},
 		{
 			name: "token file name is not valid.",

--- a/internal/cmd/skupper/token/token.go
+++ b/internal/cmd/skupper/token/token.go
@@ -48,7 +48,6 @@ func CmdTokenIssueFactory(configuredPlatform types.Platform) *cobra.Command {
 	cmd.Flags().IntVarP(&cmdFlags.RedemptionsAllowed, common.FlagNameRedemptionsAllowed, "r", 1, common.FlagDescRedemptionsAllowed)
 	cmd.Flags().DurationVarP(&cmdFlags.ExpirationWindow, common.FlagNameExpirationWindow, "e", 15*time.Minute, common.FlagDescExpirationWindow)
 	cmd.Flags().DurationVarP(&cmdFlags.Timeout, common.FlagNameTimeout, "t", 60*time.Second, common.FlagDescTimeout)
-	cmd.Flags().StringVar(&cmdFlags.Name, common.FlagNameToken, "", common.FlagDescToken)
 	cmd.Flags().StringVar(&cmdFlags.Cost, common.FlagNameCost, "1", common.FlagDescCost)
 
 	kubeCommand.CobraCmd = cmd

--- a/internal/cmd/skupper/token/token_test.go
+++ b/internal/cmd/skupper/token/token_test.go
@@ -26,7 +26,6 @@ func TestCmdTokenFactory(t *testing.T) {
 				common.FlagNameTimeout:            "1m0s",
 				common.FlagNameExpirationWindow:   "15m0s",
 				common.FlagNameRedemptionsAllowed: "1",
-				common.FlagNameToken:              "",
 				common.FlagNameCost:               "1",
 			},
 			command: CmdTokenIssueFactory(types.PlatformKubernetes),


### PR DESCRIPTION
This pull request aligns the Refdog documentation with the actual CLI.
In [Refdog](https://skupperproject.github.io/refdog/commands/token/issue.html), the `token issue` command does not have a flag add a specific name for the AccessGrant.

In a related issue, the user tries to create a token for second time specifying the same name, not supported by Refdog: #1919 