### PR TITLE
Removes helm charts from GitHub Release Artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,10 +356,8 @@ jobs:
       - run: cp ./*.yaml skupper-setup
       - run: helm registry login -u ${QUAY_LOGIN} -p ${QUAY_PASSWORD} quay.io
       - run: make pack-skupper-helm-chart
-      - run: cp ./skupper-*.tgz skupper-setup
       - run: helm push skupper-*.tgz oci://quay.io/skupper/helm
       - run: make pack-network-observer-helm-chart
-      - run: cp ./network-observer-*.tgz skupper-setup
       - run: helm push network-observer-*.tgz oci://quay.io/skupper/helm
       - run:
           name: Verify skupper-setup Directory Contents


### PR DESCRIPTION
Excludes the helm chart archives from the GitHub Release Artifacts. These charts are published as OCI artifacts to quay.io along with our container images. If in an uncommon case a user needed a Chart as an archive they could download it from quay instead of GH.

Ex: 'helm pull oci://quay.io/skupper/helm/skupper --version 2.0.0'