### PR TITLE
align struct definitions and crds

### DIFF
--- a/config/crd/bases/skupper_access_grant_crd.yaml
+++ b/config/crd/bases/skupper_access_grant_crd.yaml
@@ -75,7 +75,7 @@ spec:
                         type: string
                       type:
                         maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][- A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
                     required:
                     - lastTransitionTime

--- a/config/crd/bases/skupper_access_token_crd.yaml
+++ b/config/crd/bases/skupper_access_token_crd.yaml
@@ -69,7 +69,7 @@ spec:
                         type: string
                       type:
                         maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][- A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
                     required:
                     - lastTransitionTime

--- a/config/crd/bases/skupper_attached_connector_binding_crd.yaml
+++ b/config/crd/bases/skupper_attached_connector_binding_crd.yaml
@@ -34,6 +34,8 @@ spec:
               properties:
                 status:
                   type: string
+                message:
+                  type: string
                 conditions:
                   type: array
                   items:

--- a/config/crd/bases/skupper_attached_connector_binding_crd.yaml
+++ b/config/crd/bases/skupper_attached_connector_binding_crd.yaml
@@ -62,7 +62,7 @@ spec:
                         type: string
                       type:
                         maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][- A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
                     required:
                     - lastTransitionTime

--- a/config/crd/bases/skupper_attached_connector_crd.yaml
+++ b/config/crd/bases/skupper_attached_connector_crd.yaml
@@ -43,6 +43,8 @@ spec:
               properties:
                 status:
                   type: string
+                message:
+                  type: string
                 conditions:
                   type: array
                   items:

--- a/config/crd/bases/skupper_attached_connector_crd.yaml
+++ b/config/crd/bases/skupper_attached_connector_crd.yaml
@@ -24,6 +24,8 @@ spec:
                   type: string
                 tlsCredentials:
                   type: string
+                useClientCert:
+                  type: boolean
                 type:
                   type: string
                 includeNotReadyPods:

--- a/config/crd/bases/skupper_attached_connector_crd.yaml
+++ b/config/crd/bases/skupper_attached_connector_crd.yaml
@@ -69,7 +69,7 @@ spec:
                         type: string
                       type:
                         maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][- A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
                     required:
                     - lastTransitionTime

--- a/config/crd/bases/skupper_certificate_crd.yaml
+++ b/config/crd/bases/skupper_certificate_crd.yaml
@@ -72,7 +72,7 @@ spec:
                         type: string
                       type:
                         maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][- A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
                     required:
                     - lastTransitionTime

--- a/config/crd/bases/skupper_connector_crd.yaml
+++ b/config/crd/bases/skupper_connector_crd.yaml
@@ -83,7 +83,7 @@ spec:
                         type: string
                       type:
                         maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][- A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
                     required:
                     - lastTransitionTime

--- a/config/crd/bases/skupper_link_crd.yaml
+++ b/config/crd/bases/skupper_link_crd.yaml
@@ -78,7 +78,7 @@ spec:
                         type: string
                       type:
                         maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][- A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
                     required:
                     - lastTransitionTime

--- a/config/crd/bases/skupper_listener_crd.yaml
+++ b/config/crd/bases/skupper_listener_crd.yaml
@@ -71,7 +71,7 @@ spec:
                         type: string
                       type:
                         maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][- A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
                     required:
                     - lastTransitionTime

--- a/config/crd/bases/skupper_router_access_crd.yaml
+++ b/config/crd/bases/skupper_router_access_crd.yaml
@@ -81,7 +81,7 @@ spec:
                         type: string
                       type:
                         maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][- A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
                     required:
                     - lastTransitionTime

--- a/config/crd/bases/skupper_router_access_crd.yaml
+++ b/config/crd/bases/skupper_router_access_crd.yaml
@@ -25,6 +25,8 @@ spec:
                         type: string
                       port:
                         type: integer
+                    required:
+                      - name
                 generateTlsCredentials:
                   type: boolean
                 issuer:

--- a/config/crd/bases/skupper_secured_access_crd.yaml
+++ b/config/crd/bases/skupper_secured_access_crd.yaml
@@ -29,6 +29,9 @@ spec:
                         type: integer
                       protocol:
                         type: string
+                    required:
+                    - name
+                    - port
                 selector:
                   type: object
                   additionalProperties:

--- a/config/crd/bases/skupper_secured_access_crd.yaml
+++ b/config/crd/bases/skupper_secured_access_crd.yaml
@@ -96,7 +96,7 @@ spec:
                         type: string
                       type:
                         maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][- A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
                     required:
                     - lastTransitionTime

--- a/config/crd/bases/skupper_site_crd.yaml
+++ b/config/crd/bases/skupper_site_crd.yaml
@@ -76,7 +76,7 @@ spec:
                         type: string
                       type:
                         maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][- A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
                     required:
                     - lastTransitionTime

--- a/internal/kube/securedaccess/access_test.go
+++ b/internal/kube/securedaccess/access_test.go
@@ -456,7 +456,7 @@ func TestSecuredAccessGeneral(t *testing.T) {
 				},
 				Spec: skupperv2alpha1.SecuredAccessSpec{
 					AccessType: ACCESS_TYPE_ROUTE,
-					Options: map[string]string{
+					Settings: map[string]string{
 						"domain": "users.domain.org",
 					},
 					Selector: map[string]string{

--- a/internal/kube/securedaccess/route.go
+++ b/internal/kube/securedaccess/route.go
@@ -73,7 +73,7 @@ func (o *RouteAccessType) ensureRoute(namespace string, route *routev1.Route) (e
 
 func desiredRouteForPort(sa *skupperv2alpha1.SecuredAccess, port skupperv2alpha1.SecuredAccessPort) *routev1.Route {
 	name := fmt.Sprintf("%s-%s", sa.Name, port.Name)
-	host := sa.Spec.Options["domain"]
+	host := sa.Spec.Settings["domain"]
 	if host != "" {
 		host = fmt.Sprintf("%s.%s.%s", name, sa.Namespace, host)
 	}

--- a/internal/kube/site/site.go
+++ b/internal/kube/site/site.go
@@ -1118,7 +1118,7 @@ func asSecuredAccessSpec(la *skupperv2alpha1.RouterAccess, group string, default
 		},
 		Certificate: la.Spec.TlsCredentials,
 		Issuer:      issuer,
-		Options:     la.Spec.Options,
+		Settings:    la.Spec.Settings,
 	}
 	if group != "" {
 		//add extra label to allow for distinct sets of routers in HA

--- a/internal/nonkube/common/fs_config_renderer.go
+++ b/internal/nonkube/common/fs_config_renderer.go
@@ -446,7 +446,7 @@ func (c *FileSystemConfigurationRenderer) connectJson(siteState *api.SiteState) 
 		for _, role := range la.Spec.Roles {
 			if role.Name == "normal" {
 				port = role.Port
-				host = getOption(la.Spec.Options, la.Spec.BindHost, "127.0.0.1")
+				host = getOption(la.Spec.Settings, la.Spec.BindHost, "127.0.0.1")
 			}
 		}
 		if port > 0 {

--- a/pkg/apis/skupper/v2alpha1/types.go
+++ b/pkg/apis/skupper/v2alpha1/types.go
@@ -772,7 +772,6 @@ type SecuredAccessSpec struct {
 	Ports       []SecuredAccessPort `json:"ports"`
 	Certificate string              `json:"certificate,omitempty"`
 	Issuer      string              `json:"issuer,omitempty"`
-	Options     map[string]string   `json:"options,omitempty"`
 	Settings    map[string]string   `json:"settings,omitempty"`
 }
 
@@ -959,7 +958,6 @@ type RouterAccessSpec struct {
 	TlsCredentials          string             `json:"tlsCredentials"`
 	GenerateTlsCredentials  bool               `json:"generateTlsCredentials,omitempty"`
 	Issuer                  string             `json:"issuer,omitempty"`
-	Options                 map[string]string  `json:"options,omitempty"`
 	BindHost                string             `json:"bindHost,omitempty"`
 	SubjectAlternativeNames []string           `json:"subjectAlternativeNames,omitempty"`
 	Settings                map[string]string  `json:"settings,omitempty"`

--- a/pkg/apis/skupper/v2alpha1/types.go
+++ b/pkg/apis/skupper/v2alpha1/types.go
@@ -1012,7 +1012,7 @@ type AttachedConnectorList struct {
 
 type AttachedConnectorSpec struct {
 	SiteNamespace       string            `json:"siteNamespace"`
-	Selector            string            `json:"selector,omitempty"`
+	Selector            string            `json:"selector"`
 	Port                int               `json:"port"`
 	TlsCredentials      string            `json:"tlsCredentials,omitempty"`
 	UseClientCert       bool              `json:"useClientCert,omitempty"`

--- a/pkg/apis/skupper/v2alpha1/types.go
+++ b/pkg/apis/skupper/v2alpha1/types.go
@@ -313,8 +313,8 @@ func (a *Endpoint) Url() string {
 }
 
 type SiteRecord struct {
-	Id        string          `json:"id"`
-	Name      string          `json:"name"`
+	Id        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
 	Namespace string          `json:"namespace,omitempty"`
 	Platform  string          `json:"platform,omitempty"`
 	Version   string          `json:"version,omitempty"`
@@ -323,16 +323,16 @@ type SiteRecord struct {
 }
 
 type ServiceRecord struct {
-	RoutingKey string   `json:"routingKey"`
-	Connectors []string `json:"connectors"`
-	Listeners  []string `json:"listeners"`
+	RoutingKey string   `json:"routingKey,omitempty"`
+	Connectors []string `json:"connectors,omitempty"`
+	Listeners  []string `json:"listeners,omitempty"`
 }
 
 type LinkRecord struct {
-	Name           string `json:"name"`
-	RemoteSiteId   string `json:"remoteSiteId"`
-	RemoteSiteName string `json:"remoteSiteName"`
-	Operational    bool   `json:"operational"`
+	Name           string `json:"name,omitempty"`
+	RemoteSiteId   string `json:"remoteSiteId,omitempty"`
+	RemoteSiteName string `json:"remoteSiteName,omitempty"`
+	Operational    bool   `json:"operational,omitempty"`
 }
 
 // +genclient
@@ -504,8 +504,8 @@ type ConnectorSpec struct {
 
 type PodDetails struct {
 	UID  string `json:"-"`
-	Name string `json:"name"`
-	IP   string `json:"ip"`
+	Name string `json:"name,omitempty"`
+	IP   string `json:"ip,omitempty"`
 }
 
 type ConnectorStatus struct {
@@ -701,9 +701,9 @@ type AccessGrantSpec struct {
 
 type AccessGrantStatus struct {
 	Status         `json:",inline"`
-	Url            string `json:"url"`
-	Code           string `json:"code"`
-	Ca             string `json:"ca"`
+	Url            string `json:"url,omitempty"`
+	Code           string `json:"code,omitempty"`
+	Ca             string `json:"ca,omitempty"`
 	Redemptions    int    `json:"redemptions,omitempty"`
 	ExpirationTime string `json:"expirationTime,omitempty"`
 }

--- a/pkg/apis/skupper/v2alpha1/types.go
+++ b/pkg/apis/skupper/v2alpha1/types.go
@@ -940,7 +940,7 @@ type RouterAccessList struct {
 
 type RouterAccessRole struct {
 	Name string `json:"name"`
-	Port int    `json:"port"`
+	Port int    `json:"port,omitempty"`
 }
 
 func (role RouterAccessRole) GetPort() int32 {
@@ -957,8 +957,8 @@ type RouterAccessSpec struct {
 	AccessType              string             `json:"accessType,omitempty"`
 	Roles                   []RouterAccessRole `json:"roles"`
 	TlsCredentials          string             `json:"tlsCredentials"`
-	GenerateTlsCredentials  bool               `json:"generateTlsCredentials"`
-	Issuer                  string             `json:"issuer"`
+	GenerateTlsCredentials  bool               `json:"generateTlsCredentials,omitempty"`
+	Issuer                  string             `json:"issuer,omitempty"`
 	Options                 map[string]string  `json:"options,omitempty"`
 	BindHost                string             `json:"bindHost,omitempty"`
 	SubjectAlternativeNames []string           `json:"subjectAlternativeNames,omitempty"`

--- a/pkg/apis/skupper/v2alpha1/types.go
+++ b/pkg/apis/skupper/v2alpha1/types.go
@@ -576,7 +576,7 @@ type LinkList struct {
 }
 
 type LinkSpec struct {
-	Endpoints      []Endpoint        `json:"endpoints,omitempty"`
+	Endpoints      []Endpoint        `json:"endpoints"`
 	TlsCredentials string            `json:"tlsCredentials,omitempty"`
 	Cost           int               `json:"cost,omitempty"`
 	Settings       map[string]string `json:"settings,omitempty"`

--- a/pkg/apis/skupper/v2alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/skupper/v2alpha1/zz_generated.deepcopy.go
@@ -1019,13 +1019,6 @@ func (in *RouterAccessSpec) DeepCopyInto(out *RouterAccessSpec) {
 		*out = make([]RouterAccessRole, len(*in))
 		copy(*out, *in)
 	}
-	if in.Options != nil {
-		in, out := &in.Options, &out.Options
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	if in.SubjectAlternativeNames != nil {
 		in, out := &in.SubjectAlternativeNames, &out.SubjectAlternativeNames
 		*out = make([]string, len(*in))
@@ -1164,13 +1157,6 @@ func (in *SecuredAccessSpec) DeepCopyInto(out *SecuredAccessSpec) {
 		in, out := &in.Ports, &out.Ports
 		*out = make([]SecuredAccessPort, len(*in))
 		copy(*out, *in)
-	}
-	if in.Options != nil {
-		in, out := &in.Options, &out.Options
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
 	}
 	if in.Settings != nil {
 		in, out := &in.Settings, &out.Settings
@@ -1384,7 +1370,11 @@ func (in *SiteStatus) DeepCopyInto(out *SiteStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	out.Controller = in.Controller
+	if in.Controller != nil {
+		in, out := &in.Controller, &out.Controller
+		*out = new(Controller)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Fixes for the issues listed in #1979. However, to clarify:

> Many/all Resource Status models embed v2alpha1.Status which as a message field missing from many crd specs.

I only found AttachedConnector and AttachedConnectorBinding to be missing this field. This PR adds it to both of those. Did I miss any others?

[Also, a somewhat philosophical (not to mention pedantic!) note. I personally feel that the omitempty is not an ideal proxy for whether the field is required. If omitempty is specified then clearly the field is optional. I would argue the reverse is not necessarily true, though, i.e. the fact that a field is not marked as omitempty doesn't necessarily mean it is required. To me it just means its important enough that showing an empty value would be useful (e.g. url and ca in AccessGrantStatus). This is not really a practical concern however, since these resources will be viewed by the user through the API server rather than what is generated from the golang structs. For non-kube platforms the situation is slightly different of course, and the output from the types might indeed be viewed by users, but there is probably also less need for the 'important' fields not to be populated there.  Anyway, I have I think marked all the optional fields with omitempty.]