### PR TITLE
Change hey args, as entry point is now necessary

### DIFF
--- a/test/integration/performance/http_test.go
+++ b/test/integration/performance/http_test.go
@@ -384,7 +384,7 @@ func getHttpJobs(settings *httpSettings, serviceName string) []common.JobInfo {
 		// hey job
 		jobHeyName := fmt.Sprintf("%s-hey-clients-%d", jobPrefix, clients)
 		labelsHey := map[string]string{"job": jobHeyName, "type": "hey"}
-		heyArgs := []string{"-z", strconv.Itoa(settings.duration) + "s", "-c", strconv.Itoa(clients)}
+		heyArgs := []string{"/app/hey", "-z", strconv.Itoa(settings.duration) + "s", "-c", strconv.Itoa(clients)}
 		if settings.rate > 0 {
 			heyArgs = append(heyArgs, "-q", strconv.Itoa(settings.rate))
 		}


### PR DESCRIPTION
The `hey` Containerfile introduced in https://github.com/skupperproject/skupper/pull/1652/files#diff-a49f0e686902bad1c7d315c3d0961ac9686e01493982c4f0c3f98c560c409352 defines a `CMD`, but not an `ENTRYPOINT`.

The HTTP performance test is not reflecting that change, and failing with the error below:

```
Error: container create failed: executable file `-z` not found in $PATH: No such file or directory
```

This PR addresses that error.