### PR TITLE
Include go vet in CI test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,6 +229,9 @@ jobs:
           name: Creating artifacts directory
           command: mkdir /tmp/artifacts
       - run:
+          name: Run Vet
+          command: make vet
+      - run:
           name: Run tests
           command: make cover
       - run:


### PR DESCRIPTION
Go test runs a subset of vet's checkers, and with the large volume of tests in our codebase (especially with verbose output set) it can be difficult to identify the source of a test failure when it comes from a vet violation. This adds an explicit step to run `go vet` before the tests run.