### PR TITLE
Specify SecuredAccess Route target weight

### DIFF
--- a/internal/kube/securedaccess/access_test.go
+++ b/internal/kube/securedaccess/access_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestSecuredAccessGeneral(t *testing.T) {
+	hundred := int32(100)
 	pathTypePrefix := networkingv1.PathTypePrefix
 	testTable := []struct {
 		name                 string
@@ -406,8 +407,9 @@ func TestSecuredAccessGeneral(t *testing.T) {
 							TargetPort: intstr.FromString("a"),
 						},
 						To: routev1.RouteTargetReference{
-							Kind: "Service",
-							Name: "mysvc",
+							Kind:   "Service",
+							Name:   "mysvc",
+							Weight: &hundred,
 						},
 						TLS: &routev1.TLSConfig{
 							Termination:                   routev1.TLSTerminationPassthrough,
@@ -432,8 +434,9 @@ func TestSecuredAccessGeneral(t *testing.T) {
 							TargetPort: intstr.FromString("b"),
 						},
 						To: routev1.RouteTargetReference{
-							Kind: "Service",
-							Name: "mysvc",
+							Kind:   "Service",
+							Name:   "mysvc",
+							Weight: &hundred,
 						},
 						TLS: &routev1.TLSConfig{
 							Termination:                   routev1.TLSTerminationPassthrough,
@@ -552,8 +555,9 @@ func TestSecuredAccessGeneral(t *testing.T) {
 							TargetPort: intstr.FromString("a"),
 						},
 						To: routev1.RouteTargetReference{
-							Kind: "Service",
-							Name: "mysvc",
+							Kind:   "Service",
+							Name:   "mysvc",
+							Weight: &hundred,
 						},
 						TLS: &routev1.TLSConfig{
 							Termination:                   routev1.TLSTerminationPassthrough,
@@ -572,8 +576,9 @@ func TestSecuredAccessGeneral(t *testing.T) {
 							TargetPort: intstr.FromString("b"),
 						},
 						To: routev1.RouteTargetReference{
-							Kind: "Service",
-							Name: "mysvc",
+							Kind:   "Service",
+							Name:   "mysvc",
+							Weight: &hundred,
 						},
 						TLS: &routev1.TLSConfig{
 							Termination:                   routev1.TLSTerminationPassthrough,

--- a/internal/kube/securedaccess/route.go
+++ b/internal/kube/securedaccess/route.go
@@ -15,6 +15,8 @@ import (
 	skupperv2alpha1 "github.com/skupperproject/skupper/pkg/apis/skupper/v2alpha1"
 )
 
+var routeWeight100 int32 = 100
+
 type RouteAccessType struct {
 	manager *SecuredAccessManager
 }
@@ -121,8 +123,9 @@ func desiredRouteForPort(sa *skupperv2alpha1.SecuredAccess, port skupperv2alpha1
 				TargetPort: intstr.FromString(port.Name),
 			},
 			To: routev1.RouteTargetReference{
-				Kind: "Service",
-				Name: sa.Name,
+				Kind:   "Service",
+				Name:   sa.Name,
+				Weight: &routeWeight100,
 			},
 			TLS: &routev1.TLSConfig{
 				Termination:                   routev1.TLSTerminationPassthrough,

--- a/internal/kube/securedaccess/watchers_test.go
+++ b/internal/kube/securedaccess/watchers_test.go
@@ -912,6 +912,7 @@ func endpoint(name string, port string, host string) skupperv2alpha1.Endpoint {
 }
 
 func route(name string, namespace string, svcName string, portName string, host string) *routev1.Route {
+	hundred := int32(100)
 	return &routev1.Route{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -933,8 +934,9 @@ func route(name string, namespace string, svcName string, portName string, host 
 				TargetPort: intstr.FromString(portName),
 			},
 			To: routev1.RouteTargetReference{
-				Kind: "Service",
-				Name: svcName,
+				Kind:   "Service",
+				Name:   svcName,
+				Weight: &hundred,
 			},
 			TLS: &routev1.TLSConfig{
 				Termination:                   routev1.TLSTerminationPassthrough,


### PR DESCRIPTION
Explicitly sets Route spec.to.weight to 100. Resolves issue #2132