### PR TITLE
Check that valid site endpoints exist before allowing a token creation

### DIFF
--- a/internal/cmd/skupper/common/utils/status.go
+++ b/internal/cmd/skupper/common/utils/status.go
@@ -1,18 +1,8 @@
 package utils
 
 import (
-	"github.com/skupperproject/skupper/internal/utils/validator"
 	"github.com/skupperproject/skupper/pkg/apis/skupper/v2alpha1"
 )
-
-func SiteConfigured(siteList *v2alpha1.SiteList) bool {
-	for _, s := range siteList.Items {
-		if s.IsConfigured() {
-			return true
-		}
-	}
-	return false
-}
 
 func SiteReady(siteList *v2alpha1.SiteList) (bool, string) {
 	for _, s := range siteList.Items {
@@ -23,11 +13,9 @@ func SiteReady(siteList *v2alpha1.SiteList) (bool, string) {
 	return false, ""
 }
 
-func SiteLinkAccessEnabled(siteList *v2alpha1.SiteList, linkAccessTypes []string) (bool, string) {
-	linkAccessTypeValidator := validator.NewOptionValidator(linkAccessTypes)
+func SiteLinkAccessEndpoints(siteList *v2alpha1.SiteList) (bool, string) {
 	for _, s := range siteList.Items {
-		ok, _ := linkAccessTypeValidator.Evaluate(s.Spec.LinkAccess)
-		if ok {
+		if len(s.Status.Endpoints) > 0 {
 			return true, s.Name
 		}
 	}

--- a/internal/cmd/skupper/token/kube/token_issue.go
+++ b/internal/cmd/skupper/token/kube/token_issue.go
@@ -101,7 +101,7 @@ func (cmd *CmdTokenIssue) ValidateInput(args []string) error {
 		if !ok {
 			validationErrors = append(validationErrors, fmt.Errorf("there is no active skupper site in this namespace"))
 		} else {
-			ok, siteName = utils.SiteLinkAccessEnabled(siteList, common.LinkAccessTypes)
+			ok, siteName = utils.SiteLinkAccessEndpoints(siteList)
 			if !ok {
 				validationErrors = append(validationErrors, fmt.Errorf("You must enable link access for this site before you can create a token."))
 			} else {

--- a/internal/cmd/skupper/token/kube/token_issue_test.go
+++ b/internal/cmd/skupper/token/kube/token_issue_test.go
@@ -133,6 +133,20 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 										},
 									},
 								},
+								Endpoints: []v2alpha1.Endpoint{
+									{
+										Name:  "inter-router",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+									{
+										Name:  "edge",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+								},
 							},
 						},
 					},
@@ -175,6 +189,20 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 											Type:   "Ready",
 											Status: "True",
 										},
+									},
+								},
+								Endpoints: []v2alpha1.Endpoint{
+									{
+										Name:  "inter-router",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+									{
+										Name:  "edge",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
 									},
 								},
 							},
@@ -221,6 +249,20 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 										},
 									},
 								},
+								Endpoints: []v2alpha1.Endpoint{
+									{
+										Name:  "inter-router",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+									{
+										Name:  "edge",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+								},
 							},
 						},
 					},
@@ -263,6 +305,20 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 											Type:   "Ready",
 											Status: "True",
 										},
+									},
+								},
+								Endpoints: []v2alpha1.Endpoint{
+									{
+										Name:  "inter-router",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+									{
+										Name:  "edge",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
 									},
 								},
 							},
@@ -309,6 +365,20 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 										},
 									},
 								},
+								Endpoints: []v2alpha1.Endpoint{
+									{
+										Name:  "inter-router",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+									{
+										Name:  "edge",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+								},
 							},
 						},
 					},
@@ -351,6 +421,20 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 											Type:   "Ready",
 											Status: "True",
 										},
+									},
+								},
+								Endpoints: []v2alpha1.Endpoint{
+									{
+										Name:  "inter-router",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+									{
+										Name:  "edge",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
 									},
 								},
 							},
@@ -397,6 +481,20 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 										},
 									},
 								},
+								Endpoints: []v2alpha1.Endpoint{
+									{
+										Name:  "inter-router",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+									{
+										Name:  "edge",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+								},
 							},
 						},
 					},
@@ -439,6 +537,20 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 											Type:   "Ready",
 											Status: "True",
 										},
+									},
+								},
+								Endpoints: []v2alpha1.Endpoint{
+									{
+										Name:  "inter-router",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+									{
+										Name:  "edge",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
 									},
 								},
 							},
@@ -485,6 +597,20 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 										},
 									},
 								},
+								Endpoints: []v2alpha1.Endpoint{
+									{
+										Name:  "inter-router",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+									{
+										Name:  "edge",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+								},
 							},
 						},
 					},
@@ -529,6 +655,20 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 										},
 									},
 								},
+								Endpoints: []v2alpha1.Endpoint{
+									{
+										Name:  "inter-router",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+									{
+										Name:  "edge",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+								},
 							},
 						},
 					},
@@ -552,6 +692,9 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 							ObjectMeta: v1.ObjectMeta{
 								Name:      "site1",
 								Namespace: "test",
+							},
+							Spec: v2alpha1.SiteSpec{
+								LinkAccess: "local",
 							},
 							Status: v2alpha1.SiteStatus{
 								Status: v2alpha1.Status{
@@ -612,6 +755,20 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 											Type:   "Ready",
 											Status: "True",
 										},
+									},
+								},
+								Endpoints: []v2alpha1.Endpoint{
+									{
+										Name:  "inter-router",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+									{
+										Name:  "edge",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
 									},
 								},
 							},


### PR DESCRIPTION
The user created a site with LinkAccess = local, and then tried to create a token with the CLI and it failed.   The CLI expects LinkAccess = default, loadbalancer, or router.  The CLI token issue command has been changed to just verify that the site CR has endpoints, which indicate that the site can be linked to.   A site that has endpoints can issue a token to be used by another site to connect to this site.    

fixes #2213