### PR TITLE
Install jq in the build containers

### DIFF
--- a/Dockerfile.ci-test
+++ b/Dockerfile.ci-test
@@ -3,6 +3,8 @@ FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
+RUN apt update && apt install -y jq
+
 WORKDIR /go/src/app
 
 COPY go.mod .

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -2,6 +2,8 @@ FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 
 ARG TARGETARCH
 
+RUN apt update && apt install -y jq
+
 WORKDIR /go/src/app
 COPY go.mod .
 COPY go.sum .

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -2,6 +2,8 @@ FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 
 ARG TARGETARCH
 
+RUN apt update && apt install -y jq
+
 WORKDIR /go/src/app
 COPY go.mod .
 COPY go.sum .

--- a/Dockerfile.kube-adaptor
+++ b/Dockerfile.kube-adaptor
@@ -2,6 +2,8 @@ FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 
 ARG TARGETARCH
 
+RUN apt update && apt install -y jq
+
 WORKDIR /go/src/app
 
 COPY go.mod .

--- a/Dockerfile.network-observer
+++ b/Dockerfile.network-observer
@@ -2,6 +2,8 @@ FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 
 ARG TARGETARCH
 
+RUN apt update && apt install -y jq
+
 WORKDIR /go/src/app
 
 COPY go.mod .

--- a/Dockerfile.system-controller
+++ b/Dockerfile.system-controller
@@ -2,6 +2,8 @@ FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 
 ARG TARGETARCH
 
+RUN apt update && apt install -y jq
+
 WORKDIR /go/src/app
 COPY go.mod .
 COPY go.sum .


### PR DESCRIPTION
Makefile relies on jq to calculate dependencies, but the golang build image doesn't install it. This adds the appropriate apt invocations to make sure jq is available.