### PR TITLE
fix CLI handling of annotations

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -138,6 +138,7 @@ type SiteConfigSpec struct {
 	RunAsGroup               int64
 	EnableClusterPermissions bool
 	EnableSkupperEvents      bool
+	AnnotationSeparator      string
 }
 
 const (

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -387,14 +387,18 @@ func NewClientHandleError(namespace string, context string, kubeConfigPath strin
 var routerCreateOpts types.SiteConfigSpec
 var routerLogging string
 
-func asMap(entries []string) map[string]string {
+func asMap(entries string) map[string]string {
 	result := map[string]string{}
-	for _, entry := range entries {
-		parts := strings.Split(entry, "=")
-		if len(parts) > 1 {
-			result[parts[0]] = parts[1]
-		} else {
-			result[parts[0]] = ""
+	if entries != "" {
+		separator := routerCreateOpts.AnnotationSeparator
+		annotations := strings.SplitAfter(entries, separator)
+		for _, entry := range annotations {
+			parts := strings.SplitAfterN(entry, "=", 2)
+			if len(parts) > 1 {
+				result[strings.TrimSuffix(parts[0], "=")] = strings.TrimSuffix(parts[1], separator)
+			} else {
+				result[parts[0]] = ""
+			}
 		}
 	}
 	return result
@@ -404,7 +408,7 @@ var LoadBalancerTimeout time.Duration
 
 type InitFlags struct {
 	routerMode string
-	labels     []string
+	labels     string
 }
 
 var initFlags InitFlags
@@ -474,7 +478,7 @@ installation that can then be connected to other skupper installations`,
 	cmd.Flags().StringVarP(&routerCreateOpts.Ingress, "ingress", "", "", "Setup Skupper ingress to one of: ["+strings.Join(types.ValidIngressOptions(platform), "|")+"].")
 	cmd.Flags().StringVarP(&initFlags.routerMode, "router-mode", "", string(types.TransportModeInterior), "Skupper router-mode")
 
-	cmd.Flags().StringSliceVar(&initFlags.labels, "labels", []string{}, "Labels to add to resources created by skupper")
+	cmd.Flags().StringVar(&initFlags.labels, "labels", "", "Labels to add to resources created by skupper")
 	cmd.Flags().StringVarP(&routerLogging, "router-logging", "", "", "Logging settings for router. 'trace', 'debug', 'info' (default), 'notice', 'warning', and 'error' are valid values.")
 
 	cmd.Flags().StringVarP(&routerCreateOpts.PrometheusServer.ExternalServer, "external-prometheus-server", "", "", "External prometheus server for metric aggregation. Valid only when --enable-flow-collector")

--- a/cmd/skupper/skupper_kube.go
+++ b/cmd/skupper/skupper_kube.go
@@ -85,13 +85,13 @@ func (s *SkupperKube) Options(rootCmd *cobra.Command) {
 }
 
 type kubeInit struct {
-	annotations                    []string
-	ingressAnnotations             []string
-	routerServiceAnnotations       []string
-	routerPodAnnotations           []string
-	controllerServiceAnnotations   []string
-	controllerPodAnnotations       []string
-	prometheusServerPodAnnotations []string
+	annotations                    string
+	ingressAnnotations             string
+	routerServiceAnnotations       string
+	routerPodAnnotations           string
+	controllerServiceAnnotations   string
+	controllerPodAnnotations       string
+	prometheusServerPodAnnotations string
 }
 
 func (s *SkupperKube) NewClient(cmd *cobra.Command, args []string) {

--- a/cmd/skupper/skupper_kube_site.go
+++ b/cmd/skupper/skupper_kube_site.go
@@ -126,13 +126,6 @@ func (s *SkupperKubeSite) Create(cmd *cobra.Command, args []string) error {
 
 func (s *SkupperKubeSite) CreateFlags(cmd *cobra.Command) {
 	s.kubeInit = kubeInit{}
-	s.kubeInit.ingressAnnotations = []string{}
-	s.kubeInit.annotations = []string{}
-	s.kubeInit.routerServiceAnnotations = []string{}
-	s.kubeInit.routerPodAnnotations = []string{}
-	s.kubeInit.controllerServiceAnnotations = []string{}
-	s.kubeInit.controllerPodAnnotations = []string{}
-	s.kubeInit.prometheusServerPodAnnotations = []string{}
 	cmd.Flags().BoolVarP(&routerCreateOpts.EnableConsole, "enable-console", "", false, "Enable skupper console must be used in conjunction with '--enable-flow-collector' flag")
 	cmd.Flag("ingress").Usage += " If not specified route is used when available, otherwise loadbalancer is used."
 	cmd.Flags().StringVarP(&routerCreateOpts.IngressHost, "ingress-host", "", "", "Hostname or alias by which the ingress route or proxy can be reached")
@@ -142,13 +135,13 @@ func (s *SkupperKubeSite) CreateFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&routerCreateOpts.Password, "console-password", "", "", "Skupper console password. Valid only when --console-auth=internal")
 	cmd.Flags().StringVarP(&routerCreateOpts.ConsoleIngress, "console-ingress", "", "", "Determines if/how console is exposed outside cluster. If not specified uses value of --ingress. One of: ["+strings.Join(types.ValidIngressOptions(s.kube.Platform()), "|")+"].")
 	cmd.Flags().BoolVarP(&routerCreateOpts.EnableRestAPI, "enable-rest-api", "", false, "Enable REST API")
-	cmd.Flags().StringSliceVar(&s.kubeInit.ingressAnnotations, "ingress-annotations", []string{}, "Annotations to add to skupper ingress")
-	cmd.Flags().StringSliceVar(&s.kubeInit.annotations, "annotations", []string{}, "Annotations to add to skupper pods")
-	cmd.Flags().StringSliceVar(&s.kubeInit.routerServiceAnnotations, "router-service-annotations", []string{}, "Annotations to add to skupper router service")
-	cmd.Flags().StringSliceVar(&s.kubeInit.routerPodAnnotations, "router-pod-annotations", []string{}, "Annotations to add to skupper router pod")
-	cmd.Flags().StringSliceVar(&s.kubeInit.controllerServiceAnnotations, "controller-service-annotation", []string{}, "Annotations to add to skupper controller service")
-	cmd.Flags().StringSliceVar(&s.kubeInit.controllerPodAnnotations, "controller-pod-annotation", []string{}, "Annotations to add to skupper controller pod")
-	cmd.Flags().StringSliceVar(&s.kubeInit.prometheusServerPodAnnotations, "prometheus-server-pod-annotation", []string{}, "Annotations to add to skupper prometheus pod")
+	cmd.Flags().StringVar(&routerCreateOpts.AnnotationSeparator, "annotation-separator", ",", "String used to separate multiple annotations")
+	cmd.Flags().StringVar(&s.kubeInit.annotations, "annotations", "", "Annotations to add to skupper pods")
+	cmd.Flags().StringVar(&s.kubeInit.routerServiceAnnotations, "router-service-annotations", "", "Annotations to add to skupper router service")
+	cmd.Flags().StringVar(&s.kubeInit.routerPodAnnotations, "router-pod-annotations", "", "Annotations to add to skupper router pod")
+	cmd.Flags().StringVar(&s.kubeInit.controllerServiceAnnotations, "controller-service-annotation", "", "Annotations to add to skupper controller service")
+	cmd.Flags().StringVar(&s.kubeInit.controllerPodAnnotations, "controller-pod-annotation", "", "Annotations to add to skupper controller pod")
+	cmd.Flags().StringVar(&s.kubeInit.prometheusServerPodAnnotations, "prometheus-server-pod-annotation", "", "Annotations to add to skupper prometheus pod")
 	cmd.Flags().BoolVarP(&routerCreateOpts.EnableServiceSync, "enable-service-sync", "", true, "Participate in cross-site service synchronization")
 	cmd.Flags().DurationVar(&routerCreateOpts.SiteTtl, "service-sync-site-ttl", 0, "Time after which stale services, i.e. those whose site has not been heard from, created through service-sync are removed.")
 	cmd.Flags().BoolVarP(&routerCreateOpts.EnableFlowCollector, "enable-flow-collector", "", false, "Enable cross-site flow collection for the application network")


### PR DESCRIPTION
Add support for different annotations decoding:

The current implementation separates annotations based on commas and equal signs so an annotation like:
foo=x,y,z   would result in an incorrect annotation like:
    annotations:
      x: ""
      y: ""
      foo: z

or 

test2="value=abc" would result in an incorrect annotation like:
  annotations:
    test2: value
    abc: ""


This fix adds an annotation-separator flag that the user can specify to separate annotations and default to a comma if annotation-separator flag is not specified.  This default allows backwards compatibility with existing code.

With this fix the annotations will now correctly be decoded as:

skupper init --router-pod-annotations **service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags=Environment=dev@skupper-separator@foo=x,y,z** --annotation-separator **@skupper-separator@**

 kubectl get deployment skupper-router -o yaml

 template:
    metadata:
      annotations:
        **foo: a,b,c**
        prometheus.io/port: "9090"
        prometheus.io/scrape: "true"
        **service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: Environment=dev**

fixes #1544