### PR TITLE
add shortnames to common types

### DIFF
--- a/config/crd/bases/skupper_access_grant_crd.yaml
+++ b/config/crd/bases/skupper_access_grant_crd.yaml
@@ -110,3 +110,6 @@ spec:
     plural: accessgrants
     singular: accessgrant
     kind: AccessGrant
+    shortNames:
+    - grant
+    - gr

--- a/config/crd/bases/skupper_access_grant_crd.yaml
+++ b/config/crd/bases/skupper_access_grant_crd.yaml
@@ -10,6 +10,7 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          description: "Permission to redeem access tokens for links to the local site"
           type: object
           properties:
             spec:

--- a/config/crd/bases/skupper_access_token_crd.yaml
+++ b/config/crd/bases/skupper_access_token_crd.yaml
@@ -10,6 +10,7 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          description: "A short-lived credential used to create a link"
           type: object
           properties:
             spec:

--- a/config/crd/bases/skupper_access_token_crd.yaml
+++ b/config/crd/bases/skupper_access_token_crd.yaml
@@ -100,3 +100,6 @@ spec:
     plural: accesstokens
     singular: accesstoken
     kind: AccessToken
+    shortNames:
+    - token
+    - to

--- a/config/crd/bases/skupper_attached_connector_binding_crd.yaml
+++ b/config/crd/bases/skupper_attached_connector_binding_crd.yaml
@@ -10,6 +10,7 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          description: "A binding to an attached connector in a peer namespace"
           type: object
           properties:
             spec:

--- a/config/crd/bases/skupper_attached_connector_binding_crd.yaml
+++ b/config/crd/bases/skupper_attached_connector_binding_crd.yaml
@@ -95,3 +95,5 @@ spec:
     plural: attachedconnectorbindings
     singular: attachedconnectorbinding
     kind: AttachedConnectorBinding
+    shortNames:
+    - acrb

--- a/config/crd/bases/skupper_attached_connector_binding_crd.yaml
+++ b/config/crd/bases/skupper_attached_connector_binding_crd.yaml
@@ -96,4 +96,4 @@ spec:
     singular: attachedconnectorbinding
     kind: AttachedConnectorBinding
     shortNames:
-    - acrb
+    - acnrb

--- a/config/crd/bases/skupper_attached_connector_crd.yaml
+++ b/config/crd/bases/skupper_attached_connector_crd.yaml
@@ -10,6 +10,7 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          description: "A connector in a peer namespace"
           type: object
           properties:
             spec:

--- a/config/crd/bases/skupper_attached_connector_crd.yaml
+++ b/config/crd/bases/skupper_attached_connector_crd.yaml
@@ -110,4 +110,4 @@ spec:
     singular: attachedconnector
     kind: AttachedConnector
     shortNames:
-    - acr
+    - acnr

--- a/config/crd/bases/skupper_attached_connector_crd.yaml
+++ b/config/crd/bases/skupper_attached_connector_crd.yaml
@@ -109,3 +109,5 @@ spec:
     plural: attachedconnectors
     singular: attachedconnector
     kind: AttachedConnector
+    shortNames:
+    - acr

--- a/config/crd/bases/skupper_certificate_crd.yaml
+++ b/config/crd/bases/skupper_certificate_crd.yaml
@@ -10,6 +10,7 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          description: "An internal resource used to indicate TLS credentials to be created"
           type: object
           properties:
             spec:

--- a/config/crd/bases/skupper_connector_crd.yaml
+++ b/config/crd/bases/skupper_connector_crd.yaml
@@ -10,6 +10,7 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          description: "A connector binds a local workload to listeners in remote sites"
           type: object
           properties:
             spec:

--- a/config/crd/bases/skupper_connector_crd.yaml
+++ b/config/crd/bases/skupper_connector_crd.yaml
@@ -138,4 +138,4 @@ spec:
     singular: connector
     kind: Connector
     shortNames:
-    - cr
+    - cnr

--- a/config/crd/bases/skupper_connector_crd.yaml
+++ b/config/crd/bases/skupper_connector_crd.yaml
@@ -137,3 +137,5 @@ spec:
     plural: connectors
     singular: connector
     kind: Connector
+    shortNames:
+    - cr

--- a/config/crd/bases/skupper_link_crd.yaml
+++ b/config/crd/bases/skupper_link_crd.yaml
@@ -10,6 +10,7 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          description: "A link is a channel for communication between sites"
           type: object
           properties:
             spec:

--- a/config/crd/bases/skupper_link_crd.yaml
+++ b/config/crd/bases/skupper_link_crd.yaml
@@ -105,3 +105,5 @@ spec:
     plural: links
     singular: link
     kind: Link
+    shortNames:
+    - ln

--- a/config/crd/bases/skupper_listener_crd.yaml
+++ b/config/crd/bases/skupper_listener_crd.yaml
@@ -113,4 +113,4 @@ spec:
     singular: listener
     kind: Listener
     shortNames:
-    - lr
+    - lnr

--- a/config/crd/bases/skupper_listener_crd.yaml
+++ b/config/crd/bases/skupper_listener_crd.yaml
@@ -10,6 +10,7 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          description: "A listener binds a local connection endpoint to connectors in remote sites"
           type: object
           properties:
             spec:

--- a/config/crd/bases/skupper_listener_crd.yaml
+++ b/config/crd/bases/skupper_listener_crd.yaml
@@ -112,3 +112,5 @@ spec:
     plural: listeners
     singular: listener
     kind: Listener
+    shortNames:
+    - lr

--- a/config/crd/bases/skupper_router_access_crd.yaml
+++ b/config/crd/bases/skupper_router_access_crd.yaml
@@ -10,6 +10,7 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          description: "Configuration for secure access to the site router"
           type: object
           properties:
             spec:

--- a/config/crd/bases/skupper_secured_access_crd.yaml
+++ b/config/crd/bases/skupper_secured_access_crd.yaml
@@ -10,6 +10,7 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          description: "An internal resource used to create secure access to pods"
           type: object
           properties:
             spec:

--- a/config/crd/bases/skupper_site_crd.yaml
+++ b/config/crd/bases/skupper_site_crd.yaml
@@ -10,6 +10,7 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          description: "A site is a place on the network where application workloads are running"
           type: object
           properties:
             spec:

--- a/config/crd/bases/skupper_site_crd.yaml
+++ b/config/crd/bases/skupper_site_crd.yaml
@@ -161,3 +161,5 @@ spec:
     plural: sites
     singular: site
     kind: Site
+    shortNames:
+    - st


### PR DESCRIPTION
Fixes #1956.

Note that certificaterequests from the cert-manager.io api also use cr as a shortname which on my cluster takes precedence. The other shortnames work unqualified on the cluster I tested on though.