### PR TITLE
[kube] Check if credentials already exist before generating a link

### DIFF
--- a/internal/cmd/skupper/link/kube/link_generate.go
+++ b/internal/cmd/skupper/link/kube/link_generate.go
@@ -121,6 +121,9 @@ func (cmd *CmdLinkGenerate) InputToOptions() {
 
 	cmd.cost, _ = strconv.Atoi(cmd.Flags.Cost)
 	cmd.output = cmd.Flags.Output
+	if cmd.output == "" {
+		cmd.output = "yaml"
+	}
 	cmd.generateCredential = cmd.Flags.GenerateCredential
 	cmd.timeout = cmd.Flags.Timeout
 

--- a/internal/cmd/skupper/link/link.go
+++ b/internal/cmd/skupper/link/link.go
@@ -34,8 +34,8 @@ func CmdLinkGenerateFactory(configuredPlatform common.Platform) *cobra.Command {
 
 	cmdLinkGenerateDesc := common.SkupperCmdDescription{
 		Use:   "generate",
-		Short: "Generate a new link resource and save it as a YAML file, unless explicitly specified otherwise using the `--output` flag.",
-		Long: `Generate a new link resource and save it as a YAML file, unless explicitly specified otherwise using the --output flag. The resultant
+		Short: "Generate a new link resource as a YAML output, unless explicitly specified otherwise using the `--output` flag.",
+		Long: `Generate a new link resource as a YAML output, unless explicitly specified otherwise using the --output flag. The resultant
 output needs to be applied in the site in which we want to create the link.`,
 	}
 

--- a/internal/cmd/skupper/link/link.go
+++ b/internal/cmd/skupper/link/link.go
@@ -32,11 +32,23 @@ func CmdLinkGenerateFactory(configuredPlatform common.Platform) *cobra.Command {
 	kubeCommand := kube.NewCmdLinkGenerate()
 	nonKubeCommand := nonkube.NewCmdLinkGenerate()
 
-	cmdLinkGenerateDesc := common.SkupperCmdDescription{
+	cmdLinkGenerateKubeDesc := common.SkupperCmdDescription{
 		Use:   "generate",
 		Short: "Generate a new link resource as a YAML output, unless explicitly specified otherwise using the `--output` flag.",
 		Long: `Generate a new link resource as a YAML output, unless explicitly specified otherwise using the --output flag. The resultant
 output needs to be applied in the site in which we want to create the link.`,
+	}
+
+	cmdLinkGenerateNonKubeDesc := common.SkupperCmdDescription{
+		Use:   "generate",
+		Short: "Generate a new link resource as a YAML output",
+		Long: `Generate a new link resource as a YAML output The resultant
+output needs to be applied in the site in which we want to create the link.`,
+	}
+
+	cmdLinkGenerateDesc := cmdLinkGenerateKubeDesc
+	if configuredPlatform != common.PlatformKubernetes {
+		cmdLinkGenerateDesc = cmdLinkGenerateNonKubeDesc
 	}
 
 	cmd := common.ConfigureCobraCommand(configuredPlatform, cmdLinkGenerateDesc, kubeCommand, nonKubeCommand)
@@ -76,6 +88,10 @@ func CmdLinkUpdateFactory(configuredPlatform common.Platform) *cobra.Command {
 	cmd.Flags().DurationVar(&cmdFlags.Timeout, common.FlagNameTimeout, 60*time.Second, common.FlagDescTimeout)
 	if configuredPlatform == common.PlatformKubernetes {
 		cmd.Flags().StringVar(&cmdFlags.Wait, common.FlagNameWait, "ready", common.FlagDescWait)
+	}
+
+	if configuredPlatform != common.PlatformKubernetes {
+		cmd.Flags().MarkHidden(common.FlagNameOutput)
 	}
 
 	kubeCommand.CobraCmd = cmd

--- a/internal/cmd/skupper/link/link.go
+++ b/internal/cmd/skupper/link/link.go
@@ -34,8 +34,8 @@ func CmdLinkGenerateFactory(configuredPlatform common.Platform) *cobra.Command {
 
 	cmdLinkGenerateDesc := common.SkupperCmdDescription{
 		Use:   "generate",
-		Short: "Generate a new link resource in a yaml file",
-		Long: `Generate a new link resource with the data needed from the target site. The resultant
+		Short: "Generate a new link resource and save it as a YAML file, unless explicitly specified otherwise using the `--output` flag.",
+		Long: `Generate a new link resource and save it as a YAML file, unless explicitly specified otherwise using the --output flag. The resultant
 output needs to be applied in the site in which we want to create the link.`,
 	}
 

--- a/internal/cmd/skupper/link/link_test.go
+++ b/internal/cmd/skupper/link/link_test.go
@@ -24,7 +24,7 @@ func TestCmdLinkFactory(t *testing.T) {
 			expectedFlagsWithDefaultValue: map[string]interface{}{
 				common.FlagNameTlsCredentials:     "",
 				common.FlagNameCost:               "1",
-				common.FlagNameOutput:             "yaml",
+				common.FlagNameOutput:             "",
 				common.FlagNameGenerateCredential: "true",
 				common.FlagNameTimeout:            "1m0s",
 			},

--- a/internal/cmd/skupper/link/link_test.go
+++ b/internal/cmd/skupper/link/link_test.go
@@ -24,7 +24,7 @@ func TestCmdLinkFactory(t *testing.T) {
 			expectedFlagsWithDefaultValue: map[string]interface{}{
 				common.FlagNameTlsCredentials:     "",
 				common.FlagNameCost:               "1",
-				common.FlagNameOutput:             "",
+				common.FlagNameOutput:             "yaml",
 				common.FlagNameGenerateCredential: "true",
 				common.FlagNameTimeout:            "1m0s",
 			},


### PR DESCRIPTION
- Fixes #2005
- Avoids printing the yaml separator (`---`) after printing the last resource, in order to make it compatible with the non-kube resource parser.
