### PR TITLE
Marks test helper functions with t.Helper

### DIFF
--- a/internal/cmd/skupper/common/testutils/validate_input.go
+++ b/internal/cmd/skupper/common/testutils/validate_input.go
@@ -11,6 +11,7 @@ type inputValidatingCommand interface {
 }
 
 func CheckValidateInput(t *testing.T, command inputValidatingCommand, expectedError string, args []string) {
+	t.Helper()
 	actualError := command.ValidateInput(args)
 
 	if expectedError == "" {

--- a/internal/kube/controller/controller_test.go
+++ b/internal/kube/controller/controller_test.go
@@ -651,6 +651,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func verifyStatus(t *testing.T, expected skupperv2alpha1.Status, actual skupperv2alpha1.Status) {
+	t.Helper()
 	assert.Equal(t, expected.StatusType, actual.StatusType, actual.Message)
 	assert.Equal(t, expected.Message, actual.Message)
 	for _, condition := range expected.Conditions {

--- a/internal/kube/securedaccess/access_test.go
+++ b/internal/kube/securedaccess/access_test.go
@@ -3029,6 +3029,7 @@ func newMockCertificateManager() *MockCertificateManager {
 }
 
 func (m *MockCertificateManager) checkCertificates(t *testing.T, expected []MockCertificate) {
+	t.Helper()
 	for _, desired := range expected {
 		key := desired.namespace + "/" + desired.name
 		assert.Equal(t, desired.namespace, m.certs[key].namespace)

--- a/internal/nonkube/client/compat/container_test.go
+++ b/internal/nonkube/client/compat/container_test.go
@@ -285,6 +285,7 @@ func NewClientOrSkip(t *testing.T, endpoint string, ctx context.Context) (*Compa
 }
 
 func ValidateMaps(t *testing.T, originalMap map[string]string, finalMap map[string]string) {
+	t.Helper()
 	for k, v := range originalMap {
 		assert.Equal(t, finalMap[k], v)
 	}

--- a/internal/qdr/qdr_test.go
+++ b/internal/qdr/qdr_test.go
@@ -390,6 +390,7 @@ func TestUnmarshalErrorInvalidLogValue(t *testing.T) {
 }
 
 func checkLevel(t *testing.T, config *RouterConfig, mod string, level string) {
+	t.Helper()
 	entry, ok := config.LogConfig[mod]
 	if ok && entry.Module != mod {
 		t.Errorf("Inconsistent log config for %s. Expected %q got %q", mod, mod, entry.Module)


### PR DESCRIPTION
Marks several test utilities with the testing.T Helper function so that when assertions made within that helper fail, the go testing framework will report line number info for the calling test case instead of the shared helper function. This should make it quicker for us to identify the source of the test failure.