### PR TITLE
Improve uniqueness of system site ids

### DIFF
--- a/internal/nonkube/bundle/install.sh.template
+++ b/internal/nonkube/bundle/install.sh.template
@@ -40,7 +40,7 @@ fi
 export NAMESPACES_PATH="${SKUPPER_OUTPUT_PATH}/namespaces"
 export PLATFORM_FILE="${NAMESPACES_PATH}/${NAMESPACE}/internal/platform.yaml"
 export USER="${USER:-$(id -un)}"
-SITE_ID="$(hostname -s)-${USER}-$(date +%s)"
+SITE_ID="$(hostname -s)-${USER}-$(date +%s-%N)"
 export SITE_ID
 export NORMAL_PORT=""
 

--- a/pkg/nonkube/api/site_state.go
+++ b/pkg/nonkube/api/site_state.go
@@ -283,7 +283,8 @@ func (s *SiteState) ToRouterConfig(sslProfileBasePath string, platform string) q
 	}
 	var routerName = s.Site.Name
 	if !s.bundle {
-		routerName = fmt.Sprintf("%s-%d", s.Site.Name, time.Now().Unix())
+		now := time.Now()
+		routerName = fmt.Sprintf("%s-%d-%d", s.Site.Name, now.Unix(), now.Nanosecond())
 	}
 	routerConfig := qdr.InitialConfig(routerName, s.SiteId, version.Version, !s.IsInterior(), 3)
 	routerConfig.AddAddress(qdr.Address{
@@ -308,6 +309,7 @@ func (s *SiteState) ToRouterConfig(sslProfileBasePath string, platform string) q
 		}
 		metadataJson, _ := encodingjson.Marshal(metadata)
 		routerConfig.Metadata.Metadata = string(metadataJson)
+		routerConfig.SiteConfig.Name += "-{{.SiteNameSuffix}}"
 		routerConfig.SiteConfig.Namespace = "{{.Namespace}}"
 		routerConfig.SiteConfig.Platform = "{{.Platform}}"
 	}


### PR DESCRIPTION
* Both system bundle and local initialization to include nanoseconds as part of ID (mitigate risk of ID clashes)
* The site entity of the router config was not using an exclusive name on bundle installations