### PR TITLE
feat: Standardize E2E Log Artifact Path in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,7 +318,9 @@ jobs:
             cd tests
             cp ~/kc.west ~/.kube/config
             make ci-tests
-
+      - store_artifacts:
+          path: /tmp/e2e-venv
+          destination: e2e-logs
   generate-manifest:
     executor:
       name: go_cimg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,7 @@ jobs:
             cp ~/kc.west ~/.kube/config
             make ci-tests
       - store_artifacts:
-          path: /tmp/e2e-venv
+          path: /tmp/e2e
           destination: e2e-logs
   generate-manifest:
     executor:


### PR DESCRIPTION
**Description:**

This PR updates the `store_artifacts` path in the CircleCI configuration. The path for E2E logs has been changed to `/tmp/e2e`.

This ensures that the correct directory containing the end-to-end test logs is archived after the test run, making debugging and analysis of test failures more straightforward.

**Changes:**

- Modified `.circleci/config.yml`:
    - Updated `store_artifacts`  to `/tmp/e2e`.


---

Closes #2140 