### PR TITLE
upgrade node version

### DIFF
--- a/Dockerfile.network-observer
+++ b/Dockerfile.network-observer
@@ -13,7 +13,7 @@ COPY . .
 ENV CGO_ENABLED=0
 RUN make GOARCH=$TARGETARCH build-network-observer
 
-FROM --platform=$BUILDPLATFORM node:20.9.0 AS console-builder
+FROM --platform=$BUILDPLATFORM node:20.18.0 AS console-builder
 
 WORKDIR /skupper-console/
 ADD https://github.com/skupperproject/skupper-console/archive/main.tar.gz .


### PR DESCRIPTION
Needed node version upgrade:

```
 => ERROR [linux/amd64 console-builder 6/6] RUN yarn install && yarn bui  64.2s
------
 > [linux/amd64 console-builder 6/6] RUN yarn install && yarn build:
#0 0.288 yarn install v1.22.19
#0 0.397 [1/5] Validating package.json...
#0 0.400 [2/5] Resolving packages...
#0 0.895 [3/5] Fetching packages...
#0 63.56 error lint-staged@16.0.0: The engine "node" is incompatible with this module. Expected version ">=20.18". Got "20.9.0"
#0 63.59 error Found incompatible module.
#0 63.59 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
------
Dockerfile.network-observer:22
--------------------
  20 |     RUN tar -zxf main.tar.gz
  21 |     WORKDIR ./skupper-console-main
  22 | >>> RUN yarn install && yarn build
  23 |     
  24 |     FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9-minimal
--------------------
ERROR: failed to solve: process "/bin/sh -c yarn install && yarn build" did not complete successfully: exit code: 1
make: *** [Makefile:78: multiarch-oci-network-observer] Error 1

Exited with code exit status 2

```
https://app.circleci.com/pipelines/github/skupperproject/skupper/5052/workflows/7b1ddc6a-1763-4f21-b4be-d1afc1e6085d/jobs/34877/parallel-runs/0/steps/0-105
