### PR TITLE
imrpoved handing of conflict between multiple controllers

### DIFF
--- a/config/overlays/namespace/config.yaml
+++ b/config/overlays/namespace/config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skupper
+data:
+  controller: skupper-controller

--- a/config/overlays/namespace/kustomization.yaml
+++ b/config/overlays/namespace/kustomization.yaml
@@ -1,6 +1,7 @@
 # Reference the base deployment
 resources:
   - ../../base
+  - config.yaml
   - role.yaml
   - role_binding.yaml
 

--- a/internal/kube/client/controller.go
+++ b/internal/kube/client/controller.go
@@ -1750,3 +1750,16 @@ func (w *AttachedConnectorWatcher) List() []*skupperv2alpha1.AttachedConnector {
 	}
 	return results
 }
+
+func FilterByNamespace[V any](match func(string) bool, handler func(string, V) error) func(string, V) error {
+	if match == nil {
+		return handler
+	}
+	return func(key string, value V) error {
+		namespace, _, _ := cache.SplitMetaNamespaceKey(key)
+		if match(namespace) {
+			return handler(key, value)
+		}
+		return nil
+	}
+}

--- a/internal/kube/controller/config.go
+++ b/internal/kube/controller/config.go
@@ -11,21 +11,21 @@ import (
 )
 
 type Config struct {
-	GrantConfig         *grants.GrantConfig
-	SecuredAccessConfig *securedaccess.Config
-	Namespace           string
-	Kubeconfig          string
-	WatchNamespace      string
-	Name                string
-	RequireAnnotation   bool
+	GrantConfig            *grants.GrantConfig
+	SecuredAccessConfig    *securedaccess.Config
+	Namespace              string
+	Kubeconfig             string
+	WatchNamespace         string
+	Name                   string
+	RequireExplicitControl bool
 }
 
 func (c *Config) WatchingAllNamespaces() bool {
 	return c.WatchNamespace == metav1.NamespaceAll
 }
 
-func (c *Config) sitesRequireAnnotation() bool {
-	return !c.WatchingAllNamespaces() || c.RequireAnnotation
+func (c *Config) requireExplicitControl() bool {
+	return !c.WatchingAllNamespaces() || c.RequireExplicitControl
 }
 
 func BoundConfig(flags *flag.FlagSet) (*Config, error) {
@@ -47,6 +47,6 @@ func BoundConfig(flags *flag.FlagSet) (*Config, error) {
 	iflag.StringVar(flags, &c.Kubeconfig, "kubeconfig", "KUBECONFIG", "", "A path to the kubeconfig file to use")
 	iflag.StringVar(flags, &c.WatchNamespace, "watch-namespace", "WATCH_NAMESPACE", metav1.NamespaceAll, "The Kubernetes namespace the controller should monitor for controlled resources (will monitor all if not specified)")
 	iflag.StringVar(flags, &c.Name, "name", "CONTROLLER_NAME", "", "A name identifying the controller. If not specified it will be deduced from the hostname.")
-	iflag.BoolVar(flags, &c.RequireAnnotation, "sites-require-annotation", "SITES_REQUIRE_ANNOTATION", false, "If set, this controller instance will only process sites with an annotation matching the controller's namespace qualified name")
+	iflag.BoolVar(flags, &c.RequireExplicitControl, "require-explicit-control", "REQUIRE_EXPLICIT_CONTROL", false, "If set, this controller instance will only process resources in which there is a ConfigMap named skupper with an entry 'controller' whose value matches the controller's namespace qualified name. Controllers watching a single namespace require that ConfigMap regardless of this setting.")
 	return c, nil
 }

--- a/internal/kube/controller/controller_test.go
+++ b/internal/kube/controller/controller_test.go
@@ -71,8 +71,11 @@ func TestGeneral(t *testing.T) {
 		},
 		{
 			name: "ignored site",
+			k8sObjects: []runtime.Object{
+				f.configmap("skupper", "test", map[string]string{"controller": "foo/bar"}),
+			},
 			skupperObjects: []runtime.Object{
-				f.annotateForController(f.site("mysite", "test", "", false, false), "foo/bar"),
+				f.site("mysite", "test", "", false, false),
 			},
 			expectedSiteStatuses: []*skupperv2alpha1.Site{
 				f.siteStatus("mysite", "test", "", ""),
@@ -84,8 +87,11 @@ func TestGeneral(t *testing.T) {
 				"NAMESPACE":       "foo",
 				"CONTROLLER_NAME": "bar",
 			},
+			k8sObjects: []runtime.Object{
+				f.configmap("skupper", "test", map[string]string{"controller": "foo/bar"}),
+			},
 			skupperObjects: []runtime.Object{
-				f.annotateForController(f.site("mysite", "test", "", false, false), "foo/bar"),
+				f.site("mysite", "test", "", false, false),
 			},
 			expectedSiteStatuses: []*skupperv2alpha1.Site{
 				f.addControllerToStatus(
@@ -684,14 +690,6 @@ func (*factory) site(name string, namespace string, linkAccess string, ha bool, 
 			Edge:       edge,
 		},
 	}
-}
-
-func (*factory) annotateForController(site *skupperv2alpha1.Site, controller string) *skupperv2alpha1.Site {
-	if site.ObjectMeta.Annotations == nil {
-		site.ObjectMeta.Annotations = map[string]string{}
-	}
-	site.ObjectMeta.Annotations["skupper.io/controller"] = controller
-	return site
 }
 
 func (*factory) listener(name string, namespace string, host string, port int) *skupperv2alpha1.Listener {
@@ -1345,6 +1343,16 @@ func (*factory) networkStatusInfo(name string, namespace string, listeners map[s
 		sites: map[string]*network.SiteStatusInfo{},
 	}
 	return n.site(name, namespace, listeners, connectors)
+}
+
+func (*factory) configmap(name string, namespace string, data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: data,
+	}
 }
 
 var f factory

--- a/internal/kube/controller/namespaces.go
+++ b/internal/kube/controller/namespaces.go
@@ -1,0 +1,159 @@
+package controller
+
+import (
+	"log/slog"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	internalclient "github.com/skupperproject/skupper/internal/kube/client"
+)
+
+const (
+	namespaceConfigName  = "skupper"
+	controllerSettingKey = "controller"
+)
+
+type NamespaceConfig struct {
+	config                 map[string]*corev1.ConfigMap
+	watcher                *internalclient.ConfigMapWatcher
+	controllerName         string
+	requireExplicitControl bool
+	logging                ControlLogging
+}
+
+func newNamespaceConfig(controllerName string, requireExplicitControl bool, logging ControlLogging) *NamespaceConfig {
+	return &NamespaceConfig{
+		config:                 map[string]*corev1.ConfigMap{},
+		controllerName:         controllerName,
+		requireExplicitControl: requireExplicitControl,
+		logging:                logging,
+	}
+}
+
+func (c *NamespaceConfig) update(key string, cm *corev1.ConfigMap) error {
+	if cm == nil {
+		delete(c.config, key)
+		return nil
+	}
+	c.config[key] = cm
+	return nil
+}
+
+func (c *NamespaceConfig) controller(namespace string) (string, bool) {
+	if controller, ok := c.get(namespace, controllerSettingKey); ok {
+		if strings.Contains(controller, "/") {
+			return controller, true
+		}
+		return namespace + "/" + controller, true
+	}
+	return "", false
+}
+
+func (c *NamespaceConfig) isControlled(namespace string) bool {
+	if controller, ok := c.controller(namespace); ok {
+		if controller != c.controllerName {
+			c.logging.NamespaceNotControlled(namespace, controller)
+			return false
+		}
+		return true
+	}
+	if c.requireExplicitControl {
+		c.logging.NamespaceNotControlled(namespace, "")
+		return false
+	}
+	return true
+}
+
+func (c *NamespaceConfig) get(namespace string, setting string) (string, bool) {
+	key := namespace + "/" + namespaceConfigName
+	cm, ok := c.config[key]
+	if !ok {
+		return "", false
+	}
+	value, ok := cm.Data[setting]
+	return value, ok
+}
+
+func (c *NamespaceConfig) watch(controller *internalclient.Controller, namespace string) {
+	options := func(options *metav1.ListOptions) {
+		options.FieldSelector = "metadata.name=" + namespaceConfigName
+	}
+	c.watcher = controller.WatchConfigMaps(options, namespace, c.update)
+}
+
+func (c *NamespaceConfig) recover() {
+	if c.watcher != nil {
+		for _, config := range c.watcher.List() {
+			c.update(config.Namespace+"/"+config.Name, config)
+		}
+	}
+}
+
+type ControlLogging interface {
+	NamespaceNotControlled(namespace string, actualControllerName string)
+}
+
+type OneTimeControlLogging struct {
+	logged map[string]string
+	impl   ControlLogging
+}
+
+type ClusterScopedControlLogging struct {
+	log *slog.Logger
+}
+
+type NamespaceScopedControlLogging struct {
+	log *slog.Logger
+}
+
+func (l *ClusterScopedControlLogging) NamespaceNotControlled(namespace string, actualControllerName string) {
+	if actualControllerName != "" {
+		l.log.Info("Ignoring resources in namespace controlled by another controller",
+			slog.String("namespace", namespace),
+			slog.String("controlled-by", actualControllerName),
+		)
+	} else {
+		l.log.Info("Ignoring resources in uncontrolled namespace",
+			slog.String("namespace", namespace),
+		)
+	}
+}
+
+func (l *NamespaceScopedControlLogging) NamespaceNotControlled(namespace string, actualControllerName string) {
+	if actualControllerName != "" {
+		l.log.Warn("Ignoring all resources as this namespace is controlled by another controller",
+			slog.String("namespace", namespace),
+			slog.String("controlled-by", actualControllerName),
+		)
+	} else {
+		l.log.Warn("Ignoring all resources as this namespace has no controller assigned",
+			slog.String("namespace", namespace),
+		)
+	}
+}
+
+func (l *OneTimeControlLogging) NamespaceNotControlled(namespace string, actualControllerName string) {
+	if controller, ok := l.logged[namespace]; !ok || controller != actualControllerName {
+		l.logged[namespace] = actualControllerName
+		l.impl.NamespaceNotControlled(namespace, actualControllerName)
+	}
+}
+
+func newControlLogging(clusterScoped bool, log *slog.Logger) ControlLogging {
+	var impl ControlLogging
+	if clusterScoped {
+		impl = &ClusterScopedControlLogging{
+			log: log,
+		}
+	} else {
+		impl = &NamespaceScopedControlLogging{
+			log: log,
+		}
+	}
+	return &OneTimeControlLogging{
+		logged: map[string]string{},
+		impl:   impl,
+	}
+}

--- a/internal/kube/grants/init.go
+++ b/internal/kube/grants/init.go
@@ -4,11 +4,11 @@ import (
 	internalclient "github.com/skupperproject/skupper/internal/kube/client"
 )
 
-func Initialise(controller *internalclient.Controller, currentNamespace string, watchNamespace string, config *GrantConfig, generator GrantResponse) func() {
+func Initialise(controller *internalclient.Controller, currentNamespace string, watchNamespace string, config *GrantConfig, generator GrantResponse, filter NamespaceFilter) func() {
 	if !config.Enabled {
 		disabled(controller, watchNamespace)
 		return nil
 	}
-	ge := enabled(controller, currentNamespace, watchNamespace, config, generator)
+	ge := enabled(controller, currentNamespace, watchNamespace, config, generator, filter)
 	return ge.Start
 }

--- a/internal/kube/grants/init_test.go
+++ b/internal/kube/grants/init_test.go
@@ -77,7 +77,7 @@ func Test_Initialise(t *testing.T) {
 			}
 			controller := internalclient.NewController("Controller", client)
 
-			start := Initialise(controller, "test", metav1.NamespaceAll, &tt.config, nil)
+			start := Initialise(controller, "test", metav1.NamespaceAll, &tt.config, nil, nil)
 			if tt.endpoint != nil {
 				err = updateSecuredAccessEndpoint(controller, "skupper-grant-server", "test", tt.endpoint)
 				if err != nil {

--- a/internal/kube/securedaccess/access.go
+++ b/internal/kube/securedaccess/access.go
@@ -25,10 +25,11 @@ type AccessType interface {
 	RealiseAndResolve(access *skupperv2alpha1.SecuredAccess, service *corev1.Service) ([]skupperv2alpha1.Endpoint, error)
 }
 
-type ControllerContext struct {
-	Namespace string
-	Name      string
-	UID       string
+type ControllerContext interface {
+	IsControlled(namespace string) bool
+	Namespace() string
+	Name() string
+	UID() string
 }
 
 type SecuredAccessManager struct {
@@ -43,6 +44,7 @@ type SecuredAccessManager struct {
 	enabledAccessTypes map[string]AccessType
 	defaultAccessType  string
 	gatewayInit        func() error
+	context            ControllerContext
 }
 
 func NewSecuredAccessManager(clients internalclient.Clients, certMgr certificates.CertificateManager, config *Config, context ControllerContext) *SecuredAccessManager {
@@ -57,6 +59,7 @@ func NewSecuredAccessManager(clients internalclient.Clients, certMgr certificate
 		certMgr:            certMgr,
 		enabledAccessTypes: map[string]AccessType{},
 		defaultAccessType:  config.getDefaultAccessType(clients),
+		context:            context,
 	}
 	for _, accessType := range config.EnabledAccessTypes {
 		if accessType == ACCESS_TYPE_ROUTE {

--- a/internal/kube/securedaccess/access_test.go
+++ b/internal/kube/securedaccess/access_test.go
@@ -1828,7 +1828,7 @@ func TestSecuredAccessGeneral(t *testing.T) {
 				assert.Assert(t, tt.ssaRecorder.enable(client.GetDynamicClient()))
 			}
 			certs := newMockCertificateManager()
-			m := NewSecuredAccessManager(client, certs, &tt.config, ControllerContext{Namespace: "test"})
+			m := NewSecuredAccessManager(client, certs, &tt.config, &FakeControllerContext{namespace: "test"})
 
 			err = m.Ensure(tt.definition.Namespace, tt.definition.Name, tt.definition.Spec, nil, nil)
 			if tt.expectedError != "" {
@@ -2378,7 +2378,7 @@ func TestSecuredAccessDeleted(t *testing.T) {
 				e.Prepend(client)
 			}
 			certs := newMockCertificateManager()
-			m := NewSecuredAccessManager(client, certs, &tt.config, ControllerContext{Namespace: "test"})
+			m := NewSecuredAccessManager(client, certs, &tt.config, &FakeControllerContext{namespace: "test"})
 			w := NewSecuredAccessResourceWatcher(m)
 			controller := internalclient.NewController("Controller", client)
 			w.WatchResources(controller, metav1.NamespaceAll)
@@ -3451,7 +3451,7 @@ func TestRecreateOnDelete(t *testing.T) {
 			ssaRecorder := newServerSideApplyRecorder()
 			assert.Assert(t, ssaRecorder.enable(client.GetDynamicClient()))
 			certs := newMockCertificateManager()
-			m := NewSecuredAccessManager(client, certs, &tt.config, ControllerContext{Namespace: "test"})
+			m := NewSecuredAccessManager(client, certs, &tt.config, &FakeControllerContext{namespace: "test"})
 			w := NewSecuredAccessResourceWatcher(m)
 			controller := internalclient.NewController("Controller", client)
 			w.WatchResources(controller, metav1.NamespaceAll)
@@ -3528,4 +3528,26 @@ func TestRecreateOnDelete(t *testing.T) {
 			}
 		})
 	}
+}
+
+type FakeControllerContext struct {
+	name      string
+	namespace string
+	uid       string
+}
+
+func (c *FakeControllerContext) IsControlled(namespace string) bool {
+	return true
+}
+
+func (c *FakeControllerContext) Namespace() string {
+	return c.namespace
+}
+
+func (c *FakeControllerContext) Name() string {
+	return c.name
+}
+
+func (c *FakeControllerContext) UID() string {
+	return c.uid
 }

--- a/internal/kube/securedaccess/gateway.go
+++ b/internal/kube/securedaccess/gateway.go
@@ -52,14 +52,16 @@ type GatewayAccessType struct {
 
 func newGatewayAccess(manager *SecuredAccessManager, class string, domain string, port int, context ControllerContext) (AccessType, func() error, error) {
 	at := &GatewayAccessType{
-		manager:          manager,
-		class:            class,
-		domain:           domain,
-		port:             port,
-		gatewayNamespace: context.Namespace,
-		controllerName:   context.Name,
-		controllerUID:    context.UID,
-		unreconciled:     map[string]*skupperv2alpha1.SecuredAccess{},
+		manager:      manager,
+		class:        class,
+		domain:       domain,
+		port:         port,
+		unreconciled: map[string]*skupperv2alpha1.SecuredAccess{},
+	}
+	if context != nil {
+		at.gatewayNamespace = context.Namespace()
+		at.controllerName = context.Name()
+		at.controllerUID = context.UID()
 	}
 	if err := at.init(); err != nil {
 		return nil, nil, err

--- a/internal/kube/securedaccess/watchers_test.go
+++ b/internal/kube/securedaccess/watchers_test.go
@@ -694,7 +694,7 @@ func TestSecuredAccessRecovery(t *testing.T) {
 				e.Prepend(client)
 			}
 			certs := newMockCertificateManager()
-			m := NewSecuredAccessManager(client, certs, &tt.config, ControllerContext{Namespace: "test"})
+			m := NewSecuredAccessManager(client, certs, &tt.config, &FakeControllerContext{namespace: "test"})
 			w := NewSecuredAccessResourceWatcher(m)
 			controller := internalclient.NewController("Controller", client)
 			w.WatchResources(controller, metav1.NamespaceAll)
@@ -1197,7 +1197,7 @@ func TestGateway(t *testing.T) {
 				assert.Assert(t, tt.ssaRecorder.enable(client.GetDynamicClient()))
 			}
 			certs := newMockCertificateManager()
-			m := NewSecuredAccessManager(client, certs, &tt.config, ControllerContext{Namespace: tt.namespace})
+			m := NewSecuredAccessManager(client, certs, &tt.config, &FakeControllerContext{namespace: tt.namespace})
 			w := NewSecuredAccessResourceWatcher(m)
 			controller := internalclient.NewController("Controller", client)
 			w.WatchResources(controller, metav1.NamespaceAll)

--- a/internal/kube/site/site_test.go
+++ b/internal/kube/site/site_test.go
@@ -1045,7 +1045,7 @@ func newSiteMocks(namespace string, k8sObjects []runtime.Object, skupperObjects 
 		errors:     make(map[string]string),
 		linkAccess: make(map[string]*skupperv2alpha1.RouterAccess),
 		certs:      certificates.NewCertificateManager(controller),
-		access:     securedaccess.NewSecuredAccessManager(client, nil, &securedaccess.Config{DefaultAccessType: "loadbalancer"}, securedaccess.ControllerContext{}),
+		access:     securedaccess.NewSecuredAccessManager(client, nil, &securedaccess.Config{DefaultAccessType: "loadbalancer"}, nil),
 		routerPods: make(map[string]*corev1.Pod),
 		logger: slog.New(slog.Default().Handler()).With(
 			slog.String("component", "kube.site.site"),


### PR DESCRIPTION
Introduce a namespace level skupper setting that determines which controller should control that namespace. This allows a simpler way to handle multiple controllers on a cluster.

Namespace level settings are specified through a ConfigMap in the namespace called 'skupper'. The only currently recognised setting has key 'controller'. The value for this is the controller name, optionally qualified by a namespace if the controller is running in a different namespace from the site, indicating the controller that has control over this namespace.

Namespace scoped controllers must always set this configuration. Cluster scoped controllers will assume they can control any namespace that doesn't contain an explicit configuration for a different controller.

If operating multiple cluster scoped controllers on the same controller, all but one of them should set the -require-explicit-control argument to true.