### PR TITLE
Add output flag support for site command

### DIFF
--- a/internal/cmd/skupper/site/kube/site_status.go
+++ b/internal/cmd/skupper/site/kube/site_status.go
@@ -11,6 +11,7 @@ import (
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common/utils"
 
 	"github.com/skupperproject/skupper/internal/kube/client"
+	"github.com/skupperproject/skupper/internal/utils/validator"
 	skupperv2alpha1 "github.com/skupperproject/skupper/pkg/generated/client/clientset/versioned/typed/skupper/v2alpha1"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,6 +22,7 @@ type CmdSiteStatus struct {
 	CobraCmd  *cobra.Command
 	Flags     *common.CommandSiteStatusFlags
 	Namespace string
+	output    string
 }
 
 func NewCmdSiteStatus() *CmdSiteStatus {
@@ -39,11 +41,22 @@ func (cmd *CmdSiteStatus) NewClient(cobraCommand *cobra.Command, args []string) 
 }
 
 func (cmd *CmdSiteStatus) ValidateInput(args []string) error {
+	var validationErrors []error
+	outputTypeValidator := validator.NewOptionValidator(common.OutputTypes)
+
 	if len(args) > 0 {
 		return errors.New("this command does not need any arguments")
 	}
 
-	return nil
+	if cmd.Flags != nil && cmd.Flags.Output != "" {
+		ok, err := outputTypeValidator.Evaluate(cmd.Flags.Output)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("output type is not valid: %s", err))
+		} else {
+			cmd.output = cmd.Flags.Output
+		}
+	}
+	return errors.Join(validationErrors...)
 }
 
 func (cmd *CmdSiteStatus) InputToOptions() {}
@@ -60,15 +73,25 @@ func (cmd *CmdSiteStatus) Run() error {
 		return nil
 	}
 
-	writer := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', tabwriter.AlignRight)
-	fmt.Fprintln(writer, "NAME\tSTATUS\tMESSAGE")
+	if cmd.output != "" {
+		for _, site := range siteList.Items {
+			encodedOutput, err := utils.Encode(cmd.output, site)
+			if err != nil {
+				return err
+			}
+			fmt.Println(encodedOutput)
+		}
+	} else {
+		writer := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', tabwriter.AlignRight)
+		fmt.Fprintln(writer, "NAME\tSTATUS\tSITES IN NETWORK\tMESSAGE")
 
-	for _, site := range siteList.Items {
-		fmt.Fprintf(writer, "%s\t%s\t%s", site.Name, site.Status.StatusType, site.Status.Message)
-		fmt.Fprintln(writer)
+		for _, site := range siteList.Items {
+			fmt.Fprintf(writer, "%s\t%s\t%d\t%s", site.Name, site.Status.StatusType, site.Status.SitesInNetwork, site.Status.Message)
+			fmt.Fprintln(writer)
+		}
+
+		writer.Flush()
 	}
-
-	writer.Flush()
 	return nil
 }
 func (cmd *CmdSiteStatus) WaitUntil() error { return nil }


### PR DESCRIPTION
The site status command was missing the output flag, that allowed user to display site resource as yaml or json.
Also added "Sites in Network" parameter, which is currently not defined in refDog.   