### PR TITLE
Fixes #2118: Modified GenerateSecret() in certs.go to return an error…

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"log"
 	"math/big"
 	"net"
 	"strings"
@@ -57,31 +56,43 @@ type CertificateAuthority struct {
 
 type CertificateData map[string][]byte
 
-func decodeDataElement(in []byte, name string) []byte {
+func decodeDataElement(in []byte, name string) ([]byte, error) {
 	block, _ := pem.Decode(in)
 	if block == nil {
-		log.Fatal("failed to decode PEM block of type " + name)
+		return nil, fmt.Errorf("unable to decode the Data element of the secret %s", name)
 	}
-	return block.Bytes
+	return block.Bytes, nil
 }
 
-func getCAFromSecret(secret *corev1.Secret) *CertificateAuthority {
+func getCAFromSecret(secret *corev1.Secret) (*CertificateAuthority, error) {
 	if secret == nil || secret.Data == nil {
-		return nil
+		return nil, nil
 	}
-	cert, err := x509.ParseCertificate(decodeDataElement(secret.Data["tls.crt"], "certificate"))
+
+	certBytes, err := decodeDataElement(secret.Data["tls.crt"], "certificate")
 	if err != nil {
-		log.Fatal("failed to get CA certificate from secret")
+		return nil, err
 	}
-	key, err := x509.ParsePKCS1PrivateKey(decodeDataElement(secret.Data["tls.key"], "private key"))
+
+	cert, err := x509.ParseCertificate(certBytes)
 	if err != nil {
-		log.Fatal("failed to get CA private key from secret", err)
+		return nil, err
 	}
+
+	privateKeyBytes, err := decodeDataElement(secret.Data["tls.key"], "private key")
+	if err != nil {
+		return nil, err
+	}
+	key, err := x509.ParsePKCS1PrivateKey(privateKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CA private key from secret %s", err)
+	}
+
 	return &CertificateAuthority{
 		Certificate: cert,
 		Key:         key,
 		CrtData:     secret.Data["tls.crt"],
-	}
+	}, nil
 }
 
 // GenerateSecret generates a kubernetes secret.
@@ -90,12 +101,17 @@ func getCAFromSecret(secret *corev1.Secret) *CertificateAuthority {
 // hosts are the host names in the x509 certificate. Comma separated if more than one hostname
 // expiration is when the secret expires, if zero is passed in, the expiration is set to 5 years from now
 // ca is the certificate authority, if nil a ca cert will be created.
-func GenerateSecret(name string, subject string, hosts string, expiration time.Duration, ca *corev1.Secret) corev1.Secret {
-	caCert := getCAFromSecret(ca)
+func GenerateSecret(name string, subject string, hosts string, expiration time.Duration, ca *corev1.Secret) (*corev1.Secret, error) {
+	caCert, err := getCAFromSecret(ca)
+
+	if err != nil {
+		return nil, err
+	}
 
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		log.Fatalf("failed to generate private key: %s", err)
+		return nil, fmt.Errorf("failed to generate private key: %v", err)
+
 	}
 
 	notBefore := time.Now()
@@ -107,7 +123,7 @@ func GenerateSecret(name string, subject string, hosts string, expiration time.D
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		log.Fatalf("failed to generate serial number: %s", err)
+		return nil, err
 	}
 
 	template := x509.Certificate{
@@ -147,7 +163,7 @@ func GenerateSecret(name string, subject string, hosts string, expiration time.D
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, parent, publicKey(priv), cakey)
 	if err != nil {
-		log.Fatalf("Failed to create certificate: %s", err)
+		return nil, err
 	}
 
 	secret := corev1.Secret{
@@ -173,7 +189,7 @@ func GenerateSecret(name string, subject string, hosts string, expiration time.D
 		secret.Data["ca.crt"] = secret.Data["tls.crt"] //self.signed
 	}
 
-	return secret
+	return &secret, nil
 }
 
 func DecodeCertificate(data []byte) (*x509.Certificate, error) {

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -105,7 +105,7 @@ func GenerateSecret(name string, subject string, hosts string, expiration time.D
 	caCert, err := getCAFromSecret(ca)
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reading CA Certificate from Secret %q: %s", ca.Name, err)
 	}
 
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -69,7 +69,7 @@ func getCAFromSecret(secret *corev1.Secret) (*CertificateAuthority, error) {
 		return nil, nil
 	}
 
-	certBytes, err := decodeDataElement(secret.Data["tls.crt"], "certificate")
+	certBytes, err := decodeDataElement(secret.Data["tls.crt"], "tls.crt")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -79,7 +79,7 @@ func getCAFromSecret(secret *corev1.Secret) (*CertificateAuthority, error) {
 		return nil, err
 	}
 
-	privateKeyBytes, err := decodeDataElement(secret.Data["tls.key"], "private key")
+	privateKeyBytes, err := decodeDataElement(secret.Data["tls.key"], "tls.key")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -59,7 +59,7 @@ type CertificateData map[string][]byte
 func decodeDataElement(in []byte, name string) ([]byte, error) {
 	block, _ := pem.Decode(in)
 	if block == nil {
-		return nil, fmt.Errorf("unable to decode the Data element of the secret %s", name)
+		return nil, fmt.Errorf("failed to read PEM encoded data from %q", name)
 	}
 	return block.Bytes, nil
 }

--- a/internal/certs/certs_test.go
+++ b/internal/certs/certs_test.go
@@ -87,5 +87,5 @@ func TestGenerateSecret(t *testing.T) {
 
 	_, err = GenerateSecret("test-secret", ca_cn, "134.565.56.77", 0, caSecret)
 	errorText := err.Error()
-	assert.Equal(t, errorText, "unable to decode the Data element of the secret certificate")
+	assert.Equal(t, errorText, "error reading CA Certificate from Secret \"emptyCASecret\": failed to read PEM encoded data from \"tls.crt\"")
 }

--- a/internal/kube/certificates/mgr_test.go
+++ b/internal/kube/certificates/mgr_test.go
@@ -520,7 +520,10 @@ func (c *Call) eventcount(events int) *Call {
 
 func fixtureCASecret(t *testing.T, name, namespace string) *corev1.Secret {
 	t.Helper()
-	secret := certs.GenerateSecret(name, "skupper test CA", "", time.Hour*8, nil)
+	secret, err := certs.GenerateSecret(name, "skupper test CA", "", time.Hour*8, nil)
+	if err != nil {
+		t.Error(err)
+	}
 	secret.Namespace = namespace
-	return &secret
+	return secret
 }

--- a/internal/kube/controller/controller.go
+++ b/internal/kube/controller/controller.go
@@ -414,7 +414,10 @@ func (c *Controller) generateLinkConfig(namespace string, name string, subject s
 	if err != nil {
 		return err
 	}
-	token := generator.NewCertToken(name, subject)
+	token, err := generator.NewCertToken(name, subject)
+	if err != nil {
+		return err
+	}
 	return token.Write(writer)
 }
 

--- a/internal/kube/grants/common_test.go
+++ b/internal/kube/grants/common_test.go
@@ -132,10 +132,13 @@ func (*factory) grant(name string, namespace string, uid string) *v2alpha1.Acces
 
 }
 
-func (*factory) secret(name string, namespace string, subject string, hosts []string) *corev1.Secret {
-	secret := certs.GenerateSecret(name, subject, strings.Join(hosts, ","), 0, nil)
+func (*factory) secret(name string, namespace string, subject string, hosts []string) (*corev1.Secret, error) {
+	secret, err := certs.GenerateSecret(name, subject, strings.Join(hosts, ","), 0, nil)
+	if err != nil {
+		return nil, err
+	}
 	secret.ObjectMeta.Namespace = namespace
-	return &secret
+	return secret, nil
 }
 
 func (*factory) genericSecret(name string, namespace string) *corev1.Secret {

--- a/internal/kube/grants/enabled_test.go
+++ b/internal/kube/grants/enabled_test.go
@@ -7,6 +7,11 @@ import (
 )
 
 func Test_tlsCredentialsUpdated(t *testing.T) {
+	secret, err := tf.secret("simple", "test", "My Subject", []string{"foo.com", "bar.org"})
+	if err != nil {
+		t.Error(err)
+	}
+
 	var tests = []struct {
 		name   string
 		key    string
@@ -15,7 +20,7 @@ func Test_tlsCredentialsUpdated(t *testing.T) {
 		{
 			name:   "simple",
 			key:    "test/simple",
-			secret: tf.secret("simple", "test", "My Subject", []string{"foo.com", "bar.org"}),
+			secret: secret,
 		},
 		{
 			name:   "non tls secret",

--- a/internal/kube/grants/init_test.go
+++ b/internal/kube/grants/init_test.go
@@ -15,6 +15,14 @@ import (
 
 func Test_Initialise(t *testing.T) {
 	grantUid := "0bde3bc8-a4a2-404a-bfbe-44fdf7bf3231"
+	myCredsSecret, err := tf.secret("my-creds", "test", "grant server", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	grantSecret, err := tf.secret("skupper-grant-server", "test", "grant server", nil)
+	if err != nil {
+		t.Error(err)
+	}
 	var tests = []struct {
 		name           string
 		config         GrantConfig
@@ -35,7 +43,7 @@ func Test_Initialise(t *testing.T) {
 				BaseUrl:              "foo:5432",
 				TlsCredentialsSecret: "my-creds",
 			},
-			k8sObjects:     []runtime.Object{tf.secret("my-creds", "test", "grant server", nil)},
+			k8sObjects:     []runtime.Object{myCredsSecret},
 			expectedStatus: "OK",
 			expectedUrl:    "https://foo:5432/" + grantUid,
 		},
@@ -48,7 +56,7 @@ func Test_Initialise(t *testing.T) {
 				TlsCredentialsSecret: "skupper-grant-server",
 			},
 			//add pregenerated secret as the certificate controller is not in action in this test
-			k8sObjects: []runtime.Object{tf.pod("my-pod", "test", map[string]string{"foo": "bar"}, ref1), tf.secret("skupper-grant-server", "test", "grant server", nil)},
+			k8sObjects: []runtime.Object{tf.pod("my-pod", "test", map[string]string{"foo": "bar"}, ref1), grantSecret},
 			endpoint: &v2alpha1.Endpoint{
 				Host: "my-host",
 				Port: "1234",
@@ -65,7 +73,7 @@ func Test_Initialise(t *testing.T) {
 				TlsCredentialsSecret: "skupper-grant-server",
 			},
 			//add pregenerated secret as the certificate controller is not in action in this test
-			k8sObjects:     []runtime.Object{tf.secret("skupper-grant-server", "test", "grant server", nil)},
+			k8sObjects:     []runtime.Object{grantSecret},
 			expectedStatus: "Pending",
 		},
 	}

--- a/internal/kube/grants/server_test.go
+++ b/internal/kube/grants/server_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func Test_setCertificateFromSecret(t *testing.T) {
+	simpleSecret, err := tf.secret("simple", "", "My Subject", []string{"foo.com", "bar.org"})
+	if err != nil {
+		t.Error(err)
+	}
 	var tests = []struct {
 		name             string
 		secret           *corev1.Secret
@@ -20,7 +24,7 @@ func Test_setCertificateFromSecret(t *testing.T) {
 	}{
 		{
 			name:             "simple",
-			secret:           tf.secret("simple", "", "My Subject", []string{"foo.com", "bar.org"}),
+			secret:           simpleSecret,
 			expectedSubject:  "My Subject",
 			expectedDNSNames: []string{"foo.com", "bar.org"},
 		},

--- a/internal/kube/grants/tokens.go
+++ b/internal/kube/grants/tokens.go
@@ -88,10 +88,13 @@ func (g *TokenGenerator) setValidHostsFromSite(site *skupperv2alpha1.Site) bool 
 	return true
 }
 
-func (g *TokenGenerator) NewCertToken(name string, subject string) Token {
-	cert := certs.GenerateSecret(name, subject, strings.Join(g.hosts, ","), 0, g.ca)
+func (g *TokenGenerator) NewCertToken(name string, subject string) (Token, error) {
+	cert, err := certs.GenerateSecret(name, subject, strings.Join(g.hosts, ","), 0, g.ca)
+	if err != nil {
+		return nil, err
+	}
 	token := &CertToken{
-		tlsCredentials: &cert,
+		tlsCredentials: cert,
 	}
 	for i, endpoints := range g.endpoints {
 		linkName := name
@@ -113,7 +116,7 @@ func (g *TokenGenerator) NewCertToken(name string, subject string) Token {
 		}
 		token.links = append(token.links, link)
 	}
-	return token
+	return token, nil
 }
 
 func (t *CertToken) Write(writer io.Writer) error {

--- a/internal/kube/grants/tokens_test.go
+++ b/internal/kube/grants/tokens_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func Test_CertTokenWrite(t *testing.T) {
+	mySecret, err := tf.secret("my-token", "", "My Subject", nil)
+	if err != nil {
+		t.Error(err)
+	}
 	var tests = []struct {
 		name          string
 		cert          *CertToken
@@ -20,7 +24,7 @@ func Test_CertTokenWrite(t *testing.T) {
 		{
 			name: "good",
 			cert: &CertToken{
-				tlsCredentials: tf.secret("my-token", "", "My Subject", nil),
+				tlsCredentials: mySecret,
 				links: []*v2alpha1.Link{
 					tf.link("my-token", "", []v2alpha1.Endpoint{
 						{
@@ -34,7 +38,7 @@ func Test_CertTokenWrite(t *testing.T) {
 		{
 			name: "bad",
 			cert: &CertToken{
-				tlsCredentials: tf.secret("my-token", "", "My Subject", nil),
+				tlsCredentials: mySecret,
 				links: []*v2alpha1.Link{
 					tf.link("my-token", "", []v2alpha1.Endpoint{
 						{
@@ -50,7 +54,7 @@ func Test_CertTokenWrite(t *testing.T) {
 		{
 			name: "later bad",
 			cert: &CertToken{
-				tlsCredentials: tf.secret("my-token", "", "My Subject", nil),
+				tlsCredentials: mySecret,
 				links: []*v2alpha1.Link{
 					tf.link("my-token", "", []v2alpha1.Endpoint{
 						{

--- a/internal/nonkube/client/runtime/certs_test.go
+++ b/internal/nonkube/client/runtime/certs_test.go
@@ -38,7 +38,10 @@ func TestTlsConfigRetriever(t *testing.T) {
 	t.Run("tls-config-retriever-valid-certs", func(t *testing.T) {
 		validity, err := time.ParseDuration("1h")
 		assert.Assert(t, err)
-		ca := certs.GenerateSecret("my-ca", "my-ca", "my-ca.host", validity, nil)
+		ca, err := certs.GenerateSecret("my-ca", "my-ca", "my-ca.host", validity, nil)
+		if err != nil {
+			t.Error(err)
+		}
 
 		certPath := path.Join(baseCertsPath, "valid-certificate")
 		assert.Assert(t, os.MkdirAll(certPath, 0755))

--- a/internal/nonkube/common/fs_config_renderer_test.go
+++ b/internal/nonkube/common/fs_config_renderer_test.go
@@ -123,15 +123,24 @@ func compareCertificates(t *testing.T, customOutputPath string) {
 func createInputCertificates(t *testing.T, customOutputPath string) {
 	// preparing certificates
 	fakeHosts := "10.0.0.1,10.0.0.2,fake.domain"
-	ca := certs.GenerateSecret("fake-ca", "fake-ca", "", 0, nil)
-	server := certs.GenerateSecret("fake-server-cert", "fake-server-cert", fakeHosts, 0, &ca)
-	client := certs.GenerateSecret("fake-client-cert", "fake-client-cert", "", 0, &ca)
+	ca, err := certs.GenerateSecret("fake-ca", "fake-ca", "", 0, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	server, err := certs.GenerateSecret("fake-server-cert", "fake-server-cert", fakeHosts, 0, ca)
+	if err != nil {
+		t.Error(err)
+	}
+	client, err := certs.GenerateSecret("fake-client-cert", "fake-client-cert", "", 0, ca)
+	if err != nil {
+		t.Error(err)
+	}
 
 	// paths for each provided certificate
 	caPath := path.Join(customOutputPath, "namespaces/default", string(api.InputIssuersPath), "skupper-site-ca")
 	serverPath := path.Join(customOutputPath, "namespaces/default", string(api.InputCertificatesPath), "link-access-one")
 	clientPath := path.Join(customOutputPath, "namespaces/default", string(api.InputCertificatesPath), "client-link-access-one")
-	certsMap := map[string]corev1.Secret{
+	certsMap := map[string]*corev1.Secret{
 		caPath:     ca,
 		serverPath: server,
 		clientPath: client,


### PR DESCRIPTION
… instead of log.Fatal() messages. This would ensure that the controller does not exit