### PR TITLE
Added s390x arch in Makefiles to build multi arch images and skipped some tests on s390x because of image unavailability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TEST_IMAGE := quay.io/skupper/skupper-tests
 TEST_BINARIES_FOLDER := ${PWD}/test/integration/bin
 DOCKER := docker
 LDFLAGS := -X github.com/skupperproject/skupper/pkg/version.Version=${VERSION}
-PLATFORMS ?= linux/amd64,linux/arm64
+PLATFORMS ?= linux/amd64,linux/arm64,linux/s390x
 GOOS ?= linux
 GOARCH ?= amd64
 

--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -86,7 +86,7 @@ SKOPEO = skopeo
 # That is required for their use with Openshift 3.11
 FORMAT_OPTIONS = --format docker
 TRANSFORM_OPTIONS = --format v2s2
-PLATFORM = linux/amd64,linux/arm64
+PLATFORM = linux/amd64,linux/arm64,linux/s390x
 
 # Repositories
 MAIN_REPO = quay.io/skupper

--- a/test/integration/acceptance/gateway_test.go
+++ b/test/integration/acceptance/gateway_test.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"testing"
 	"time"
+	"runtime"
 
 	"github.com/skupperproject/skupper/test/integration/acceptance/gateway"
 	"github.com/skupperproject/skupper/test/integration/examples/tcp_echo"
@@ -49,6 +50,9 @@ func TestGateway(t *testing.T) {
 // port reaching out tcp-echo-cluster service using a
 // dynamic port
 func testLocalGatewayService(t *testing.T) {
+	if runtime.GOARCH == "s390x" {
+		t.Skip("Skipping test on s390x architecture as skupper router binary is unavailable for 1.x versions")
+	}
 	testLocalGateway(t, "")
 }
 

--- a/test/integration/examples/bookinfo_test.go
+++ b/test/integration/examples/bookinfo_test.go
@@ -6,12 +6,16 @@ package examples
 import (
 	"context"
 	"testing"
+	"runtime"
 
 	"github.com/skupperproject/skupper/test/integration/examples/bookinfo"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 func TestBookinfo(t *testing.T) {
+	if runtime.GOARCH == "s390x" {
+		t.Skip("Skipping test on s390x architecture as bookinfo images support is unavailable for s390x")
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	bookinfo.Run(ctx, t, testRunner)

--- a/test/integration/examples/custom/hipstershop/hipstershop_test.go
+++ b/test/integration/examples/custom/hipstershop/hipstershop_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"runtime"
 
 	"github.com/skupperproject/skupper/test/utils/base"
 	"github.com/skupperproject/skupper/test/utils/constants"
@@ -29,6 +30,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestHipsterShop(t *testing.T) {
+	if runtime.GOARCH == "s390x" {
+		t.Skip("Skipping test on s390x architecture as images unavailble for s390x")
+	}
 	// Cluster needs for hipster shop
 	needs := base.ClusterNeeds{
 		NamespaceId:     "hipster",

--- a/test/integration/examples/mongo_test.go
+++ b/test/integration/examples/mongo_test.go
@@ -6,10 +6,14 @@ package examples
 import (
 	"context"
 	"testing"
+	"runtime"
 
 	"github.com/skupperproject/skupper/test/integration/examples/mongodb"
 )
 
 func TestMongo(t *testing.T) {
+	if runtime.GOARCH == "s390x" {
+		t.Skip("Skipping test on s390x architecture as mongo image unsupported for s390x")
+	}
 	mongodb.Run(context.Background(), t, testRunner)
 }

--- a/test/integration/performance/postgres_test.go
+++ b/test/integration/performance/postgres_test.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"runtime"
 	"time"
 
 	"github.com/skupperproject/skupper/test/integration/performance/common"
@@ -45,6 +46,9 @@ type postgresSettings struct {
 }
 
 func TestPostgres(t *testing.T) {
+	if runtime.GOARCH == "s390x" {
+		t.Skip("Skipping test on s390x architecture as image unavailable")
+	}
 	// TestPostgres is currently not functional for ARM
 	// https://github.com/skupperproject/skupper/issues/1650
 	common.CheckArch(t)


### PR DESCRIPTION
Added s390x arch in Makefiles to build multi arch images and 
Skipping below tests on s390x because of image unavailability :
- TestGateway/local-gateway-service
- TestBookinfo
- TestMongo
- TestHipsterShop
- TestPostgres

cc: @hash-d 