### PR TITLE
Fixes #2161 - Properly protect only the initial-config listeners.

### DIFF
--- a/internal/kube/adaptor/config_sync.go
+++ b/internal/kube/adaptor/config_sync.go
@@ -193,7 +193,7 @@ func syncListeners(agent *qdr.Agent, desired *qdr.RouterConfig) error {
 		return fmt.Errorf("Error retrieving local listeners: %s", err)
 	}
 
-	if differences := qdr.ListenersDifference(qdr.FilterListeners(actual, qdr.IsNotNormalListener), desired.GetMatchingListeners(qdr.IsNotNormalListener)); !differences.Empty() {
+	if differences := qdr.ListenersDifference(qdr.FilterListeners(actual, qdr.IsNotProtectedListener), desired.GetMatchingListeners(qdr.IsNotProtectedListener)); !differences.Empty() {
 		if err := agent.UpdateListenerConfig(differences); err != nil {
 			return fmt.Errorf("Error syncing listeners: %s", err)
 		}

--- a/internal/kube/site/site.go
+++ b/internal/kube/site/site.go
@@ -238,6 +238,10 @@ func (s *Site) reconcile(siteDef *skupperv2alpha1.Site, inRecovery bool) error {
 }
 
 func (s *Site) initialRouterConfig() *qdr.RouterConfig {
+	//
+	// If the set of listeners in this initial configuration changes, make sure to update the function
+	// IsNotNormalListener to include the complete list of "protected" listeners.
+	//
 	rc := qdr.InitialConfig(s.name+"-${HOSTNAME}", s.site.GetSiteId(), version.Version, s.isEdge(), 3)
 	rc.AddAddress(qdr.Address{
 		Prefix:       "mc",

--- a/internal/kube/site/site.go
+++ b/internal/kube/site/site.go
@@ -240,7 +240,7 @@ func (s *Site) reconcile(siteDef *skupperv2alpha1.Site, inRecovery bool) error {
 func (s *Site) initialRouterConfig() *qdr.RouterConfig {
 	//
 	// If the set of listeners in this initial configuration changes, make sure to update the function
-	// IsNotNormalListener to include the complete list of "protected" listeners.
+	// IsNotProtectedListener to include the complete list of "protected" listeners.
 	//
 	rc := qdr.InitialConfig(s.name+"-${HOSTNAME}", s.site.GetSiteId(), version.Version, s.isEdge(), 3)
 	rc.AddAddress(qdr.Address{

--- a/internal/qdr/qdr.go
+++ b/internal/qdr/qdr.go
@@ -824,8 +824,14 @@ func (r *RouterConfig) UpdateConfigMap(configmap *corev1.ConfigMap) (bool, error
 
 type ListenerPredicate func(Listener) bool
 
-func IsNotNormalListener(l Listener) bool {
-	return l.Role != "normal" && l.Role != ""
+func IsNotProtectedListener(l Listener) bool {
+	protectedNames := [3]string{"@9090", "amqp", "amqps"}
+	for _, name := range protectedNames {
+		if l.Name == name {
+			return false
+		}
+	}
+	return true
 }
 
 func FilterListeners(in map[string]Listener, predicate ListenerPredicate) map[string]Listener {

--- a/internal/site/routeraccess.go
+++ b/internal/site/routeraccess.go
@@ -74,7 +74,7 @@ type RouterAccessConfig struct {
 
 func (g *RouterAccessConfig) Apply(config *qdr.RouterConfig) bool {
 	changed := false
-	lc := qdr.ListenersDifference(config.GetMatchingListeners(qdr.IsNotNormalListener), g.listeners)
+	lc := qdr.ListenersDifference(config.GetMatchingListeners(qdr.IsNotProtectedListener), g.listeners)
 	// delete before add with listeners, as changes are handled as delete and add
 	for _, value := range lc.Deleted {
 		if removed, _ := config.RemoveListener(value.Name); removed {

--- a/internal/site/routeraccess_test.go
+++ b/internal/site/routeraccess_test.go
@@ -289,7 +289,7 @@ func TestRouterAccessConfig_Apply(t *testing.T) {
 			argsConfig.SslProfiles = tt.args.sslProfiles
 
 			if got := g.Apply(&argsConfig); got != tt.want {
-				t.Errorf("RouterAccessConfig.Apply() = %v, want %v", got, tt.want)
+				t.Errorf("RouterAccessConfig.Apply() = %v, want %v (subtest: %s)", got, tt.want, tt.name)
 			}
 		})
 	}


### PR DESCRIPTION
The old code assumed that all normal-role listeners come from the initial configuration. This does not allow for the possibility of creating normal-role RouterAccess resources. This fix makes "protected" status more explicit for listeners.