### PR TITLE
Add ensure-secret command to network observer

### DIFF
--- a/cmd/network-observer/internal/cmd/commands.go
+++ b/cmd/network-observer/internal/cmd/commands.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	iflag "github.com/skupperproject/skupper/internal/flag"
+	"github.com/skupperproject/skupper/internal/kube/client"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const usage string = `Usage of network-observer <subcommand>:
+Intended for internal use. API is not stable.
+
+	ensure-secret:
+		Provisions kubernetes Secrets related to the execution of the
+		network-observer.`
+const ensureSecretCmd string = "ensure-secret"
+const ensureSecretDesc string = `Creates a kubernetes secret <secret name> with randomly generated contents
+based on one of the preconfigured formats when the secret does not already exist.`
+
+func Run(args []string) {
+	subcommand := args[0]
+	switch subcommand {
+	case "ensure-secret":
+		if err := runEnsureSecret(args); err != nil {
+			slog.Error("ensure secret error", slog.Any("error", err))
+			os.Exit(1)
+		}
+	default:
+		fmt.Printf("Unknown command %q\n", subcommand)
+		fmt.Println(usage)
+		os.Exit(1)
+	}
+}
+
+type secretProvider func(name string) (*corev1.Secret, error)
+
+func runEnsureSecret(args []string) error {
+	var (
+		namespace       string
+		kubeconfig      string
+		format          string
+		secretName      string
+		secretsProvider func(name string) (*corev1.Secret, error)
+	)
+	flags := flag.NewFlagSet(ensureSecretCmd, flag.ExitOnError)
+	flags.Usage = func() {
+		fmt.Fprintf(flags.Output(), "Usage of %s %s [options...] <secret name>\n", os.Args[0], args[0])
+		fmt.Fprintln(flags.Output(), ensureSecretDesc)
+		flags.PrintDefaults()
+	}
+	iflag.StringVar(flags, &namespace, "namespace", "NAMESPACE", "", "The Kubernetes namespace scope for the controller")
+	iflag.StringVar(flags, &kubeconfig, "kubeconfig", "KUBECONFIG", "", "A path to the kubeconfig file to use")
+	iflag.StringVar(flags, &format, "format", "ENSURE_SECRET_FORMAT", "", "Secret format. One of [oauth2-proxy-session-cookie, htpasswd]. Requried.")
+	flags.Parse(args[1:])
+	posArgs := flags.Args()
+	if len(posArgs) != 1 {
+		fmt.Fprintf(flags.Output(), "expected argument for secret name\n")
+		flags.Usage()
+		os.Exit(1)
+	}
+	secretName = posArgs[0]
+
+	switch format {
+	case "htpasswd":
+		secretsProvider = generateHtpasswdSecret
+	case "oauth2-proxy-session-cookie":
+		secretsProvider = generateOauth2ProxySessionSecret
+	case "":
+		fmt.Fprintf(flags.Output(), "flag --format is requried\n")
+		flags.Usage()
+		os.Exit(1)
+	default:
+		fmt.Fprintf(flags.Output(), "format %q not supported\n", format)
+		flags.Usage()
+		os.Exit(1)
+	}
+
+	cli, err := client.NewClient(namespace, "", kubeconfig)
+	if err != nil {
+		return fmt.Errorf("error creating skupper client: %w", err)
+	}
+	secretsClient := cli.Kube.CoreV1().Secrets(cli.GetNamespace())
+
+	return ensureSecret(context.Background(), secretsClient, secretName, secretsProvider)
+}
+
+func generateOauth2ProxySessionSecret(name string) (*corev1.Secret, error) {
+	secretBytes := [32]byte{}
+	if _, err := rand.Read(secretBytes[:]); err != nil {
+		return nil, fmt.Errorf("error generating random cookie secret: %w", err)
+	}
+	encoded := base64.URLEncoding.EncodeToString(secretBytes[:])
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Type: "Opaque",
+		Data: map[string][]byte{
+			"secret": []byte(encoded),
+		},
+	}, nil
+}
+
+func generateHtpasswdSecret(name string) (*corev1.Secret, error) {
+	const htpasswdPrefix = "skupper:{PLAIN}"
+	secretBytes := [16]byte{}
+	if _, err := rand.Read(secretBytes[:]); err != nil {
+		return nil, fmt.Errorf("error generating random base for password: %w", err)
+	}
+	encoded := base64.RawStdEncoding.EncodeToString(secretBytes[:])
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Type: "Opaque",
+		Data: map[string][]byte{
+			"htpasswd": fmt.Append([]byte(htpasswdPrefix), encoded),
+		},
+	}, nil
+}
+
+func ensureSecret(ctx context.Context, client secretCreator, secretName string, provider secretProvider) error {
+	secret, err := provider(secretName)
+	if err != nil {
+		return err
+	}
+	slog.Info("Ensuring cookie secret exists", slog.String("secret", secret.Name))
+	if _, err := client.Create(ctx, secret, metav1.CreateOptions{}); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("error creating secret: %w", err)
+		}
+		slog.Info("Secret already exists", slog.String("secret", secret.Name))
+	} else {
+		slog.Info("Created secret", slog.String("secret", secret.Name))
+	}
+	return nil
+}
+
+type secretCreator interface {
+	Create(ctx context.Context, secret *corev1.Secret, opts metav1.CreateOptions) (*corev1.Secret, error)
+}

--- a/cmd/network-observer/internal/cmd/commands_test.go
+++ b/cmd/network-observer/internal/cmd/commands_test.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type mockSecretCreator func(secret *corev1.Secret) (*corev1.Secret, error)
+
+func (fn mockSecretCreator) Create(_ context.Context, secret *corev1.Secret, _ metav1.CreateOptions) (*corev1.Secret, error) {
+	return fn(secret)
+}
+
+func TestEnsureSecrets(t *testing.T) {
+
+	tCtx := context.Background()
+	testCases := []struct {
+		ArgClient         secretCreator
+		ArgSecretName     string
+		ArgSecretProvider secretProvider
+
+		ExpectErr bool
+		Assert    func(t *testing.T, client secretCreator)
+	}{
+		{
+			ArgClient:         fake.NewClientset().CoreV1().Secrets("testing"),
+			ArgSecretName:     "mysecret",
+			ArgSecretProvider: generateOauth2ProxySessionSecret,
+			Assert: func(t *testing.T, client secretCreator) {
+				s, err := client.(v1.SecretInterface).Get(tCtx, "mysecret", metav1.GetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				val := s.Data["secret"]
+				if len(val) < 42 {
+					t.Errorf("Expected secret to have secret key with sufficeint length: %q", val)
+				}
+			},
+		}, {
+			ArgClient:         fake.NewClientset().CoreV1().Secrets("testing"),
+			ArgSecretName:     "mysecret",
+			ArgSecretProvider: generateHtpasswdSecret,
+			Assert: func(t *testing.T, client secretCreator) {
+				s, err := client.(v1.SecretInterface).Get(tCtx, "mysecret", metav1.GetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				const expectedPrefix string = "skupper:{PLAIN}"
+				val := string(s.Data["htpasswd"])
+				if !strings.HasPrefix(val, expectedPrefix) {
+					t.Errorf("Expected user:scheme prefix: %q", val)
+				}
+				if len(val) < len(expectedPrefix)+16 {
+					t.Errorf("Expected password of at least length 16: %q", val)
+				}
+			},
+		}, {
+			ArgClient: fake.NewClientset(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mysecret",
+					Namespace: "testing",
+				},
+				Type: "Opaque",
+				Data: map[string][]byte{
+					"secret": []byte("expected"),
+				},
+			}).CoreV1().Secrets("testing"),
+			ArgSecretName:     "mysecret",
+			ArgSecretProvider: generateOauth2ProxySessionSecret,
+			Assert: func(t *testing.T, client secretCreator) {
+				s, err := client.(v1.SecretInterface).Get(tCtx, "mysecret", metav1.GetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				val := string(s.Data["secret"])
+				if val != "expected" {
+					t.Errorf("Expected secret to not change: wanted 'expected' got %q", val)
+				}
+			},
+		}, {
+			ArgClient: fake.NewClientset(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mysecret",
+					Namespace: "testing",
+				},
+				Type: "Opaque",
+				Data: map[string][]byte{
+					"secret": []byte("expected"),
+				},
+			}).CoreV1().Secrets("testing"),
+			ArgSecretName:     "secret-ii",
+			ArgSecretProvider: generateHtpasswdSecret,
+		}, {
+			ArgClient: mockSecretCreator(func(*corev1.Secret) (*corev1.Secret, error) {
+				return nil, fmt.Errorf("500 server error")
+			}),
+			ArgSecretName:     "mysecret",
+			ArgSecretProvider: generateHtpasswdSecret,
+			ExpectErr:         true,
+		}, {
+			ArgClient: mockSecretCreator(func(*corev1.Secret) (*corev1.Secret, error) {
+				return nil, errors.NewAlreadyExists(schema.GroupResource{}, "already exists")
+			}),
+			ArgSecretName:     "mysecret",
+			ArgSecretProvider: generateHtpasswdSecret,
+			ExpectErr:         false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			err := ensureSecret(tCtx, tc.ArgClient, tc.ArgSecretName, tc.ArgSecretProvider)
+			switch {
+			case err == nil && !tc.ExpectErr:
+				// OKAY
+			case err == nil && tc.ExpectErr:
+				t.Fatal("Expected error but returned nil")
+			case err != nil && tc.ExpectErr:
+				// OKAY
+			case err != nil && !tc.ExpectErr:
+				t.Fatalf("Unxpected error %s", err)
+			}
+
+			if tc.Assert != nil {
+				tc.Assert(t, tc.ArgClient)
+			}
+
+		})
+	}
+}

--- a/cmd/network-observer/main.go
+++ b/cmd/network-observer/main.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/skupperproject/skupper/cmd/network-observer/internal/api"
+	"github.com/skupperproject/skupper/cmd/network-observer/internal/cmd"
 	"github.com/skupperproject/skupper/cmd/network-observer/internal/collector"
 	"github.com/skupperproject/skupper/cmd/network-observer/internal/flowlog"
 	"github.com/skupperproject/skupper/cmd/network-observer/internal/server"
@@ -222,6 +223,17 @@ func main() {
 	if *isVersion {
 		fmt.Println(version.Version)
 		os.Exit(0)
+	}
+
+	args := flags.Args()
+	if len(args) > 0 {
+		// Handle internal subcommands
+		if args[0] == "help" {
+			flags.Usage()
+			os.Exit(0)
+		}
+		cmd.Run(args)
+		return
 	}
 
 	if err := run(cfg); err != nil {


### PR DESCRIPTION
Adds a new subcommand "ensure-secret" to the network observer so that it can be used as a standalone Job or helm hook for provisioning k8s secrets where the user chooses not to provide one. One of --format=oauth2-proxy-session-cookie for a random seed for securing session cookies with the openshift oauth proxy or --format=htpasswd for generating a random plaintext password for http basic authentication.

Phase 1 of https://github.com/skupperproject/skupper/issues/1969