### PR TITLE
set anti affinity on router pods in HA sites

### DIFF
--- a/internal/kube/site/resources/skupper-router-deployment.yaml
+++ b/internal/kube/site/resources/skupper-router-deployment.yaml
@@ -159,3 +159,15 @@ spec:
       volumes:
       - emptyDir: {}
         name: skupper-router-certs
+{{- if .EnableAntiAffinity}}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  application: skupper-router
+                  skupper.io/type: site
+              topologyKey: "kubernetes.io/hostname"
+{{- end }}


### PR DESCRIPTION
Can be disabled through site setting `disable-anti-affinity`