### PR TITLE
Add ability to configure labels and annotations on created resources

### DIFF
--- a/internal/kube/client/controller.go
+++ b/internal/kube/client/controller.go
@@ -60,12 +60,6 @@ type ResourceChangeHandler interface {
 	Describe(event ResourceChange) string
 }
 
-func ListByName(name string) internalinterfaces.TweakListOptionsFunc {
-	return func(options *metav1.ListOptions) {
-		options.FieldSelector = "metadata.name=" + name
-	}
-}
-
 func ListByLabelSelector(selector string) internalinterfaces.TweakListOptionsFunc {
 	return func(options *metav1.ListOptions) {
 		options.LabelSelector = selector

--- a/internal/kube/securedaccess/tls-route.yaml
+++ b/internal/kube/securedaccess/tls-route.yaml
@@ -5,6 +5,17 @@ metadata:
   labels:
     internal.skupper.io/securedaccess: {{ .ServiceName }}
     internal.skupper.io/controlled: "true"
+{{- if .Labels }}
+{{- range $key, $value := .Labels }}
+    {{ $key }}: {{$value -}}
+{{- end }}
+{{- end }}
+{{- if .Annotations }}
+  annotations:
+{{- range $key, $value := .Annotations }}
+    {{ $key }}: {{$value -}}
+{{- end }}
+{{- end }}
   ownerReferences:
   - apiVersion: skupper.io/v2alpha1
     kind: SecuredAccess

--- a/internal/kube/site/labels/registry.go
+++ b/internal/kube/site/labels/registry.go
@@ -1,0 +1,178 @@
+package labels
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type LabelsAndAnnotations struct {
+	namespaces          map[string]*Registry
+	controllerNamespace string
+}
+
+func NewLabelsAndAnnotations(controllerNamespace string) *LabelsAndAnnotations {
+	if controllerNamespace == "" {
+		controllerNamespace = "default"
+	}
+	return &LabelsAndAnnotations{
+		namespaces:          map[string]*Registry{},
+		controllerNamespace: controllerNamespace,
+	}
+}
+
+func (l *LabelsAndAnnotations) Update(key string, cm *corev1.ConfigMap) error {
+	namespace, _, _ := cache.SplitMetaNamespaceKey(key)
+	if existing, ok := l.namespaces[namespace]; ok {
+		return existing.update(key, cm)
+	} else if cm != nil {
+		created := newRegistry()
+		l.namespaces[namespace] = created
+		return created.update(key, cm)
+	}
+	return nil
+}
+
+func (l *LabelsAndAnnotations) SetLabels(namespace string, name string, kind string, labels map[string]string) bool {
+	desired := map[string]string{}
+	if registry, ok := l.namespaces[namespace]; ok {
+		registry.setLabels(name, kind, desired)
+	}
+	if namespace != l.controllerNamespace {
+		if registry, ok := l.namespaces[l.controllerNamespace]; ok {
+			registry.setLabels(name, kind, desired)
+		}
+	}
+	return setValues(desired, labels)
+}
+
+func (l *LabelsAndAnnotations) SetAnnotations(namespace string, name string, kind string, annotations map[string]string) bool {
+	desired := map[string]string{}
+	if registry, ok := l.namespaces[namespace]; ok {
+		registry.setAnnotations(name, kind, desired)
+	}
+	if namespace != l.controllerNamespace {
+		if registry, ok := l.namespaces[l.controllerNamespace]; ok {
+			registry.setAnnotations(name, kind, desired)
+		}
+	}
+	return setValues(desired, annotations)
+}
+
+type Registry struct {
+	config map[string]*corev1.ConfigMap
+}
+
+func newRegistry() *Registry {
+	return &Registry{
+		config: map[string]*corev1.ConfigMap{},
+	}
+}
+
+func (r *Registry) update(key string, cm *corev1.ConfigMap) error {
+	_, ok := label(cm, "skupper.io/label-template")
+	if !ok {
+		delete(r.config, key)
+		return nil
+	}
+	r.config[key] = cm
+	return nil
+}
+
+func (r *Registry) setLabels(name string, kind string, labels map[string]string) bool {
+	return r.filter(name, kind, labels, nil)
+}
+
+func (r *Registry) setAnnotations(name string, kind string, annotations map[string]string) bool {
+	return r.filter(name, kind, nil, annotations)
+}
+
+func (r *Registry) filter(name string, kind string, labels map[string]string, annotations map[string]string) bool {
+	changed := false
+	for _, cm := range r.config {
+		if !matchKey(cm, "name", name) {
+			continue
+		}
+		if !matchKey(cm, "kind", kind) {
+			continue
+		}
+		excludes := exclude(cm)
+		if labels != nil {
+			for k, v := range cm.ObjectMeta.Labels {
+				if isExcluded(k, excludes) {
+					continue
+				}
+				if v2, ok := labels[k]; !ok || v != v2 {
+					labels[k] = v
+					changed = true
+				}
+			}
+		}
+		if annotations != nil {
+			for k, v := range cm.ObjectMeta.Annotations {
+				if isExcluded(k, excludes) {
+					continue
+				}
+				if v2, ok := labels[k]; !ok || v != v2 {
+					annotations[k] = v
+					changed = true
+				}
+			}
+		}
+	}
+	return changed
+}
+
+func label(cm *corev1.ConfigMap, key string) (string, bool) {
+	if cm == nil || cm.ObjectMeta.Labels == nil {
+		return "", false
+	}
+	label, ok := cm.ObjectMeta.Labels[key]
+	return label, ok
+}
+
+func matchKey(cm *corev1.ConfigMap, key string, expected string) bool {
+	if cm.Data == nil {
+		return true
+	}
+	actual, ok := cm.Data[key]
+	if !ok {
+		return true
+	}
+	return actual == expected
+}
+
+func exclude(cm *corev1.ConfigMap) []string {
+	if cm.Data == nil {
+		return nil
+	}
+	value, ok := cm.Data["exclude"]
+	if !ok {
+		return nil
+	}
+	return strings.Split(value, ",")
+}
+
+func isExcluded(key string, excluded []string) bool {
+	if key == "skupper.io/label-template" || key == "kubectl.kubernetes.io/last-applied-configuration" {
+		return true
+	}
+	for _, exclude := range excluded {
+		if key == exclude {
+			return true
+		}
+	}
+	return false
+}
+
+func setValues(desired map[string]string, actual map[string]string) bool {
+	changed := false
+	for k, v := range desired {
+		if v2, ok := actual[k]; !ok || v != v2 {
+			actual[k] = v
+			changed = true
+		}
+	}
+	return changed
+}

--- a/internal/kube/site/labels/registry_test.go
+++ b/internal/kube/site/labels/registry_test.go
@@ -1,0 +1,353 @@
+package labels
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"gotest.tools/v3/assert"
+)
+
+type Update struct {
+	key    string
+	config *corev1.ConfigMap
+}
+
+func TestLabels(t *testing.T) {
+	type Expectation struct {
+		namespace   string
+		name        string
+		kind        string
+		labels      map[string]string
+		annotations map[string]string
+	}
+	tests := []struct {
+		name                string
+		controllerNamespace string
+		config              []Update
+		expectations        []Expectation
+	}{
+		{
+			name: "namespace scoped labels matching everything",
+			config: []Update{
+				update("test/labels", map[string]string{"foo": "bar"}, nil, "", ""),
+			},
+			expectations: []Expectation{
+				{
+					namespace: "test",
+					name:      "xyz",
+					kind:      "ConfigMap",
+					labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+		{
+			name:                "namespace scoped annotations matching everything",
+			controllerNamespace: "skupper",
+			config: []Update{
+				update("test/labels", nil, map[string]string{"foo": "bar"}, "", ""),
+			},
+			expectations: []Expectation{
+				{
+					namespace: "test",
+					name:      "xyz",
+					kind:      "ConfigMap",
+					annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+		{
+			name: "controller scoped labels override some entries",
+			config: []Update{
+				update("default/labels", map[string]string{"foo": "baz"}, nil, "", ""),
+				update("test/labels", map[string]string{"foo": "bar", "bing": "bong"}, nil, "", ""),
+			},
+			expectations: []Expectation{
+				{
+					namespace: "test",
+					name:      "xyz",
+					kind:      "ConfigMap",
+					labels: map[string]string{
+						"foo":  "baz",
+						"bing": "bong",
+					},
+				},
+			},
+		},
+		{
+			name: "controller scoped anntations override some entries",
+			config: []Update{
+				update("default/labels", nil, map[string]string{"foo": "baz"}, "", ""),
+				update("test/labels", nil, map[string]string{"foo": "bar", "bing": "bong"}, "", ""),
+			},
+			expectations: []Expectation{
+				{
+					namespace: "test",
+					name:      "xyz",
+					kind:      "ConfigMap",
+					annotations: map[string]string{
+						"foo":  "baz",
+						"bing": "bong",
+					},
+				},
+			},
+		},
+		{
+			name: "update of label configuration",
+			config: []Update{
+				update("test/labels", map[string]string{"foo": "bar"}, nil, "", ""),
+				update("test/labels", map[string]string{"foo": "baz"}, nil, "", ""),
+				update("test/labels", map[string]string{"foo": "baz"}, nil, "", ""),
+			},
+			expectations: []Expectation{
+				{
+					namespace: "test",
+					name:      "xyz",
+					kind:      "ConfigMap",
+					labels: map[string]string{
+						"foo": "baz",
+					},
+				},
+			},
+		},
+		{
+			name: "update of annotation configuration",
+			config: []Update{
+				update("test/annotations", nil, map[string]string{"foo": "bar"}, "", ""),
+				update("test/annotations", nil, map[string]string{"foo": "baz"}, "", ""),
+				update("test/annotations", nil, map[string]string{"foo": "baz"}, "", ""),
+			},
+			expectations: []Expectation{
+				{
+					namespace: "test",
+					name:      "xyz",
+					kind:      "ConfigMap",
+					annotations: map[string]string{
+						"foo": "baz",
+					},
+				},
+			},
+		},
+		{
+			name: "deletion of label configuration",
+			config: []Update{
+				update("default/labels", map[string]string{"foo": "baz"}, nil, "", ""),
+				update("test/labels", map[string]string{"foo": "bar", "bing": "bong"}, nil, "", ""),
+				{
+					key: "default/labels",
+				},
+			},
+			expectations: []Expectation{
+				{
+					namespace: "test",
+					name:      "xyz",
+					kind:      "ConfigMap",
+					labels: map[string]string{
+						"foo":  "bar",
+						"bing": "bong",
+					},
+				},
+			},
+		},
+		{
+			name: "deletion of annotation configuration",
+			config: []Update{
+				update("default/annotations", nil, map[string]string{"foo": "baz"}, "", ""),
+				update("test/annotations", nil, map[string]string{"foo": "bar", "bing": "bong"}, "", ""),
+				{
+					key: "test/annotations",
+				},
+				{
+					key: "never/existed",
+				},
+			},
+			expectations: []Expectation{
+				{
+					namespace: "test",
+					name:      "xyz",
+					kind:      "ConfigMap",
+					annotations: map[string]string{
+						"foo": "baz",
+					},
+				},
+			},
+		},
+		{
+			name: "restricted label configuration",
+			config: []Update{
+				update("default/all", map[string]string{"ding": "dong"}, nil, "", ""),
+				update("default/svc-specific", map[string]string{"foo": "faa"}, nil, "Service", ""),
+				update("test/labels", map[string]string{"foo": "bar", "bing": "bong"}, nil, "", "xyz"),
+			},
+			expectations: []Expectation{
+				{
+					namespace: "test",
+					name:      "xyz",
+					kind:      "ConfigMap",
+					labels: map[string]string{
+						"foo":  "bar",
+						"bing": "bong",
+						"ding": "dong",
+					},
+				},
+				{
+					namespace: "test",
+					name:      "abc",
+					kind:      "Service",
+					labels: map[string]string{
+						"foo":  "faa",
+						"ding": "dong",
+					},
+				},
+				{
+					namespace: "test",
+					name:      "xyz",
+					kind:      "Service",
+					labels: map[string]string{
+						"foo":  "faa",
+						"bing": "bong",
+						"ding": "dong",
+					},
+				},
+				{
+					namespace: "other",
+					name:      "def",
+					kind:      "Deployment",
+					labels: map[string]string{
+						"ding": "dong",
+					},
+				},
+			},
+		},
+		{
+			name: "restricted annotation configuration",
+			config: []Update{
+				update("default/all", nil, map[string]string{"ding": "dong"}, "", ""),
+				update("default/svc-specific", nil, map[string]string{"foo": "faa"}, "Service", ""),
+				update("test/annotations", nil, map[string]string{"foo": "bar", "bing": "bong"}, "", "xyz"),
+			},
+			expectations: []Expectation{
+				{
+					namespace: "test",
+					name:      "xyz",
+					kind:      "ConfigMap",
+					annotations: map[string]string{
+						"foo":  "bar",
+						"bing": "bong",
+						"ding": "dong",
+					},
+				},
+				{
+					namespace: "test",
+					name:      "abc",
+					kind:      "Service",
+					annotations: map[string]string{
+						"foo":  "faa",
+						"ding": "dong",
+					},
+				},
+				{
+					namespace: "test",
+					name:      "xyz",
+					kind:      "Service",
+					annotations: map[string]string{
+						"foo":  "faa",
+						"bing": "bong",
+						"ding": "dong",
+					},
+				},
+				{
+					namespace: "other",
+					name:      "def",
+					kind:      "Deployment",
+					annotations: map[string]string{
+						"ding": "dong",
+					},
+				},
+			},
+		},
+		{
+			name: "excludes",
+			config: []Update{
+				updateWithExcludes("test/labels", nil, map[string]string{"acme.com/foo": "bar", "dont/copy/me": "xyz", "or-me": ""}, "", "", "dont/copy/me,or-me"),
+			},
+			expectations: []Expectation{
+				{
+					namespace: "test",
+					name:      "xyz",
+					kind:      "ConfigMap",
+					annotations: map[string]string{
+						"acme.com/foo": "bar",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := NewLabelsAndAnnotations(tt.controllerNamespace)
+			for _, update := range tt.config {
+				registry.Update(update.key, update.config)
+			}
+			for _, expectation := range tt.expectations {
+				if expectation.labels != nil {
+					actual := map[string]string{}
+					result := registry.SetLabels(expectation.namespace, expectation.name, expectation.kind, actual)
+					//t.Logf("Checking labels for %s %s/%s", expectation.kind, expectation.namespace, expectation.name)
+					assert.DeepEqual(t, actual, expectation.labels)
+					assert.Assert(t, result)
+				}
+				if expectation.annotations != nil {
+					actual := map[string]string{}
+					result := registry.SetAnnotations(expectation.namespace, expectation.name, expectation.kind, actual)
+					//t.Logf("Checking annotations for %s %s/%s", expectation.kind, expectation.namespace, expectation.name)
+					assert.DeepEqual(t, actual, expectation.annotations)
+					assert.Assert(t, result)
+				}
+			}
+		})
+	}
+}
+
+func update(key string, labels map[string]string, annotations map[string]string, kind string, name string) Update {
+	return updateWithExcludes(key, labels, annotations, kind, name, "")
+}
+
+func updateWithExcludes(key string, labels map[string]string, annotations map[string]string, kind string, name string, excludes string) Update {
+	data := map[string]string{}
+	if kind != "" {
+		data["kind"] = kind
+	}
+	if name != "" {
+		data["name"] = name
+	}
+	if excludes != "" {
+		data["exclude"] = excludes
+	}
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels["skupper.io/label-template"] = "true"
+	if len(data) == 0 {
+		data = nil
+	}
+	return configmap(key, data, labels, annotations)
+}
+
+func configmap(key string, data map[string]string, labels map[string]string, annotations map[string]string) Update {
+	return Update{
+		key: key,
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:      labels,
+				Annotations: annotations,
+			},
+			Data: data,
+		},
+	}
+}

--- a/internal/kube/site/resources/skupper-router-deployment.yaml
+++ b/internal/kube/site/resources/skupper-router-deployment.yaml
@@ -22,6 +22,17 @@ metadata:
     application: skupper-router
     skupper.io/component: router
     skupper.io/type: site
+{{- if .Labels }}
+{{- range $key, $value := .Labels }}
+    {{ $key }}: {{$value -}}
+{{- end }}
+{{- end }}
+{{- if .Annotations }}
+  annotations:
+{{- range $key, $value := .Annotations }}
+    {{ $key }}: {{$value -}}
+{{- end }}
+{{- end }}
   name: {{ .Group }}
   ownerReferences:
   - apiVersion: skupper.io/v2alpha1

--- a/internal/kube/site/resources/skupper-router-local-service.yaml
+++ b/internal/kube/site/resources/skupper-router-local-service.yaml
@@ -2,6 +2,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: skupper-router-local
+{{- if .Labels }}
+  labels:
+{{- range $key, $value := .Labels }}
+    {{ $key }}: {{$value -}}
+{{- end }}
+{{- end }}
+{{- if .Annotations }}
+  annotations:
+{{- range $key, $value := .Annotations }}
+    {{ $key }}: {{$value -}}
+{{- end }}
+{{- end }}
   ownerReferences:
   - apiVersion: skupper.io/v2alpha1
     kind: Site

--- a/internal/site/bindings.go
+++ b/internal/site/bindings.go
@@ -1,7 +1,6 @@
 package site
 
 import (
-	"log"
 	"reflect"
 
 	"github.com/skupperproject/skupper/internal/qdr"
@@ -136,7 +135,6 @@ func (b *Bindings) UpdateListener(name string, listener *skupperv2alpha1.Listene
 }
 
 func (b *Bindings) updateListener(latest *skupperv2alpha1.Listener) qdr.ConfigUpdate {
-	log.Printf("updating listener %s/%s...", latest.Namespace, latest.Name)
 	name := latest.ObjectMeta.Name
 	existing, ok := b.listeners[name]
 	b.listeners[name] = latest


### PR DESCRIPTION
Labels and annotations to apply can be supplied through ConfigMaps with label `skupper.io/label-template`. These ConfigMaps can be supplied in the namespace of the site or in the namespace in which the controller is running (if different). Definitions in the controller namespace override any similar settings in the site namespace.

The labels or annotations defined a label-template ConfigMap can be restricted to only apply resources of a particular kind by specifying the value for `kind` in the data of the ConfigMap. E.g. `kind=Service` will only apply to Service resources created by skupper. Likewise specifying a value for `name` will result in those labels and/or annotations only being applied to resources which match the specified name.

ConfigMaps can be constrained by both kind and name simultaneously.

If any label or annotation on the label-template should not be applied, it can be excluded by adding a key in the data `exclude` whose value is a comma separated list of keys to ignore from either labels or annotations.