### PR TITLE
Remove ExposePodsByName service and mapping with Pod

### DIFF
--- a/internal/kube/site/per_target_listener.go
+++ b/internal/kube/site/per_target_listener.go
@@ -143,7 +143,7 @@ func extractTargets(prefix string, network []skupperv2alpha1.SiteRecord) []strin
 	var results []string
 	for _, site := range network {
 		for _, service := range site.Services {
-			if strings.HasPrefix(service.RoutingKey, prefix) {
+			if strings.HasPrefix(service.RoutingKey, prefix) && len(service.Connectors) > 0 {
 				results = append(results, strings.TrimPrefix(service.RoutingKey, prefix))
 			}
 		}


### PR DESCRIPTION
Bug fix updates the site bindings logic so that when the network status is updated and the final connector for a per-target address is removed, corresponding per-target listeners and services will also be removed.

Fixes issue #2054