### PR TITLE
remove help subcommand

### DIFF
--- a/internal/cmd/skupper/root/root.go
+++ b/internal/cmd/skupper/root/root.go
@@ -36,6 +36,8 @@ func NewSkupperRootCommand() *cobra.Command {
 	rootCmd.AddCommand(debug.NewCmdDebug())
 	rootCmd.AddCommand(system.NewCmdSystem())
 
+	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+
 	return rootCmd
 }
 


### PR DESCRIPTION
Fixes #2011 

This change removes the help subcommand, while maintaining `--help` flag.