### PR TITLE
[v2] Add check that linkaccess enabled before allowing token to be created

### DIFF
--- a/internal/cmd/skupper/common/utils/status.go
+++ b/internal/cmd/skupper/common/utils/status.go
@@ -21,3 +21,12 @@ func SiteReady(siteList *v2alpha1.SiteList) (bool, string) {
 	}
 	return false, ""
 }
+
+func SiteLinkAccessEnabled(siteList *v2alpha1.SiteList) (bool, string) {
+	for _, s := range siteList.Items {
+		if s.Spec.LinkAccess == "default" {
+			return true, s.Name
+		}
+	}
+	return false, ""
+}

--- a/internal/cmd/skupper/common/utils/status.go
+++ b/internal/cmd/skupper/common/utils/status.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"github.com/skupperproject/skupper/internal/utils/validator"
 	"github.com/skupperproject/skupper/pkg/apis/skupper/v2alpha1"
 )
 
@@ -22,9 +23,11 @@ func SiteReady(siteList *v2alpha1.SiteList) (bool, string) {
 	return false, ""
 }
 
-func SiteLinkAccessEnabled(siteList *v2alpha1.SiteList) (bool, string) {
+func SiteLinkAccessEnabled(siteList *v2alpha1.SiteList, linkAccessTypes []string) (bool, string) {
+	linkAccessTypeValidator := validator.NewOptionValidator(linkAccessTypes)
 	for _, s := range siteList.Items {
-		if s.Spec.LinkAccess == "default" {
+		ok, _ := linkAccessTypeValidator.Evaluate(s.Spec.LinkAccess)
+		if ok {
 			return true, s.Name
 		}
 	}

--- a/internal/cmd/skupper/token/kube/token_issue.go
+++ b/internal/cmd/skupper/token/kube/token_issue.go
@@ -80,9 +80,9 @@ func (cmd *CmdTokenIssue) ValidateInput(args []string) error {
 		if !ok {
 			validationErrors = append(validationErrors, fmt.Errorf("there is no active skupper site in this namespace"))
 		} else {
-			ok, siteName = utils.SiteLinkAccessEnabled(siteList)
+			ok, siteName = utils.SiteLinkAccessEnabled(siteList, common.LinkAccessTypes)
 			if !ok {
-				validationErrors = append(validationErrors, fmt.Errorf("A site must have link access enabled before a token can be created"))
+				validationErrors = append(validationErrors, fmt.Errorf("You must enable link access for this site before you can create a token."))
 			} else {
 				cmd.grantName = siteName + "-" + uuid.New().String()
 			}

--- a/internal/cmd/skupper/token/kube/token_issue.go
+++ b/internal/cmd/skupper/token/kube/token_issue.go
@@ -80,7 +80,12 @@ func (cmd *CmdTokenIssue) ValidateInput(args []string) error {
 		if !ok {
 			validationErrors = append(validationErrors, fmt.Errorf("there is no active skupper site in this namespace"))
 		} else {
-			cmd.grantName = siteName + "-" + uuid.New().String()
+			ok, siteName = utils.SiteLinkAccessEnabled(siteList)
+			if !ok {
+				validationErrors = append(validationErrors, fmt.Errorf("A site must have link access enabled before a token can be created"))
+			} else {
+				cmd.grantName = siteName + "-" + uuid.New().String()
+			}
 		}
 	}
 

--- a/internal/cmd/skupper/token/kube/token_issue_test.go
+++ b/internal/cmd/skupper/token/kube/token_issue_test.go
@@ -105,6 +105,9 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 								Name:      "site1",
 								Namespace: "test",
 							},
+							Spec: v2alpha1.SiteSpec{
+								LinkAccess: "default",
+							},
 							Status: v2alpha1.SiteStatus{
 								Status: v2alpha1.Status{
 									Conditions: []v1.Condition{
@@ -145,6 +148,9 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 							ObjectMeta: v1.ObjectMeta{
 								Name:      "site1",
 								Namespace: "test",
+							},
+							Spec: v2alpha1.SiteSpec{
+								LinkAccess: "default",
 							},
 							Status: v2alpha1.SiteStatus{
 								Status: v2alpha1.Status{
@@ -187,6 +193,9 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 								Name:      "site1",
 								Namespace: "test",
 							},
+							Spec: v2alpha1.SiteSpec{
+								LinkAccess: "default",
+							},
 							Status: v2alpha1.SiteStatus{
 								Status: v2alpha1.Status{
 									Conditions: []v1.Condition{
@@ -227,6 +236,9 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 							ObjectMeta: v1.ObjectMeta{
 								Name:      "site1",
 								Namespace: "test",
+							},
+							Spec: v2alpha1.SiteSpec{
+								LinkAccess: "default",
 							},
 							Status: v2alpha1.SiteStatus{
 								Status: v2alpha1.Status{
@@ -269,6 +281,9 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 								Name:      "site1",
 								Namespace: "test",
 							},
+							Spec: v2alpha1.SiteSpec{
+								LinkAccess: "default",
+							},
 							Status: v2alpha1.SiteStatus{
 								Status: v2alpha1.Status{
 									Conditions: []v1.Condition{
@@ -309,6 +324,9 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 							ObjectMeta: v1.ObjectMeta{
 								Name:      "site1",
 								Namespace: "test",
+							},
+							Spec: v2alpha1.SiteSpec{
+								LinkAccess: "default",
 							},
 							Status: v2alpha1.SiteStatus{
 								Status: v2alpha1.Status{
@@ -351,6 +369,9 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 								Name:      "site1",
 								Namespace: "test",
 							},
+							Spec: v2alpha1.SiteSpec{
+								LinkAccess: "default",
+							},
 							Status: v2alpha1.SiteStatus{
 								Status: v2alpha1.Status{
 									Conditions: []v1.Condition{
@@ -391,6 +412,9 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 							ObjectMeta: v1.ObjectMeta{
 								Name:      "site1",
 								Namespace: "test",
+							},
+							Spec: v2alpha1.SiteSpec{
+								LinkAccess: "default",
 							},
 							Status: v2alpha1.SiteStatus{
 								Status: v2alpha1.Status{
@@ -433,6 +457,9 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 								Name:      "site1",
 								Namespace: "test",
 							},
+							Spec: v2alpha1.SiteSpec{
+								LinkAccess: "default",
+							},
 							Status: v2alpha1.SiteStatus{
 								Status: v2alpha1.Status{
 									Conditions: []v1.Condition{
@@ -458,6 +485,47 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 			expectedError: `link cost is not valid: strconv.Atoi: parsing "Not-valid": invalid syntax`,
 		},
 		{
+			name: "linkaccess is not valid",
+			args: []string{"~/token.yaml"},
+			flags: common.CommandTokenIssueFlags{
+				ExpirationWindow:   15 * time.Minute,
+				RedemptionsAllowed: 1,
+				Timeout:            60 * time.Second,
+				Cost:               "1",
+			},
+			skupperObjects: []runtime.Object{
+				&v2alpha1.SiteList{
+					Items: []v2alpha1.Site{
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name:      "site1",
+								Namespace: "test",
+							},
+							Status: v2alpha1.SiteStatus{
+								Status: v2alpha1.Status{
+									Conditions: []v1.Condition{
+										{
+											Type:   "Configured",
+											Status: "True",
+										},
+										{
+											Type:   "Running",
+											Status: "True",
+										},
+										{
+											Type:   "Ready",
+											Status: "True",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: `A site must have link access enabled before a token can be created`,
+		},
+		{
 			name: "flags all valid",
 			args: []string{"~/token.yaml"},
 			flags: common.CommandTokenIssueFlags{
@@ -473,6 +541,9 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 							ObjectMeta: v1.ObjectMeta{
 								Name:      "site1",
 								Namespace: "test",
+							},
+							Spec: v2alpha1.SiteSpec{
+								LinkAccess: "default",
 							},
 							Status: v2alpha1.SiteStatus{
 								Status: v2alpha1.Status{

--- a/internal/cmd/skupper/token/kube/token_issue_test.go
+++ b/internal/cmd/skupper/token/kube/token_issue_test.go
@@ -150,7 +150,7 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 								Namespace: "test",
 							},
 							Spec: v2alpha1.SiteSpec{
-								LinkAccess: "default",
+								LinkAccess: "loadbalancer",
 							},
 							Status: v2alpha1.SiteStatus{
 								Status: v2alpha1.Status{
@@ -282,7 +282,7 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 								Namespace: "test",
 							},
 							Spec: v2alpha1.SiteSpec{
-								LinkAccess: "default",
+								LinkAccess: "route",
 							},
 							Status: v2alpha1.SiteStatus{
 								Status: v2alpha1.Status{
@@ -485,7 +485,7 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 			expectedError: `link cost is not valid: strconv.Atoi: parsing "Not-valid": invalid syntax`,
 		},
 		{
-			name: "linkaccess is not valid",
+			name: "link access is not valid",
 			args: []string{"~/token.yaml"},
 			flags: common.CommandTokenIssueFlags{
 				ExpirationWindow:   15 * time.Minute,
@@ -523,7 +523,7 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 					},
 				},
 			},
-			expectedError: `A site must have link access enabled before a token can be created`,
+			expectedError: `You must enable link access for this site before you can create a token.`,
 		},
 		{
 			name: "flags all valid",

--- a/internal/cmd/skupper/token/kube/token_redeem.go
+++ b/internal/cmd/skupper/token/kube/token_redeem.go
@@ -131,7 +131,6 @@ func (cmd *CmdTokenRedeem) WaitUntil() error {
 	}
 
 	fmt.Printf("Token %q has been redeemed\n", cmd.name)
-	fmt.Printf("You can now safely delete %s\n", cmd.fileName)
 	return nil
 }
 


### PR DESCRIPTION
Added check that linkaccess is enabled in the site before allowing token to be created, otherwise
the token is created but cannot be used and will lead to confusion by the user.