### PR TITLE
Added s390x architecture to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TEST_IMAGE := quay.io/skupper/skupper-tests
 TEST_BINARIES_FOLDER := ${PWD}/test/integration/bin
 DOCKER := docker
 LDFLAGS := -X github.com/skupperproject/skupper/pkg/version.Version=${VERSION}
-PLATFORMS ?= linux/amd64,linux/arm64
+PLATFORMS ?= linux/amd64,linux/arm64,linux/s390x 
 GOOS ?= linux
 GOARCH ?= amd64
 

--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -86,7 +86,7 @@ SKOPEO = skopeo
 # That is required for their use with Openshift 3.11
 FORMAT_OPTIONS = --format docker
 TRANSFORM_OPTIONS = --format v2s2
-PLATFORM = linux/amd64,linux/arm64
+PLATFORM = linux/amd64,linux/arm64,linux/s390x
 
 # Repositories
 MAIN_REPO = quay.io/skupper


### PR DESCRIPTION
Please review this PR. This is to ensure the skupper-tests image is build for s390x.
Also, please build the following images for s390x and push it to the quay :
iperf3
nghttp2
hey
cc: @hash-d 