### PR TITLE
Add README to skupper chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ skupper-namespace-scope.yaml
 skupper-network-observer*.yaml
 bundle.Dockerfile
 ./bundle/
+!charts/skupper/README.md
 charts/skupper/
 skupper-*.tgz
 artifacthub-repo.yml

--- a/Makefile
+++ b/Makefile
@@ -181,5 +181,5 @@ clean:
 	rm -rf skupper controller kube-adaptor \
 		network-observer generate-doc \
 		cover.out oci-archives bundle bundle.Dockerfile \
-		charts/skupper skupper-*.tgz artifacthub-repo.yml \
+		skupper-*.tgz artifacthub-repo.yml \
 		network-observer-*.tgz  skupper-*-scope.yaml

--- a/charts/skupper/README.md
+++ b/charts/skupper/README.md
@@ -37,9 +37,13 @@ the `--skip-crds` flag with `helm install`.
 ### Image Overrides
 
 The chart exposes overrides for the three images required to run a skupper site.
-* `controllerImage`
-* `kubeAdaptorImage`
-* `routerImage`
+
+Example values.yaml file:
+```
+controllerImage:    examplemirror.acme.com/skupper/controller:2.0.0
+kubeAdaptorImage:   examplemirror.acme.com/skupper/kube-adaptor:2.0.0
+routerImage:        examplemirror.acme.com/skupper/skupper-router:3.3.0
+```
 
 ## Alternative Installation Methods
 

--- a/charts/skupper/README.md
+++ b/charts/skupper/README.md
@@ -1,0 +1,63 @@
+# Skupper
+
+Skupper is a layer 7 service interconnect. It enables secure communications
+across Kubernetes clusters with no VPNs or special firewall rules.
+
+This chart installs the [Skupper](https://skupper.io) version 2 controller for
+[Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh)
+package manager.
+
+
+## Prerequisites
+
+- Kubernetes 1.25+
+- Helm 3
+
+## Usage
+
+A cluster-scoped skupper controller can be deployed with
+```
+helm install skupper oci://quay.io/skupper/helm/skupper \
+    --namespace skupper \
+    --create-namespace
+```
+
+To install the controller at a namespace-scope use `--set scope=namespace`
+```
+helm install skupper oci://quay.io/skupper/helm/skupper \
+    --set scope=namespace
+```
+
+### CRDs
+
+By default, the chart will install the Skupper CRDs required for the controller
+to properly function. To install CRDs independently from the Helm chart, use
+the `--skip-crds` flag with `helm install`.
+
+### Image Overrides
+
+The chart exposes overrides for the three images required to run a skupper site.
+* `controllerImage`
+* `kubeAdaptorImage`
+* `routerImage`
+
+## Alternative Installation Methods
+
+In addition to this Helm Chart, Skupper releases static manifest yamls for
+deploying both cluster and namespace-scoped controllers.
+
+```
+SKUPPER_VERSION=2.0.0
+# Deploys a cluster scoped controller to the 'skupper' namespace.
+kubectl apply -f "https://github.com/skupperproject/skupper/releases/download/$SKUPPER_VERSION/skupper-cluster-scope.yaml"
+# Deploys a namespace scoped controller to the current context namespace.
+kubectl apply -f "https://github.com/skupperproject/skupper/releases/download/$SKUPPER_VERSION/skupper-namespace-scope.yaml"
+```
+
+## Development
+
+This Helm chart is generated from the Makefile at root of the [skupper
+repository.](https://github.com/skupperproject/skupper)
+```asciidoc
+make generate-skupper-helm-chart
+```

--- a/charts/skupper/README.md
+++ b/charts/skupper/README.md
@@ -4,8 +4,8 @@ Skupper is a layer 7 service interconnect. It enables secure communications
 across Kubernetes clusters with no VPNs or special firewall rules.
 
 This chart installs the [Skupper](https://skupper.io) version 2 controller for
-[Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh)
-package manager.
+[Kubernetes](https://kubernetes.io) using the [Helm](https://helm.sh) package
+manager.
 
 
 ## Prerequisites

--- a/charts/skupper/README.md
+++ b/charts/skupper/README.md
@@ -15,10 +15,15 @@ manager.
 
 ## Using the chart
 
-Deploy a cluster-scoped Skupper controller
+Deploy a cluster-scoped Skupper controller in the current namespace:
+```
+helm install skupper oci://quay.io/skupper/helm/skupper
+```
+
+If you want to deploy the controller in a specific namespace:
 ```
 helm install skupper oci://quay.io/skupper/helm/skupper \
-    --namespace skupper \
+    --namespace <custom-ns> \
     --create-namespace
 ```
 

--- a/charts/skupper/README.md
+++ b/charts/skupper/README.md
@@ -56,8 +56,5 @@ kubectl apply -f "https://github.com/skupperproject/skupper/releases/download/$S
 
 ## Development
 
-This Helm chart is generated from the Makefile at root of the [skupper
-repository.](https://github.com/skupperproject/skupper)
-```asciidoc
-make generate-skupper-helm-chart
-```
+This Helm Chart is generated. For instructions on working with this chart see
+[skupper/charts](https://github.com/skupperproject/skupper/tree/main/charts).

--- a/charts/skupper/README.md
+++ b/charts/skupper/README.md
@@ -1,7 +1,7 @@
 # Skupper
 
 Skupper is a layer 7 service interconnect. It enables secure communications
-across Kubernetes clusters with no VPNs or special firewall rules.
+across Kubernetes clusters and/or local systems with no VPNs or special firewall rules.
 
 This chart installs the [Skupper](https://skupper.io) version 2 controller for
 [Kubernetes](https://kubernetes.io) using the [Helm](https://helm.sh) package
@@ -13,16 +13,16 @@ manager.
 - Kubernetes 1.25+
 - Helm 3
 
-## Usage
+## Using the chart
 
-A cluster-scoped skupper controller can be deployed with
+Deploy a cluster-scoped Skupper controller
 ```
 helm install skupper oci://quay.io/skupper/helm/skupper \
     --namespace skupper \
     --create-namespace
 ```
 
-To install the controller at a namespace-scope use `--set scope=namespace`
+Deploy a controller with namespace-scope in the current namespace using  `--set scope=namespace`:
 ```
 helm install skupper oci://quay.io/skupper/helm/skupper \
     --set scope=namespace
@@ -30,8 +30,8 @@ helm install skupper oci://quay.io/skupper/helm/skupper \
 
 ### CRDs
 
-By default, the chart will install the Skupper CRDs required for the controller
-to properly function. To install CRDs independently from the Helm chart, use
+By default, the chart installs the Skupper CRDs required by the controller
+to properly function.  If you want to install CRDs separately from the Helm chart, use
 the `--skip-crds` flag with `helm install`.
 
 ### Image Overrides


### PR DESCRIPTION
Adds a README.md file to the generated skupper helm chart explaining the purpose and usage of the chart. Including this inside of the chart directory allows it to integrate better with the helm tooling that expects to find documentation packaged along with the chart.