### PR TITLE
Fix nil pointer dereference in CheckSslProfiles

### DIFF
--- a/internal/kube/site/site.go
+++ b/internal/kube/site/site.go
@@ -1091,7 +1091,7 @@ func (s *Site) updateLinkOperationalCondition(link *skupperv2alpha1.Link, operat
 }
 
 func (s *Site) CheckSslProfiles(config *qdr.RouterConfig) error {
-	if !s.initialised {
+	if !s.initialised || config == nil {
 		return nil
 	}
 	s.profiles.UseProfiles(config.SslProfiles)


### PR DESCRIPTION
Fixes nil pointer dereference introduced in https://github.com/skupperproject/skupper/pull/2133. Found in CI unit tests.