### PR TITLE
Fixes labeling for Contour HTTPProxy resources

### DIFF
--- a/internal/kube/securedaccess/contour.go
+++ b/internal/kube/securedaccess/contour.go
@@ -105,8 +105,8 @@ func (o *ContourHttpProxyAccessType) ensureHttpProxy(namespace string, desired H
 	}
 	log.Printf("Creating contour httpproxy")
 	if o.manager.context != nil {
-		o.manager.context.SetLabels(namespace, desired.Name, "HttpProxy", labels)
-		o.manager.context.SetAnnotations(namespace, desired.Name, "HttpProxy", annotations)
+		o.manager.context.SetLabels(namespace, desired.Name, "HTTPProxy", labels)
+		o.manager.context.SetAnnotations(namespace, desired.Name, "HTTPProxy", annotations)
 	}
 	created, err := createContourProxy(o.manager.clients.GetDynamicClient(), namespace, desired, labels, annotations, ownerRefs)
 	if err != nil {


### PR DESCRIPTION
Changes the kind filter 'HttpProxy' to 'HTTPProxy'. Fixes https://github.com/skupperproject/skupper/issues/2131