### PR TITLE
Fix panic when trying to set annotations on router config

### DIFF
--- a/internal/kube/qdr/update_config.go
+++ b/internal/kube/qdr/update_config.go
@@ -26,6 +26,12 @@ func updateRouterConfig(client kubernetes.Interface, name string, namespace stri
 	if err != nil {
 		return err
 	}
+	if current.ObjectMeta.Labels == nil {
+		current.ObjectMeta.Labels = map[string]string{}
+	}
+	if current.ObjectMeta.Annotations == nil {
+		current.ObjectMeta.Annotations = map[string]string{}
+	}
 
 	config, err := qdr.GetRouterConfigFromConfigMap(current)
 	if err != nil {


### PR DESCRIPTION
I ran into a panic from `UpdateRouterConfig` because the router config configmap didn't have any annotations, so the annotations map was nil, so I took the same approach as is already taken when handling SecuredAccesses to ensure that the maps are non-nil.