### PR TITLE
Container image build executables unconditionally

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -11,7 +11,7 @@ RUN go mod download
 COPY . .
 
 ENV CGO_ENABLED=0
-RUN make build-cli GOARCH=$TARGETARCH
+RUN make -B build-cli GOARCH=$TARGETARCH
 
 # Use scratch for minimal image size
 FROM scratch

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -12,7 +12,7 @@ COPY . .
 
 # Build statically linked binary
 ENV CGO_ENABLED=0
-RUN make build-controller GOARCH=$TARGETARCH
+RUN make -B build-controller GOARCH=$TARGETARCH
 
 # Use scratch for minimal image size
 FROM scratch

--- a/Dockerfile.kube-adaptor
+++ b/Dockerfile.kube-adaptor
@@ -12,7 +12,7 @@ RUN go mod download
 
 COPY . .
 ENV CGO_ENABLED=0
-RUN make build-kube-adaptor GOARCH=$TARGETARCH
+RUN make -B build-kube-adaptor GOARCH=$TARGETARCH
 
 # Use scratch for minimal image size
 FROM scratch

--- a/Dockerfile.network-observer
+++ b/Dockerfile.network-observer
@@ -13,7 +13,7 @@ RUN go mod download
 COPY . .
 
 ENV CGO_ENABLED=0
-RUN make GOARCH=$TARGETARCH build-network-observer
+RUN make -B GOARCH=$TARGETARCH build-network-observer
 
 FROM --platform=$BUILDPLATFORM node:20.18.0 AS console-builder
 

--- a/Dockerfile.system-controller
+++ b/Dockerfile.system-controller
@@ -11,7 +11,7 @@ RUN go mod download
 COPY . .
 
 ENV CGO_ENABLED=0
-RUN make system-controller GOARCH=$TARGETARCH
+RUN make -B system-controller GOARCH=$TARGETARCH
 
 # Use scratch for minimal image size
 FROM scratch


### PR DESCRIPTION
Changes the Dockerfile build stages to execute make with "-B" to unconditionally make all targets. Prevents workspace/host executables copied into the build stage from ending up in the image.

Closes https://github.com/skupperproject/skupper/issues/2196