### PR TITLE
Fix Skupper V1 ingress-annotations

### DIFF
--- a/cmd/skupper/skupper_kube_site.go
+++ b/cmd/skupper/skupper_kube_site.go
@@ -136,6 +136,7 @@ func (s *SkupperKubeSite) CreateFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&routerCreateOpts.ConsoleIngress, "console-ingress", "", "", "Determines if/how console is exposed outside cluster. If not specified uses value of --ingress. One of: ["+strings.Join(types.ValidIngressOptions(s.kube.Platform()), "|")+"].")
 	cmd.Flags().BoolVarP(&routerCreateOpts.EnableRestAPI, "enable-rest-api", "", false, "Enable REST API")
 	cmd.Flags().StringVar(&routerCreateOpts.AnnotationSeparator, "annotation-separator", ",", "String used to separate multiple annotations")
+	cmd.Flags().StringVar(&s.kubeInit.ingressAnnotations, "ingress-annotations", "", "Annotations to add to skupper ingress")
 	cmd.Flags().StringVar(&s.kubeInit.annotations, "annotations", "", "Annotations to add to skupper pods")
 	cmd.Flags().StringVar(&s.kubeInit.routerServiceAnnotations, "router-service-annotations", "", "Annotations to add to skupper router service")
 	cmd.Flags().StringVar(&s.kubeInit.routerPodAnnotations, "router-pod-annotations", "", "Annotations to add to skupper router pod")

--- a/cmd/skupper/skupper_mock_test.go
+++ b/cmd/skupper/skupper_mock_test.go
@@ -454,6 +454,7 @@ func TestCmdInitAnnotations(t *testing.T) {
 			"routerAddsAnnotations",
 			[]string{"--annotations", "Name=xyz@@test=value=abc",
 				"--annotation-separator", "@@",
+				"--ingress-annotations", "test=abc",
 				"--router-service-annotations", "foo=1,2,3@@test=abc",
 				"--router-pod-annotations", "test=abc",
 				"--controller-service-annotation", "foo=1,2,3@@test=abc",
@@ -487,6 +488,7 @@ func TestCmdInitAnnotations(t *testing.T) {
 			err := cmd.RunE(cmd, tc.args)
 			assert.Assert(t, err)
 			assert.Equal(t, routerCreateOpts.AnnotationSeparator, tc.expectedSeparator)
+			assert.Assert(t, reflect.DeepEqual(routerCreateOpts.IngressAnnotations, tc.expectedAnnotations3))
 			assert.Assert(t, reflect.DeepEqual(routerCreateOpts.Annotations, tc.expectedAnnotations1))
 			assert.Assert(t, reflect.DeepEqual(routerCreateOpts.Router.ServiceAnnotations, tc.expectedAnnotations2))
 			assert.Assert(t, reflect.DeepEqual(routerCreateOpts.Router.PodAnnotations, tc.expectedAnnotations3))


### PR DESCRIPTION
There was a missed flag in the CLI for creating ingress-annotations.   Added it back and modified unit test to test for it.

Additional fix for #1544

New Issue #2179 