### PR TITLE
Implement and document resource multiplier controls for test execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@ The plan is to produce a number of "previews" on the branch in order to get furt
 implementation of this major release. The v2 version is intended for evaluation purposes only and should not be used
 in production environments.
 
+## Resource Multipliers
+
+The test uses `RESOURCE_RETRY_MULTIPLIER` and `RESOURCE_DELAY_MULTIPLIER` to dynamically adjust the retry and delay behavior for Kubernetes operations. These multipliers are applied to the base values `resource_retry_value` and `resource_delay_value` defined in the inventory.
+
+- `RESOURCE_RETRY_MULTIPLIER`: Multiplies the base retry value, allowing more attempts for operations to succeed.
+- `RESOURCE_DELAY_MULTIPLIER`: Multiplies the base delay value, increasing the wait time between retries.
+
+This configuration helps in managing network latency and resource availability issues during the test execution.
+
+Example:
+```yaml
+resource_retry_value: 30
+resource_delay_value: 10
+RESOURCE_RETRY_MULTIPLIER: 2
+RESOURCE_DELAY_MULTIPLIER: 3
+```
+
+In this example, the retry attempts will be 60 (30 * 2) and the delay will be 30 seconds (10 * 3).
+
 # Highlights
 
 The objective of the next Skupper major release is to better support a full declarative model so that applications

--- a/README.md
+++ b/README.md
@@ -14,25 +14,6 @@ The plan is to produce a number of "previews" on the branch in order to get furt
 implementation of this major release. The v2 version is intended for evaluation purposes only and should not be used
 in production environments.
 
-## Resource Multipliers
-
-The test uses `RESOURCE_RETRY_MULTIPLIER` and `RESOURCE_DELAY_MULTIPLIER` to dynamically adjust the retry and delay behavior for Kubernetes operations. These multipliers are applied to the base values `resource_retry_value` and `resource_delay_value` defined in the inventory.
-
-- `RESOURCE_RETRY_MULTIPLIER`: Multiplies the base retry value, allowing more attempts for operations to succeed.
-- `RESOURCE_DELAY_MULTIPLIER`: Multiplies the base delay value, increasing the wait time between retries.
-
-This configuration helps in managing network latency and resource availability issues during the test execution.
-
-Example:
-```yaml
-resource_retry_value: 30
-resource_delay_value: 10
-RESOURCE_RETRY_MULTIPLIER: 2
-RESOURCE_DELAY_MULTIPLIER: 3
-```
-
-In this example, the retry attempts will be 60 (30 * 2) and the delay will be 30 seconds (10 * 3).
-
 # Highlights
 
 The objective of the next Skupper major release is to better support a full declarative model so that applications

--- a/tests/README.md
+++ b/tests/README.md
@@ -51,6 +51,23 @@ ci-tests: TESTS=hello-world,attached-connector,YOUR_TEST
 ```
 3. Ensure your test has a README.md file with instructions on how to run it.
 
+## Resource Multipliers
+
+In the `vars.yml` file, you can configure the multipliers for resource retries and delays using the following variables:
+
+- `RESOURCE_RETRY_MULTIPLIER`: Multiplies the base retry value for resource operations.
+- `RESOURCE_DELAY_MULTIPLIER`: Multiplies the base delay value between retries.
+
+These multipliers allow you to adjust the retry and delay behavior dynamically based on your testing needs.
+
+Example usage in `vars.yml`:
+```yaml
+RESOURCE_RETRY_MULTIPLIER: 2
+RESOURCE_DELAY_MULTIPLIER: 3
+```
+
+This configuration will double the retry attempts and triple the delay duration for resource operations.
+
 ## Test Requirements
 
 To run the tests in this repository, you'll need:

--- a/tests/README.md
+++ b/tests/README.md
@@ -60,6 +60,17 @@ In the `vars.yml` file, you can configure the multipliers for resource retries a
 
 These multipliers allow you to adjust the retry and delay behavior dynamically based on your testing needs.
 
+### Usage in Tests
+
+In the `test.yml` file, these multipliers are used to control the retry and delay logic for Kubernetes operations. For example:
+
+```yaml
+retries: "{{ resource_retry_value * RESOURCE_RETRY_MULTIPLIER }}"
+delay: "{{ resource_delay_value * RESOURCE_DELAY_MULTIPLIER }}"
+```
+
+This configuration helps manage network latency and resource availability issues during test execution.
+
 Example usage in `vars.yml`:
 ```yaml
 RESOURCE_RETRY_MULTIPLIER: 2

--- a/tests/e2e/scenarios/attached-connector/inventory/group_vars/all.yml
+++ b/tests/e2e/scenarios/attached-connector/inventory/group_vars/all.yml
@@ -4,3 +4,5 @@ ansible_user: "{{ lookup('env', 'USER') }}"
 debug: false
 site_access_token_path: ""
 generate_namespaces_namespace_label: "e2e-attached-connector"
+resource_retry_value: 30
+resource_delay_value: 10

--- a/tests/e2e/scenarios/attached-connector/test.yml
+++ b/tests/e2e/scenarios/attached-connector/test.yml
@@ -140,8 +140,8 @@
             kubeconfig: "{{ kubeconfig }}"
           register: acb
           until: acb.resources | length > 0 and acb.resources[0].status.status == "Ready"
-          retries: 10
-          delay: 10
+          retries: "{{ resource_retry_value * RESOURCE_RETRY_MULTIPLIER }}"
+          delay: "{{ resource_delay_value * RESOURCE_DELAY_MULTIPLIER }}"
           when: "'iperf3-hub' in inventory_hostname"
 
         - name: Creating a JOB to test the connection

--- a/tests/e2e/scenarios/attached-connector/test.yml
+++ b/tests/e2e/scenarios/attached-connector/test.yml
@@ -165,8 +165,8 @@
             (job.resources[0].status.succeeded is defined and job.resources[0].status.succeeded == 1) or
             (job.resources[0].status.failed is defined and job.resources[0].status.failed > 0)
             )
-          retries: 10
-          delay: 10
+          retries: "{{ resource_retry_value * RESOURCE_RETRY_MULTIPLIER }}"
+          delay: "{{ resource_delay_value * RESOURCE_DELAY_MULTIPLIER }}"
           when: "'iperf3-client' in inventory_hostname"
 
         - name: Print the iperf test job logs

--- a/tests/vars.yml
+++ b/tests/vars.yml
@@ -7,6 +7,12 @@ debug: false
 teardown_flag: true
 
 ##################################################
+# Common variables
+##################################################
+RESOURCE_RETRY_MULTIPLIER:  1
+RESOURCE_DELAY_MULTIPLIER:  1
+
+##################################################
 # IPERF3 variables
 ##################################################
 # iperf3_bandwidth: 10M


### PR DESCRIPTION
**PR Message:**

This pull request introduces the functionality to control test execution using resource multipliers. It includes the following changes:

* **feat: update test.yml to use multipliers for retries and delay values:** This commit updates the `test.yml` configuration to utilize multiplier variables for defining retry attempts and delay intervals.
* **docs: UPDATE README.md with instructions for vars.yml resource multipliers:** The README has been updated to provide instructions on how to define and use resource multiplier variables within the `vars.yml` file.
* **docs: add explanation of resource multipliers in test workflow section:** This commit adds a dedicated explanation of how resource multipliers function within the test workflow section of the documentation.
* **Revert "docs: add explanation of resource multipliers in test workflow section":** This commit reverts a previous attempt to document the resource multipliers, likely to refine the approach or content.
* **docs: update README to explain usage of retry and delay variables:** The README has been updated to specifically explain the usage of the newly implemented retry and delay variables.
* **feat: Using the resource multipliers to control the test execution:** This commit implements the logic to actually use the defined resource multiplier variables to control the execution behavior of the tests.

closes #2103 