### PR TITLE
Adds a SKUPPER_TESTING flag to deployment generator

### DIFF
--- a/scripts/kind-dev-cluster
+++ b/scripts/kind-dev-cluster
@@ -139,7 +139,7 @@ EOF
 }
 
 skupper::cluster::controller() {
-	scripts/skupper-deployment-generator.sh cluster ${IMAGE_TAG} ${ROUTER_IMAGE_TAG} false
+	SKUPPER_TESTING=true scripts/skupper-deployment-generator.sh cluster ${IMAGE_TAG} ${ROUTER_IMAGE_TAG} false
 }
 
 main () {


### PR DESCRIPTION
Prevents kind-dev-cluster script from configuring a cluster that will pull images (rather than use the development images.)