### PR TITLE
Adjust tests/vars.yml to default to a specific kubeconfig

### DIFF
--- a/tests/vars.yml
+++ b/tests/vars.yml
@@ -1,5 +1,5 @@
 ---
-kubeconfig: "/home/{{ ansible_user }}/.kube/config"
+kubeconfig: "{{ lookup('ansible.builtin.env', 'KUBECONFIG') | default('/home/' ~ ansible_user ~ '/.kube/config', true) }}"
 kubeconfig_1: "{{ kubeconfig }}"
 kubeconfig_2: "{{ kubeconfig }}"
 kubeconfig_3: "{{ kubeconfig }}"

--- a/tests/vars.yml
+++ b/tests/vars.yml
@@ -1,7 +1,8 @@
 ---
-# kubeconfig_1: /home/user/.kube/config
-# kubeconfig_2: /home/user/.kube/config
 kubeconfig: "/home/{{ ansible_user }}/.kube/config"
+kubeconfig_1: "{{ kubeconfig }}"
+kubeconfig_2: "{{ kubeconfig }}"
+kubeconfig_3: "{{ kubeconfig }}"
 debug: false
 teardown_flag: true
 


### PR DESCRIPTION
When overwriting the kubeconfig variable to a non-default file, some tests were previously ignoring that overwrite (by instead using their own defaults for kubeconfig_1|2|3. This change makes the kubeconfig_1|2|3 variables take their default from the value of kubeconfig. It also changes the default behavior to use the `KUBECONFIG` environment variable.

Mitigates https://github.com/skupperproject/skupper/issues/2098