### PR TITLE
Add validation for namespace in nonkube site create

### DIFF
--- a/internal/cmd/skupper/connector/nonkube/connector_create.go
+++ b/internal/cmd/skupper/connector/nonkube/connector_create.go
@@ -54,6 +54,14 @@ func (cmd *CmdConnectorCreate) ValidateInput(args []string) error {
 	numberValidator := validator.NewNumberValidator()
 	connectorTypeValidator := validator.NewOptionValidator(common.ConnectorTypes)
 	hostStringValidator := validator.NewHostStringValidator()
+	namespaceStringValidator := validator.NamespaceStringValidator()
+
+	if cmd.namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
+	}
 
 	// Validate arguments name and port
 	if len(args) < 2 {

--- a/internal/cmd/skupper/connector/nonkube/connector_delete.go
+++ b/internal/cmd/skupper/connector/nonkube/connector_delete.go
@@ -34,6 +34,7 @@ func (cmd *CmdConnectorDelete) ValidateInput(args []string) error {
 	var validationErrors []error
 	opts := fs.GetOptions{RuntimeFirst: false, LogWarning: false}
 	resourceStringValidator := validator.NewResourceStringValidator()
+	namespaceStringValidator := validator.NamespaceStringValidator()
 
 	if cmd.CobraCmd != nil && cmd.CobraCmd.Flag(common.FlagNameContext) != nil && cmd.CobraCmd.Flag(common.FlagNameContext).Value.String() != "" {
 		fmt.Println("Warning: --context flag is not supported on this platform")
@@ -41,6 +42,13 @@ func (cmd *CmdConnectorDelete) ValidateInput(args []string) error {
 
 	if cmd.CobraCmd != nil && cmd.CobraCmd.Flag(common.FlagNameKubeconfig) != nil && cmd.CobraCmd.Flag(common.FlagNameKubeconfig).Value.String() != "" {
 		fmt.Println("Warning: --kubeconfig flag is not supported on this platform")
+	}
+
+	if cmd.namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
 	}
 
 	// Validate arguments name

--- a/internal/cmd/skupper/connector/nonkube/connector_delete_test.go
+++ b/internal/cmd/skupper/connector/nonkube/connector_delete_test.go
@@ -19,6 +19,7 @@ import (
 func TestCmdConnectorDelete_ValidateInput(t *testing.T) {
 	type test struct {
 		name              string
+		namespace         string
 		args              []string
 		flags             *common.CommandConnectorDeleteFlags
 		cobraGenericFlags map[string]string
@@ -36,12 +37,14 @@ func TestCmdConnectorDelete_ValidateInput(t *testing.T) {
 	testTable := []test{
 		{
 			name:          "connector name is not specified",
+			namespace:     "test",
 			args:          []string{},
 			flags:         &common.CommandConnectorDeleteFlags{},
 			expectedError: "connector name must be configured",
 		},
 		{
 			name:          "connector name is nil",
+			namespace:     "test",
 			args:          []string{""},
 			flags:         &common.CommandConnectorDeleteFlags{},
 			expectedError: "connector name must not be empty",
@@ -74,6 +77,13 @@ func TestCmdConnectorDelete_ValidateInput(t *testing.T) {
 				common.FlagNameKubeconfig: "test",
 			},
 		},
+		{
+			name:          "invalid namespace",
+			namespace:     "Test5",
+			args:          []string{"my-connector"},
+			flags:         &common.CommandConnectorDeleteFlags{},
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+		},
 	}
 
 	//Add a temp file so connector exists for update tests will pass
@@ -105,6 +115,7 @@ func TestCmdConnectorDelete_ValidateInput(t *testing.T) {
 			if test.flags != nil {
 				command.Flags = test.flags
 			}
+			command.namespace = test.namespace
 
 			if test.cobraGenericFlags != nil && len(test.cobraGenericFlags) > 0 {
 				for name, value := range test.cobraGenericFlags {

--- a/internal/cmd/skupper/connector/nonkube/connector_generate.go
+++ b/internal/cmd/skupper/connector/nonkube/connector_generate.go
@@ -57,6 +57,14 @@ func (cmd *CmdConnectorGenerate) ValidateInput(args []string) error {
 	connectorTypeValidator := validator.NewOptionValidator(common.ConnectorTypes)
 	outputTypeValidator := validator.NewOptionValidator(common.OutputTypes)
 	hostStringValidator := validator.NewHostStringValidator()
+	namespaceStringValidator := validator.NamespaceStringValidator()
+
+	if cmd.namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
+	}
 
 	// Validate arguments name and port
 	if len(args) < 2 {

--- a/internal/cmd/skupper/connector/nonkube/connector_generate_test.go
+++ b/internal/cmd/skupper/connector/nonkube/connector_generate_test.go
@@ -15,6 +15,7 @@ import (
 func TestNonKubeCmdConnectorGenerate_ValidateInput(t *testing.T) {
 	type test struct {
 		name              string
+		namespace         string
 		args              []string
 		k8sObjects        []runtime.Object
 		skupperObjects    []runtime.Object
@@ -26,42 +27,49 @@ func TestNonKubeCmdConnectorGenerate_ValidateInput(t *testing.T) {
 	testTable := []test{
 		{
 			name:          "Connector name and port are not specified",
+			namespace:     "test",
 			args:          []string{},
 			flags:         &common.CommandConnectorGenerateFlags{Host: "1.2.3.4"},
 			expectedError: "connector name and port must be configured",
 		},
 		{
 			name:          "Connector name is not valid",
+			namespace:     "test",
 			args:          []string{"my new Connector", "8080"},
 			flags:         &common.CommandConnectorGenerateFlags{Host: "1.2.3.4"},
 			expectedError: "connector name is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$",
 		},
 		{
 			name:          "Connector name is empty",
+			namespace:     "test",
 			args:          []string{"", "1234"},
 			flags:         &common.CommandConnectorGenerateFlags{Host: "1.2.3.4"},
 			expectedError: "connector name must not be empty",
 		},
 		{
 			name:          "connector port empty",
+			namespace:     "test",
 			args:          []string{"my-name-port-empty", ""},
 			flags:         &common.CommandConnectorGenerateFlags{Host: "1.2.3.4"},
 			expectedError: "connector port must not be empty",
 		},
 		{
 			name:          "port is not valid",
+			namespace:     "test",
 			args:          []string{"my-connector-port", "abcd"},
 			flags:         &common.CommandConnectorGenerateFlags{Host: "1.2.3.4"},
 			expectedError: "connector port is not valid: strconv.Atoi: parsing \"abcd\": invalid syntax",
 		},
 		{
 			name:          "port not positive",
+			namespace:     "test",
 			args:          []string{"my-port-positive", "-45"},
 			flags:         &common.CommandConnectorGenerateFlags{Host: "1.2.3.4"},
 			expectedError: "connector port is not valid: value is not positive",
 		},
 		{
 			name:          "more than two arguments was specified",
+			namespace:     "test",
 			args:          []string{"my", "Connector", "test"},
 			flags:         &common.CommandConnectorGenerateFlags{Host: "1.2.3.4"},
 			expectedError: "only two arguments are allowed for this command",
@@ -91,12 +99,14 @@ func TestNonKubeCmdConnectorGenerate_ValidateInput(t *testing.T) {
 		},
 		{
 			name:          "tlsCredentials is not valid",
+			namespace:     "test",
 			args:          []string{"my-connector-tls", "8080"},
 			flags:         &common.CommandConnectorGenerateFlags{TlsCredentials: "not-valid$", Host: "1.2.3.4"},
 			expectedError: "tlsCredentials is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$",
 		},
 		{
 			name:          "output format is not valid",
+			namespace:     "test",
 			args:          []string{"my-connector", "8080"},
 			flags:         &common.CommandConnectorGenerateFlags{Output: "not-valid", Host: "1.2.3.4"},
 			expectedError: "output type is not valid: value not-valid not allowed. It should be one of this options: [json yaml]",
@@ -109,6 +119,13 @@ func TestNonKubeCmdConnectorGenerate_ValidateInput(t *testing.T) {
 				common.FlagNameContext:    "test",
 				common.FlagNameKubeconfig: "test",
 			},
+		},
+		{
+			name:          "invalid namespace",
+			namespace:     "TestInvalid",
+			args:          []string{"my-connector", "8080"},
+			flags:         &common.CommandConnectorGenerateFlags{},
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
 		},
 		{
 			name: "flags all valid",
@@ -131,6 +148,7 @@ func TestNonKubeCmdConnectorGenerate_ValidateInput(t *testing.T) {
 			if test.flags != nil {
 				command.Flags = test.flags
 			}
+			command.namespace = test.namespace
 
 			if test.cobraGenericFlags != nil && len(test.cobraGenericFlags) > 0 {
 				for name, value := range test.cobraGenericFlags {

--- a/internal/cmd/skupper/connector/nonkube/connector_update.go
+++ b/internal/cmd/skupper/connector/nonkube/connector_update.go
@@ -48,6 +48,7 @@ func (cmd *CmdConnectorUpdate) ValidateInput(args []string) error {
 	numberValidator := validator.NewNumberValidator()
 	connectorTypeValidator := validator.NewOptionValidator(common.ConnectorTypes)
 	hostStringValidator := validator.NewHostStringValidator()
+	namespaceStringValidator := validator.NamespaceStringValidator()
 
 	if cmd.CobraCmd != nil && cmd.CobraCmd.Flag(common.FlagNameContext) != nil && cmd.CobraCmd.Flag(common.FlagNameContext).Value.String() != "" {
 		fmt.Println("Warning: --context flag is not supported on this platform")
@@ -55,6 +56,13 @@ func (cmd *CmdConnectorUpdate) ValidateInput(args []string) error {
 
 	if cmd.CobraCmd != nil && cmd.CobraCmd.Flag(common.FlagNameKubeconfig) != nil && cmd.CobraCmd.Flag(common.FlagNameKubeconfig).Value.String() != "" {
 		fmt.Println("Warning: --kubeconfig flag is not supported on this platform")
+	}
+
+	if cmd.namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
 	}
 
 	// Validate arguments name

--- a/internal/cmd/skupper/connector/nonkube/connector_update_test.go
+++ b/internal/cmd/skupper/connector/nonkube/connector_update_test.go
@@ -18,6 +18,7 @@ import (
 func TestCmdConnectorUpdate_ValidateInput(t *testing.T) {
 	type test struct {
 		name              string
+		namespace         string
 		args              []string
 		flags             *common.CommandConnectorUpdateFlags
 		cobraGenericFlags map[string]string
@@ -35,12 +36,14 @@ func TestCmdConnectorUpdate_ValidateInput(t *testing.T) {
 	testTable := []test{
 		{
 			name:          "connector is not updated because get connector returned error",
+			namespace:     "test",
 			args:          []string{"no-connector"},
 			flags:         &common.CommandConnectorUpdateFlags{Host: "1.2.3.4"},
 			expectedError: "connector no-connector must exist in namespace test to be updated",
 		},
 		{
 			name:          "connector name is not specified",
+			namespace:     "test",
 			args:          []string{},
 			flags:         &common.CommandConnectorUpdateFlags{Host: "localhost"},
 			expectedError: "connector name must be configured",
@@ -104,8 +107,16 @@ func TestCmdConnectorUpdate_ValidateInput(t *testing.T) {
 			expectedError: "",
 		},
 		{
-			name: "flags all valid",
-			args: []string{"my-connector"},
+			name:          "invalid namespace",
+			namespace:     "TestInvalid",
+			args:          []string{"my-connector"},
+			flags:         &common.CommandConnectorUpdateFlags{Host: "localhost"},
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+		},
+		{
+			name:      "flags all valid",
+			namespace: "test",
+			args:      []string{"my-connector"},
 			flags: &common.CommandConnectorUpdateFlags{
 				RoutingKey:     "routingkeyname",
 				TlsCredentials: "secretname",
@@ -151,6 +162,7 @@ func TestCmdConnectorUpdate_ValidateInput(t *testing.T) {
 			if test.flags != nil {
 				command.Flags = test.flags
 			}
+			command.namespace = test.namespace
 
 			if test.cobraGenericFlags != nil && len(test.cobraGenericFlags) > 0 {
 				for name, value := range test.cobraGenericFlags {

--- a/internal/cmd/skupper/link/nonkube/link_delete.go
+++ b/internal/cmd/skupper/link/nonkube/link_delete.go
@@ -33,6 +33,14 @@ func (cmd *CmdLinkDelete) NewClient(cobraCommand *cobra.Command, args []string) 
 func (cmd *CmdLinkDelete) ValidateInput(args []string) error {
 	var validationErrors []error
 	resourceStringValidator := validator.NewResourceStringValidator()
+	namespaceStringValidator := validator.NamespaceStringValidator()
+
+	if cmd.namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
+	}
 
 	// Validate arguments name if specified
 	if len(args) > 1 {

--- a/internal/cmd/skupper/link/nonkube/link_delete_test.go
+++ b/internal/cmd/skupper/link/nonkube/link_delete_test.go
@@ -19,6 +19,7 @@ import (
 func TestCmdLinkDelete_ValidateInput(t *testing.T) {
 	type test struct {
 		name              string
+		namespace         string
 		args              []string
 		linkHandler       *fs.LinkHandler
 		flags             *common.CommandLinkDeleteFlags
@@ -37,18 +38,21 @@ func TestCmdLinkDelete_ValidateInput(t *testing.T) {
 	testTable := []test{
 		{
 			name:          "Link name is not specified",
+			namespace:     "test",
 			args:          []string{},
 			flags:         &common.CommandLinkDeleteFlags{},
 			expectedError: "link name must be specified",
 		},
 		{
 			name:          "Link name is nil",
+			namespace:     "test",
 			args:          []string{""},
 			flags:         &common.CommandLinkDeleteFlags{},
 			expectedError: "link name must not be empty",
 		},
 		{
 			name:          "Link name is not valid",
+			namespace:     "test",
 			args:          []string{"my name"},
 			flags:         &common.CommandLinkDeleteFlags{},
 			expectedError: "link name is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$",
@@ -75,6 +79,13 @@ func TestCmdLinkDelete_ValidateInput(t *testing.T) {
 				common.FlagNameKubeconfig: "test",
 			},
 		},
+		{
+			name:          "invalid namespace",
+			namespace:     "TestInvalid",
+			args:          []string{"link-mine"},
+			flags:         &common.CommandLinkDeleteFlags{},
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$\nThere is no link resource in the namespace with the name \"link-mine\"",
+		},
 	}
 
 	// Add temp files so Link exists for update tests
@@ -84,7 +95,7 @@ func TestCmdLinkDelete_ValidateInput(t *testing.T) {
 			Kind:       "Link",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "Link-mine",
+			Name:      "link-mine",
 			Namespace: "test",
 		},
 	}
@@ -105,6 +116,7 @@ func TestCmdLinkDelete_ValidateInput(t *testing.T) {
 			if test.flags != nil {
 				command.Flags = test.flags
 			}
+			command.namespace = test.namespace
 
 			if test.cobraGenericFlags != nil && len(test.cobraGenericFlags) > 0 {
 				for name, value := range test.cobraGenericFlags {

--- a/internal/cmd/skupper/link/nonkube/link_generate.go
+++ b/internal/cmd/skupper/link/nonkube/link_generate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/nonkube/client/fs"
 	nonkubecommon "github.com/skupperproject/skupper/internal/nonkube/common"
+	"github.com/skupperproject/skupper/internal/utils/validator"
 	"github.com/skupperproject/skupper/pkg/nonkube/api"
 	"github.com/spf13/cobra"
 )
@@ -40,11 +41,18 @@ func (cmd *CmdLinkGenerate) NewClient(cobraCommand *cobra.Command, args []string
 }
 
 func (cmd *CmdLinkGenerate) ValidateInput(args []string) error {
-
 	var validationErrors []error
+	namespaceStringValidator := validator.NamespaceStringValidator()
 
 	if len(args) > 0 {
 		validationErrors = append(validationErrors, fmt.Errorf("arguments are not allowed in this command"))
+	}
+
+	if cmd.Namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.Namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
 	}
 
 	pathProvider := fs.PathProvider{Namespace: cmd.Namespace}

--- a/internal/cmd/skupper/listener/nonkube/listener_create.go
+++ b/internal/cmd/skupper/listener/nonkube/listener_create.go
@@ -54,6 +54,14 @@ func (cmd *CmdListenerCreate) ValidateInput(args []string) error {
 	numberValidator := validator.NewNumberValidator()
 	listenerTypeValidator := validator.NewOptionValidator(common.ListenerTypes)
 	hostStringValidator := validator.NewHostStringValidator()
+	namespaceStringValidator := validator.NamespaceStringValidator()
+
+	if cmd.namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
+	}
 
 	// Validate arguments name and port
 	if len(args) < 2 {

--- a/internal/cmd/skupper/listener/nonkube/listener_create_test.go
+++ b/internal/cmd/skupper/listener/nonkube/listener_create_test.go
@@ -15,6 +15,7 @@ import (
 func TestNonKubeCmdListenerCreate_ValidateInput(t *testing.T) {
 	type test struct {
 		name              string
+		namespace         string
 		args              []string
 		k8sObjects        []runtime.Object
 		skupperObjects    []runtime.Object
@@ -26,18 +27,21 @@ func TestNonKubeCmdListenerCreate_ValidateInput(t *testing.T) {
 	testTable := []test{
 		{
 			name:          "listener name and port are not specified",
+			namespace:     "test",
 			args:          []string{},
 			flags:         &common.CommandListenerCreateFlags{Host: "1.2.3.4"},
 			expectedError: "listener name and port must be configured",
 		},
 		{
 			name:          "listener name is not valid",
+			namespace:     "test",
 			args:          []string{"my new Listener", "8080"},
 			flags:         &common.CommandListenerCreateFlags{Host: "1.2.3.4"},
 			expectedError: "listener name is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$",
 		},
 		{
 			name:          "listener name is empty",
+			namespace:     "test",
 			args:          []string{"", "1234"},
 			flags:         &common.CommandListenerCreateFlags{Host: "1.2.3.4"},
 			expectedError: "listener name must not be empty",
@@ -100,6 +104,13 @@ func TestNonKubeCmdListenerCreate_ValidateInput(t *testing.T) {
 			},
 		},
 		{
+			name:          "invalid namespace",
+			namespace:     "TestInvalid",
+			args:          []string{"my-listener-invalid", "8080"},
+			flags:         &common.CommandListenerCreateFlags{},
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+		},
+		{
 			name: "flags all valid",
 			args: []string{"my-listener-flags", "8080"},
 			flags: &common.CommandListenerCreateFlags{
@@ -115,6 +126,7 @@ func TestNonKubeCmdListenerCreate_ValidateInput(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			command := &CmdListenerCreate{Flags: &common.CommandListenerCreateFlags{}}
 			command.CobraCmd = &cobra.Command{Use: "test"}
+			command.namespace = test.namespace
 
 			if test.flags != nil {
 				command.Flags = test.flags

--- a/internal/cmd/skupper/listener/nonkube/listener_delete.go
+++ b/internal/cmd/skupper/listener/nonkube/listener_delete.go
@@ -44,6 +44,14 @@ func (cmd *CmdListenerDelete) ValidateInput(args []string) error {
 	}
 
 	resourceStringValidator := validator.NewResourceStringValidator()
+	namespaceStringValidator := validator.NamespaceStringValidator()
+
+	if cmd.namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
+	}
 
 	// Validate arguments name
 	if len(args) < 1 {

--- a/internal/cmd/skupper/listener/nonkube/listener_delete_test.go
+++ b/internal/cmd/skupper/listener/nonkube/listener_delete_test.go
@@ -19,6 +19,7 @@ import (
 func TestCmdListenerDelete_ValidateInput(t *testing.T) {
 	type test struct {
 		name              string
+		namespace         string
 		args              []string
 		flags             *common.CommandListenerDeleteFlags
 		cobraGenericFlags map[string]string
@@ -36,18 +37,21 @@ func TestCmdListenerDelete_ValidateInput(t *testing.T) {
 	testTable := []test{
 		{
 			name:          "listener name is not specified",
+			namespace:     "test",
 			args:          []string{},
 			flags:         &common.CommandListenerDeleteFlags{},
 			expectedError: "listener name must be specified",
 		},
 		{
 			name:          "listener name is nil",
+			namespace:     "test",
 			args:          []string{""},
 			flags:         &common.CommandListenerDeleteFlags{},
 			expectedError: "listener name must not be empty",
 		},
 		{
 			name:          "listener name is not valid",
+			namespace:     "test",
 			args:          []string{"my name"},
 			flags:         &common.CommandListenerDeleteFlags{},
 			expectedError: "listener name is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$",
@@ -73,6 +77,13 @@ func TestCmdListenerDelete_ValidateInput(t *testing.T) {
 				common.FlagNameContext:    "test",
 				common.FlagNameKubeconfig: "test",
 			},
+		},
+		{
+			name:          "invalid namespace",
+			namespace:     "TestInvalid",
+			args:          []string{"my-listener"},
+			flags:         &common.CommandListenerDeleteFlags{},
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
 		},
 	}
 
@@ -105,6 +116,7 @@ func TestCmdListenerDelete_ValidateInput(t *testing.T) {
 			if test.flags != nil {
 				command.Flags = test.flags
 			}
+			command.namespace = test.namespace
 
 			if test.cobraGenericFlags != nil && len(test.cobraGenericFlags) > 0 {
 				for name, value := range test.cobraGenericFlags {

--- a/internal/cmd/skupper/listener/nonkube/listener_generate.go
+++ b/internal/cmd/skupper/listener/nonkube/listener_generate.go
@@ -57,6 +57,14 @@ func (cmd *CmdListenerGenerate) ValidateInput(args []string) error {
 	listenerTypeValidator := validator.NewOptionValidator(common.ListenerTypes)
 	outputTypeValidator := validator.NewOptionValidator(common.OutputTypes)
 	hostStringValidator := validator.NewHostStringValidator()
+	namespaceStringValidator := validator.NamespaceStringValidator()
+
+	if cmd.namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
+	}
 
 	// Validate arguments name and port
 	if len(args) < 2 {

--- a/internal/cmd/skupper/listener/nonkube/listener_generate_test.go
+++ b/internal/cmd/skupper/listener/nonkube/listener_generate_test.go
@@ -15,6 +15,7 @@ import (
 func TestNonKubeCmdListenerGenerate_ValidateInput(t *testing.T) {
 	type test struct {
 		name              string
+		namespace         string
 		args              []string
 		k8sObjects        []runtime.Object
 		skupperObjects    []runtime.Object
@@ -26,18 +27,21 @@ func TestNonKubeCmdListenerGenerate_ValidateInput(t *testing.T) {
 	testTable := []test{
 		{
 			name:          "listener name and port are not specified",
+			namespace:     "test",
 			args:          []string{},
 			flags:         &common.CommandListenerGenerateFlags{Host: "1.2.3.4"},
 			expectedError: "listener name and port must be configured",
 		},
 		{
 			name:          "listener name is not valid",
+			namespace:     "test",
 			args:          []string{"my new Listener", "8080"},
 			flags:         &common.CommandListenerGenerateFlags{Host: "1.2.3.4"},
 			expectedError: "listener name is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$",
 		},
 		{
 			name:          "listener name is empty",
+			namespace:     "test",
 			args:          []string{"", "1234"},
 			flags:         &common.CommandListenerGenerateFlags{Host: "1.2.3.4"},
 			expectedError: "listener name must not be empty",
@@ -106,6 +110,13 @@ func TestNonKubeCmdListenerGenerate_ValidateInput(t *testing.T) {
 			},
 		},
 		{
+			name:          "invalid namespace",
+			namespace:     "TestInvalid",
+			args:          []string{"my-listener", "8080"},
+			flags:         &common.CommandListenerGenerateFlags{Host: "1.2.3.4"},
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+		},
+		{
 			name: "flags all valid",
 			args: []string{"my-listener-flags", "8080"},
 			flags: &common.CommandListenerGenerateFlags{
@@ -126,6 +137,7 @@ func TestNonKubeCmdListenerGenerate_ValidateInput(t *testing.T) {
 			if test.flags != nil {
 				command.Flags = test.flags
 			}
+			command.namespace = test.namespace
 
 			if test.cobraGenericFlags != nil && len(test.cobraGenericFlags) > 0 {
 				for name, value := range test.cobraGenericFlags {

--- a/internal/cmd/skupper/listener/nonkube/listener_update.go
+++ b/internal/cmd/skupper/listener/nonkube/listener_update.go
@@ -48,6 +48,7 @@ func (cmd *CmdListenerUpdate) ValidateInput(args []string) error {
 	numberValidator := validator.NewNumberValidator()
 	listenerTypeValidator := validator.NewOptionValidator(common.ListenerTypes)
 	hostStringValidator := validator.NewHostStringValidator()
+	namespaceStringValidator := validator.NamespaceStringValidator()
 
 	if cmd.CobraCmd != nil && cmd.CobraCmd.Flag(common.FlagNameContext) != nil && cmd.CobraCmd.Flag(common.FlagNameContext).Value.String() != "" {
 		fmt.Println("Warning: --context flag is not supported on this platform")
@@ -55,6 +56,13 @@ func (cmd *CmdListenerUpdate) ValidateInput(args []string) error {
 
 	if cmd.CobraCmd != nil && cmd.CobraCmd.Flag(common.FlagNameKubeconfig) != nil && cmd.CobraCmd.Flag(common.FlagNameKubeconfig).Value.String() != "" {
 		fmt.Println("Warning: --kubeconfig flag is not supported on this platform")
+	}
+
+	if cmd.namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
 	}
 
 	// Validate arguments name

--- a/internal/cmd/skupper/listener/nonkube/listener_update_test.go
+++ b/internal/cmd/skupper/listener/nonkube/listener_update_test.go
@@ -19,6 +19,7 @@ import (
 func TestCmdListenerUpdate_ValidateInput(t *testing.T) {
 	type test struct {
 		name              string
+		namespace         string
 		args              []string
 		flags             *common.CommandListenerUpdateFlags
 		cobraGenericFlags map[string]string
@@ -36,18 +37,21 @@ func TestCmdListenerUpdate_ValidateInput(t *testing.T) {
 	testTable := []test{
 		{
 			name:          "Listener is not updated because get listener returned error",
+			namespace:     "test",
 			args:          []string{"no-listener"},
 			flags:         &common.CommandListenerUpdateFlags{},
 			expectedError: "listener no-listener must exist in namespace test to be updated",
 		},
 		{
 			name:          "listener name is not specified",
+			namespace:     "test",
 			args:          []string{},
 			flags:         &common.CommandListenerUpdateFlags{},
 			expectedError: "listener name must be configured",
 		},
 		{
 			name:          "listener name is nil",
+			namespace:     "test",
 			args:          []string{""},
 			flags:         &common.CommandListenerUpdateFlags{},
 			expectedError: "listener name must not be empty",
@@ -105,6 +109,13 @@ func TestCmdListenerUpdate_ValidateInput(t *testing.T) {
 			expectedError: "",
 		},
 		{
+			name:          "invalid namespace",
+			namespace:     "TestInvalid",
+			args:          []string{"my-connector"},
+			flags:         &common.CommandListenerUpdateFlags{},
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$\nlistener my-connector must exist in namespace TestInvalid to be updated",
+		},
+		{
 			name: "flags all valid",
 			args: []string{"my-listener"},
 			flags: &common.CommandListenerUpdateFlags{
@@ -148,6 +159,7 @@ func TestCmdListenerUpdate_ValidateInput(t *testing.T) {
 			if test.flags != nil {
 				command.Flags = test.flags
 			}
+			command.namespace = test.namespace
 
 			if test.cobraGenericFlags != nil && len(test.cobraGenericFlags) > 0 {
 				for name, value := range test.cobraGenericFlags {

--- a/internal/cmd/skupper/site/nonkube/site_create_test.go
+++ b/internal/cmd/skupper/site/nonkube/site_create_test.go
@@ -13,6 +13,7 @@ import (
 func TestNonKubeCmdSiteCreate_ValidateInput(t *testing.T) {
 	type test struct {
 		name              string
+		namespace         string
 		args              []string
 		flags             *common.CommandSiteCreateFlags
 		cobraGenericFlags map[string]string
@@ -22,24 +23,28 @@ func TestNonKubeCmdSiteCreate_ValidateInput(t *testing.T) {
 	testTable := []test{
 		{
 			name:          "site name is not valid.",
+			namespace:     "test1",
 			args:          []string{"my new site"},
 			flags:         &common.CommandSiteCreateFlags{EnableLinkAccess: true},
 			expectedError: "site name is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$",
 		},
 		{
 			name:          "site name is not specified.",
+			namespace:     "test2",
 			args:          []string{},
 			flags:         &common.CommandSiteCreateFlags{},
 			expectedError: "site name must not be empty",
 		},
 		{
 			name:          "more than one argument was specified",
+			namespace:     "test3",
 			args:          []string{"my", "site"},
 			flags:         &common.CommandSiteCreateFlags{},
 			expectedError: "only one argument is allowed for this command",
 		},
 		{
 			name:          "kubernetes flags are not valid on this platform",
+			namespace:     "test4",
 			args:          []string{"my-site"},
 			flags:         &common.CommandSiteCreateFlags{},
 			expectedError: "",
@@ -49,8 +54,16 @@ func TestNonKubeCmdSiteCreate_ValidateInput(t *testing.T) {
 			},
 		},
 		{
-			name: "flags all valid",
-			args: []string{"my-site"},
+			name:          "invalid namespace",
+			namespace:     "Test5",
+			args:          []string{"my-site"},
+			flags:         &common.CommandSiteCreateFlags{},
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+		},
+		{
+			name:      "flags all valid",
+			namespace: "test6",
+			args:      []string{"my-site"},
 			flags: &common.CommandSiteCreateFlags{
 				EnableLinkAccess: true,
 			},
@@ -62,6 +75,7 @@ func TestNonKubeCmdSiteCreate_ValidateInput(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			command := &CmdSiteCreate{Flags: &common.CommandSiteCreateFlags{}}
 			command.CobraCmd = &cobra.Command{Use: "test"}
+			command.namespace = test.namespace
 			command.siteHandler = fs.NewSiteHandler(command.namespace)
 
 			if test.flags != nil {

--- a/internal/cmd/skupper/site/nonkube/site_delete.go
+++ b/internal/cmd/skupper/site/nonkube/site_delete.go
@@ -37,6 +37,7 @@ func (cmd *CmdSiteDelete) ValidateInput(args []string) error {
 	var validationErrors []error
 	opts := fs.GetOptions{RuntimeFirst: false, LogWarning: false}
 	resourceStringValidator := validator.NewResourceStringValidator()
+	namespaceStringValidator := validator.NamespaceStringValidator()
 
 	if cmd.CobraCmd != nil && cmd.CobraCmd.Flag(common.FlagNameContext) != nil && cmd.CobraCmd.Flag(common.FlagNameContext).Value.String() != "" {
 		fmt.Println("Warning: --context flag is not supported on this platform")
@@ -44,6 +45,13 @@ func (cmd *CmdSiteDelete) ValidateInput(args []string) error {
 
 	if cmd.CobraCmd != nil && cmd.CobraCmd.Flag(common.FlagNameKubeconfig) != nil && cmd.CobraCmd.Flag(common.FlagNameKubeconfig).Value.String() != "" {
 		fmt.Println("Warning: --kubeconfig flag is not supported on this platform")
+	}
+
+	if cmd.namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
 	}
 
 	// Validate arguments name

--- a/internal/cmd/skupper/site/nonkube/site_delete_test.go
+++ b/internal/cmd/skupper/site/nonkube/site_delete_test.go
@@ -19,6 +19,7 @@ import (
 func TestCmdSiteDelete_ValidateInput(t *testing.T) {
 	type test struct {
 		name              string
+		namespace         string
 		args              []string
 		flags             *common.CommandSiteDeleteFlags
 		cobraGenericFlags map[string]string
@@ -36,41 +37,48 @@ func TestCmdSiteDelete_ValidateInput(t *testing.T) {
 	testTable := []test{
 		{
 			name:          "site name is not specified",
+			namespace:     "test",
 			args:          []string{},
 			flags:         &common.CommandSiteDeleteFlags{},
 			expectedError: "site name must be specified",
 		},
 		{
-			name:  "site name is not specified, all",
-			args:  []string{},
-			flags: &common.CommandSiteDeleteFlags{All: true},
+			name:      "site name is not specified, all",
+			namespace: "test",
+			args:      []string{},
+			flags:     &common.CommandSiteDeleteFlags{All: true},
 		},
 		{
 			name:          "site name is nil",
+			namespace:     "test",
 			args:          []string{""},
 			flags:         &common.CommandSiteDeleteFlags{All: false},
 			expectedError: "site name must not be empty",
 		},
 		{
 			name:          "site name is not valid",
+			namespace:     "test",
 			args:          []string{"my name"},
 			flags:         &common.CommandSiteDeleteFlags{},
 			expectedError: "site name is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$",
 		},
 		{
 			name:          "more than one argument is specified",
+			namespace:     "test",
 			args:          []string{"my", "site"},
 			flags:         &common.CommandSiteDeleteFlags{},
 			expectedError: "only one argument is allowed for this command",
 		},
 		{
 			name:          "site doesn't exist",
+			namespace:     "test",
 			args:          []string{"no-site"},
 			flags:         &common.CommandSiteDeleteFlags{},
 			expectedError: "site no-site does not exist",
 		},
 		{
 			name:          "kubernetes flags are not valid on this platform",
+			namespace:     "test",
 			args:          []string{"my-site"},
 			flags:         &common.CommandSiteDeleteFlags{},
 			expectedError: "",
@@ -78,6 +86,13 @@ func TestCmdSiteDelete_ValidateInput(t *testing.T) {
 				common.FlagNameContext:    "test",
 				common.FlagNameKubeconfig: "test",
 			},
+		},
+		{
+			name:          "invalid namespace",
+			namespace:     "TestInvalid",
+			args:          []string{"my-site"},
+			flags:         &common.CommandSiteDeleteFlags{},
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
 		},
 	}
 
@@ -110,6 +125,7 @@ func TestCmdSiteDelete_ValidateInput(t *testing.T) {
 			if test.flags != nil {
 				command.Flags = test.flags
 			}
+			command.namespace = test.namespace
 
 			if test.cobraGenericFlags != nil && len(test.cobraGenericFlags) > 0 {
 				for name, value := range test.cobraGenericFlags {

--- a/internal/cmd/skupper/site/nonkube/site_generate.go
+++ b/internal/cmd/skupper/site/nonkube/site_generate.go
@@ -6,6 +6,8 @@ package nonkube
 import (
 	"errors"
 	"fmt"
+	"log/slog"
+
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common/utils"
 	"github.com/skupperproject/skupper/internal/nonkube/client/fs"
@@ -13,7 +15,6 @@ import (
 	"github.com/skupperproject/skupper/pkg/apis/skupper/v2alpha1"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"log/slog"
 )
 
 type CmdSiteGenerate struct {
@@ -48,6 +49,7 @@ func (cmd *CmdSiteGenerate) ValidateInput(args []string) error {
 	var validationErrors []error
 	resourceStringValidator := validator.NewResourceStringValidator()
 	outputTypeValidator := validator.NewOptionValidator(common.OutputTypes)
+	namespaceStringValidator := validator.NamespaceStringValidator()
 
 	if cmd.CobraCmd != nil && cmd.CobraCmd.Flag(common.FlagNameContext) != nil && cmd.CobraCmd.Flag(common.FlagNameContext).Value.String() != "" {
 		fmt.Println("Warning: --context flag is not supported on this platform")
@@ -55,6 +57,13 @@ func (cmd *CmdSiteGenerate) ValidateInput(args []string) error {
 
 	if cmd.CobraCmd != nil && cmd.CobraCmd.Flag(common.FlagNameKubeconfig) != nil && cmd.CobraCmd.Flag(common.FlagNameKubeconfig).Value.String() != "" {
 		fmt.Println("Warning: --kubeconfig flag is not supported on this platform")
+	}
+
+	if cmd.namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
 	}
 
 	if len(args) == 0 || args[0] == "" {

--- a/internal/cmd/skupper/site/nonkube/site_generate_test.go
+++ b/internal/cmd/skupper/site/nonkube/site_generate_test.go
@@ -14,6 +14,7 @@ import (
 func TestNonKubeCmdSiteGenerate_ValidateInput(t *testing.T) {
 	type test struct {
 		name              string
+		namespace         string
 		args              []string
 		flags             *common.CommandSiteGenerateFlags
 		cobraGenericFlags map[string]string
@@ -23,40 +24,53 @@ func TestNonKubeCmdSiteGenerate_ValidateInput(t *testing.T) {
 	testTable := []test{
 		{
 			name:          "site name is not valid.",
+			namespace:     "test",
 			args:          []string{"my new site"},
 			flags:         &common.CommandSiteGenerateFlags{},
 			expectedError: "site name is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$",
 		},
 		{
 			name:          "site name is not specified.",
+			namespace:     "test",
 			args:          []string{},
 			flags:         &common.CommandSiteGenerateFlags{},
 			expectedError: "site name must not be empty",
 		},
 		{
 			name:          "more than one argument was specified",
+			namespace:     "test",
 			args:          []string{"my", "site"},
 			flags:         &common.CommandSiteGenerateFlags{},
 			expectedError: "only one argument is allowed for this command",
 		},
 		{
 			name:          "output format is not valid",
+			namespace:     "test",
 			args:          []string{"my-site"},
 			flags:         &common.CommandSiteGenerateFlags{Output: "not-valid"},
 			expectedError: "output type is not valid: value not-valid not allowed. It should be one of this options: [json yaml]",
 		},
 		{
-			name:  "kubernetes flags are not valid on this platform",
-			args:  []string{"my-site"},
-			flags: &common.CommandSiteGenerateFlags{},
+			name:      "kubernetes flags are not valid on this platform",
+			namespace: "test",
+			args:      []string{"my-site"},
+			flags:     &common.CommandSiteGenerateFlags{},
 			cobraGenericFlags: map[string]string{
 				common.FlagNameContext:    "test",
 				common.FlagNameKubeconfig: "test",
 			},
 		},
 		{
-			name: "flags all valid",
-			args: []string{"my-site"},
+			name:          "invalid namespace",
+			namespace:     "TestInvalid",
+			args:          []string{"my-site"},
+			flags:         &common.CommandSiteGenerateFlags{},
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+		},
+		{
+			name:      "flags all valid",
+			namespace: "test",
+			args:      []string{"my-site"},
 			flags: &common.CommandSiteGenerateFlags{
 				EnableLinkAccess: true,
 			},
@@ -67,7 +81,7 @@ func TestNonKubeCmdSiteGenerate_ValidateInput(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			command := &CmdSiteGenerate{Flags: &common.CommandSiteGenerateFlags{}}
 			command.CobraCmd = &cobra.Command{Use: "test"}
-
+			command.namespace = test.namespace
 			if test.flags != nil {
 				command.Flags = test.flags
 			}

--- a/internal/cmd/skupper/site/nonkube/site_update.go
+++ b/internal/cmd/skupper/site/nonkube/site_update.go
@@ -3,6 +3,7 @@ package nonkube
 import (
 	"errors"
 	"fmt"
+
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/nonkube/client/fs"
 	"github.com/skupperproject/skupper/internal/utils/validator"
@@ -41,6 +42,7 @@ func (cmd *CmdSiteUpdate) ValidateInput(args []string) error {
 	var validationErrors []error
 	opts := fs.GetOptions{RuntimeFirst: false, LogWarning: false}
 	resourceStringValidator := validator.NewResourceStringValidator()
+	namespaceStringValidator := validator.NamespaceStringValidator()
 
 	if cmd.CobraCmd != nil && cmd.CobraCmd.Flag(common.FlagNameContext) != nil && cmd.CobraCmd.Flag(common.FlagNameContext).Value.String() != "" {
 		fmt.Println("Warning: --context flag is not supported on this platform")
@@ -48,6 +50,13 @@ func (cmd *CmdSiteUpdate) ValidateInput(args []string) error {
 
 	if cmd.CobraCmd != nil && cmd.CobraCmd.Flag(common.FlagNameKubeconfig) != nil && cmd.CobraCmd.Flag(common.FlagNameKubeconfig).Value.String() != "" {
 		fmt.Println("Warning: --kubeconfig flag is not supported on this platform")
+	}
+
+	if cmd.namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
 	}
 
 	// Validate arguments name

--- a/internal/cmd/skupper/site/nonkube/site_update_test.go
+++ b/internal/cmd/skupper/site/nonkube/site_update_test.go
@@ -18,6 +18,7 @@ import (
 func TestCmdSiteUpdate_ValidateInput(t *testing.T) {
 	type test struct {
 		name              string
+		namespace         string
 		args              []string
 		flags             *common.CommandSiteUpdateFlags
 		cobraGenericFlags map[string]string
@@ -35,24 +36,28 @@ func TestCmdSiteUpdate_ValidateInput(t *testing.T) {
 	testTable := []test{
 		{
 			name:          "site is not updated because get site returned error",
+			namespace:     "test4",
 			args:          []string{"no-site"},
 			flags:         &common.CommandSiteUpdateFlags{},
 			expectedError: "site no-site must exist to be updated",
 		},
 		{
 			name:          "site name is not specified",
+			namespace:     "test4",
 			args:          []string{},
 			flags:         &common.CommandSiteUpdateFlags{},
 			expectedError: "site name must be configured",
 		},
 		{
 			name:          "site name is nil",
+			namespace:     "test4",
 			args:          []string{""},
 			flags:         &common.CommandSiteUpdateFlags{},
 			expectedError: "site name must not be empty",
 		},
 		{
 			name:          "more than one argument is specified",
+			namespace:     "test4",
 			args:          []string{"my", "site"},
 			flags:         &common.CommandSiteUpdateFlags{},
 			expectedError: "only one argument is allowed for this command",
@@ -64,8 +69,16 @@ func TestCmdSiteUpdate_ValidateInput(t *testing.T) {
 			expectedError: "site name is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])*(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])*)*$",
 		},
 		{
-			name: "flags all valid",
-			args: []string{"my-site"},
+			name:          "invalid namespace",
+			namespace:     "TestInvalid",
+			args:          []string{"my-site"},
+			flags:         &common.CommandSiteUpdateFlags{},
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+		},
+		{
+			name:      "flags all valid",
+			namespace: "test4",
+			args:      []string{"my-site"},
 			flags: &common.CommandSiteUpdateFlags{
 				EnableLinkAccess: true,
 			},
@@ -133,6 +146,8 @@ func TestCmdSiteUpdate_ValidateInput(t *testing.T) {
 			if test.flags != nil {
 				command.Flags = test.flags
 			}
+
+			command.namespace = test.namespace
 
 			if test.cobraGenericFlags != nil && len(test.cobraGenericFlags) > 0 {
 				for name, value := range test.cobraGenericFlags {

--- a/internal/cmd/skupper/system/nonkube/system_apply.go
+++ b/internal/cmd/skupper/system/nonkube/system_apply.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/nonkube/client/fs"
+	"github.com/skupperproject/skupper/internal/utils/validator"
 	skupperv2alpha1 "github.com/skupperproject/skupper/pkg/generated/client/clientset/versioned/typed/skupper/v2alpha1"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
@@ -60,6 +61,7 @@ func (cmd *CmdSystemApply) NewClient(cobraCommand *cobra.Command, args []string)
 
 func (cmd *CmdSystemApply) ValidateInput(args []string) error {
 	var validationErrors []error
+	namespaceStringValidator := validator.NamespaceStringValidator()
 
 	if len(args) > 0 {
 		validationErrors = append(validationErrors, fmt.Errorf("This command does not accept arguments"))
@@ -67,6 +69,13 @@ func (cmd *CmdSystemApply) ValidateInput(args []string) error {
 
 	if cmd.Flags == nil || cmd.Flags.Filename == "" {
 		validationErrors = append(validationErrors, fmt.Errorf("You need to provide a file to apply or use standard input.\n Example: cat site.yaml | skupper system apply -f -"))
+	}
+
+	if cmd.Namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.Namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
 	}
 
 	if cmd.Flags != nil && cmd.Flags.Filename != "" && cmd.Flags.Filename != "-" {

--- a/internal/cmd/skupper/system/nonkube/system_apply_test.go
+++ b/internal/cmd/skupper/system/nonkube/system_apply_test.go
@@ -3,19 +3,21 @@ package nonkube
 import (
 	"bufio"
 	"fmt"
+	"log"
+	"os"
+	"testing"
+
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common/testutils"
 	"github.com/skupperproject/skupper/internal/nonkube/client/fs"
 	"github.com/spf13/cobra"
 	"gotest.tools/v3/assert"
-	"log"
-	"os"
-	"testing"
 )
 
 func TestCmdSystemApply_ValidateInput(t *testing.T) {
 	type test struct {
 		name          string
+		namespace     string
 		args          []string
 		flags         *common.CommandSystemApplyFlags
 		expectedError string
@@ -24,6 +26,7 @@ func TestCmdSystemApply_ValidateInput(t *testing.T) {
 	testTable := []test{
 		{
 			name:          "arguments are not accepted",
+			namespace:     "test",
 			args:          []string{"something"},
 			flags:         &common.CommandSystemApplyFlags{Filename: "-"},
 			expectedError: "This command does not accept arguments",
@@ -48,12 +51,19 @@ func TestCmdSystemApply_ValidateInput(t *testing.T) {
 			flags:         &common.CommandSystemApplyFlags{Filename: "file.txt"},
 			expectedError: "The file has an unsupported extension, it should have one of the following: .yaml, .json\nThe file \"file.txt\" does not exist",
 		},
+		{
+			name:          "invalid-namespace",
+			namespace:     "Invalid",
+			flags:         &common.CommandSystemApplyFlags{Filename: "-"},
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+		},
 	}
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
 
 			command := &CmdSystemApply{Flags: test.flags}
+			command.Namespace = test.namespace
 
 			testutils.CheckValidateInput(t, command, test.expectedError, test.args)
 		})

--- a/internal/cmd/skupper/system/nonkube/system_delete.go
+++ b/internal/cmd/skupper/system/nonkube/system_delete.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/nonkube/client/fs"
+	"github.com/skupperproject/skupper/internal/utils/validator"
 	skupperv2alpha1 "github.com/skupperproject/skupper/pkg/generated/client/clientset/versioned/typed/skupper/v2alpha1"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
@@ -60,6 +61,7 @@ func (cmd *CmdSystemDelete) NewClient(cobraCommand *cobra.Command, args []string
 
 func (cmd *CmdSystemDelete) ValidateInput(args []string) error {
 	var validationErrors []error
+	namespaceStringValidator := validator.NamespaceStringValidator()
 
 	if len(args) > 0 {
 		validationErrors = append(validationErrors, fmt.Errorf("This command does not accept arguments"))
@@ -67,6 +69,13 @@ func (cmd *CmdSystemDelete) ValidateInput(args []string) error {
 
 	if cmd.Flags == nil || cmd.Flags.Filename == "" {
 		validationErrors = append(validationErrors, fmt.Errorf("You need to provide a file to delete custom resources or use standard input.\n Example: cat site.yaml | skupper system delete -f -"))
+	}
+
+	if cmd.Namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.Namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
 	}
 
 	if cmd.Flags != nil && cmd.Flags.Filename != "" && cmd.Flags.Filename != "-" {

--- a/internal/cmd/skupper/system/nonkube/system_delete_test.go
+++ b/internal/cmd/skupper/system/nonkube/system_delete_test.go
@@ -2,18 +2,20 @@ package nonkube
 
 import (
 	"fmt"
+	"log"
+	"os"
+	"testing"
+
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common/testutils"
 	"github.com/spf13/cobra"
 	"gotest.tools/v3/assert"
-	"log"
-	"os"
-	"testing"
 )
 
 func TestCmdSystemDelete_ValidateInput(t *testing.T) {
 	type test struct {
 		name          string
+		namespace     string
 		args          []string
 		flags         *common.CommandSystemDeleteFlags
 		expectedError string
@@ -46,12 +48,19 @@ func TestCmdSystemDelete_ValidateInput(t *testing.T) {
 			flags:         &common.CommandSystemDeleteFlags{Filename: "file.txt"},
 			expectedError: "The file has an unsupported extension, it should have one of the following: .yaml, .json\nThe file \"file.txt\" does not exist",
 		},
+		{
+			name:          "invalid-namespace",
+			namespace:     "Invalid",
+			flags:         &common.CommandSystemDeleteFlags{Filename: "-"},
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+		},
 	}
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
 
 			command := &CmdSystemDelete{Flags: test.flags}
+			command.Namespace = test.namespace
 
 			testutils.CheckValidateInput(t, command, test.expectedError, test.args)
 		})

--- a/internal/cmd/skupper/system/nonkube/system_generate-bundle_test.go
+++ b/internal/cmd/skupper/system/nonkube/system_generate-bundle_test.go
@@ -2,20 +2,22 @@ package nonkube
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"testing"
+
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common/testutils"
 	"github.com/skupperproject/skupper/internal/config"
 	"github.com/skupperproject/skupper/internal/nonkube/bootstrap"
 	"github.com/skupperproject/skupper/pkg/nonkube/api"
 	"gotest.tools/v3/assert"
-	"os"
-	"strings"
-	"testing"
 )
 
 func TestCmdSystemGenerateBundle_ValidateInput(t *testing.T) {
 	type test struct {
 		name          string
+		namespace     string
 		args          []string
 		flags         *common.CommandSystemGenerateBundleFlags
 		expectedError string
@@ -24,6 +26,7 @@ func TestCmdSystemGenerateBundle_ValidateInput(t *testing.T) {
 	testTable := []test{
 		{
 			name:          "no-args",
+			namespace:     "test",
 			args:          []string{},
 			expectedError: "You need to specify a name for the bundle file to generate.",
 		},
@@ -55,6 +58,12 @@ func TestCmdSystemGenerateBundle_ValidateInput(t *testing.T) {
 				Input: "./",
 			},
 		},
+		{
+			name:          "invalid-namespace",
+			namespace:     "Invalid",
+			args:          []string{"bundle-name"},
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+		},
 	}
 
 	for _, test := range testTable {
@@ -62,7 +71,7 @@ func TestCmdSystemGenerateBundle_ValidateInput(t *testing.T) {
 
 			command := &CmdSystemGenerateBundle{}
 			command.CobraCmd = common.ConfigureCobraCommand(common.PlatformLinux, common.SkupperCmdDescription{}, command, nil)
-
+			command.Namespace = test.namespace
 			if test.flags != nil {
 				command.Flags = test.flags
 			}

--- a/internal/cmd/skupper/system/nonkube/system_reload.go
+++ b/internal/cmd/skupper/system/nonkube/system_reload.go
@@ -7,6 +7,7 @@ import (
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/config"
 	"github.com/skupperproject/skupper/internal/nonkube/bootstrap"
+	"github.com/skupperproject/skupper/internal/utils/validator"
 	"github.com/skupperproject/skupper/pkg/nonkube/api"
 	"github.com/spf13/cobra"
 )
@@ -35,11 +36,21 @@ func (cmd *CmdSystemReload) NewClient(cobraCommand *cobra.Command, args []string
 }
 
 func (cmd *CmdSystemReload) ValidateInput(args []string) error {
+	var validationErrors []error
+	namespaceStringValidator := validator.NamespaceStringValidator()
+
 	if len(args) > 0 {
-		return errors.New("this command does not accept arguments")
+		validationErrors = append(validationErrors, fmt.Errorf("this command does not accept arguments"))
 	}
 
-	return nil
+	if cmd.Namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.Namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
+	}
+
+	return errors.Join(validationErrors...)
 }
 
 func (cmd *CmdSystemReload) InputToOptions() {

--- a/internal/cmd/skupper/system/nonkube/system_reload_test.go
+++ b/internal/cmd/skupper/system/nonkube/system_reload_test.go
@@ -16,6 +16,7 @@ import (
 func TestCmdSystemReload_ValidateInput(t *testing.T) {
 	type test struct {
 		name          string
+		namespace     string
 		args          []string
 		expectedError string
 	}
@@ -26,12 +27,18 @@ func TestCmdSystemReload_ValidateInput(t *testing.T) {
 			args:          []string{"something"},
 			expectedError: "this command does not accept arguments",
 		},
+		{
+			name:          "invalid-namespace",
+			namespace:     "Invalid",
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+		},
 	}
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
 
 			command := &CmdSystemReload{}
+			command.Namespace = test.namespace
 			command.CobraCmd = common.ConfigureCobraCommand(common.PlatformLinux, common.SkupperCmdDescription{}, command, nil)
 
 			testutils.CheckValidateInput(t, command, test.expectedError, test.args)

--- a/internal/cmd/skupper/system/nonkube/system_start.go
+++ b/internal/cmd/skupper/system/nonkube/system_start.go
@@ -3,12 +3,14 @@ package nonkube
 import (
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/config"
 	"github.com/skupperproject/skupper/internal/nonkube/bootstrap"
+	"github.com/skupperproject/skupper/internal/utils/validator"
 	"github.com/skupperproject/skupper/pkg/nonkube/api"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 type CmdSystemStart struct {
@@ -36,6 +38,7 @@ func (cmd *CmdSystemStart) NewClient(cobraCommand *cobra.Command, args []string)
 
 func (cmd *CmdSystemStart) ValidateInput(args []string) error {
 	var validationErrors []error
+	namespaceStringValidator := validator.NamespaceStringValidator()
 
 	if args != nil && len(args) > 0 {
 		validationErrors = append(validationErrors, fmt.Errorf("this command does not accept arguments"))
@@ -43,6 +46,10 @@ func (cmd *CmdSystemStart) ValidateInput(args []string) error {
 
 	selectedNamespace := "default"
 	if cmd.Namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.Namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
 		selectedNamespace = cmd.Namespace
 	}
 

--- a/internal/cmd/skupper/system/nonkube/system_start_test.go
+++ b/internal/cmd/skupper/system/nonkube/system_start_test.go
@@ -2,7 +2,6 @@ package nonkube
 
 import (
 	"fmt"
-	"github.com/skupperproject/skupper/internal/utils"
 	"os"
 	"testing"
 
@@ -26,8 +25,14 @@ func TestCmdSystemSetup_ValidateInput(t *testing.T) {
 		{
 			name:          "args-are-not-accepted",
 			args:          []string{"something"},
-			namespace:     utils.RandomId(4),
+			namespace:     "test",
 			expectedError: "this command does not accept arguments",
+		},
+		{
+			name:          "invalid-namespace",
+			args:          []string{},
+			namespace:     "Invalid",
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
 		},
 	}
 

--- a/internal/cmd/skupper/system/nonkube/system_stop.go
+++ b/internal/cmd/skupper/system/nonkube/system_stop.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/skupperproject/skupper/internal/config"
 	"github.com/skupperproject/skupper/internal/nonkube/bootstrap"
+	"github.com/skupperproject/skupper/internal/utils/validator"
 	"github.com/spf13/cobra"
 )
 
@@ -30,11 +31,21 @@ func (cmd *CmdSystemStop) NewClient(cobraCommand *cobra.Command, args []string) 
 }
 
 func (cmd *CmdSystemStop) ValidateInput(args []string) error {
+	var validationErrors []error
+	namespaceStringValidator := validator.NamespaceStringValidator()
+
 	if len(args) > 0 {
-		return errors.New("this command does not accept arguments")
+		validationErrors = append(validationErrors, fmt.Errorf("this command does not accept arguments"))
 	}
 
-	return nil
+	if cmd.Namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.Namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
+	}
+
+	return errors.Join(validationErrors...)
 }
 
 func (cmd *CmdSystemStop) InputToOptions() {

--- a/internal/cmd/skupper/system/nonkube/system_stop_test.go
+++ b/internal/cmd/skupper/system/nonkube/system_stop_test.go
@@ -12,6 +12,7 @@ import (
 func TestCmdSystemTearDown_ValidateInput(t *testing.T) {
 	type test struct {
 		name          string
+		namespace     string
 		args          []string
 		expectedError string
 	}
@@ -22,12 +23,18 @@ func TestCmdSystemTearDown_ValidateInput(t *testing.T) {
 			args:          []string{"namespace"},
 			expectedError: "this command does not accept arguments",
 		},
+		{
+			name:          "invalid-namespace",
+			namespace:     "Invalid",
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+		},
 	}
 
 	for _, test := range testTable {
 		t.Run(test.name, func(t *testing.T) {
 
 			command := &CmdSystemStop{}
+			command.Namespace = test.namespace
 			command.CobraCmd = common.ConfigureCobraCommand(common.PlatformLinux, common.SkupperCmdDescription{}, command, nil)
 
 			testutils.CheckValidateInput(t, command, test.expectedError, test.args)

--- a/internal/cmd/skupper/system/nonkube/system_uninstall.go
+++ b/internal/cmd/skupper/system/nonkube/system_uninstall.go
@@ -10,6 +10,7 @@ import (
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/config"
 	"github.com/skupperproject/skupper/internal/nonkube/bootstrap"
+	"github.com/skupperproject/skupper/internal/utils/validator"
 	"github.com/skupperproject/skupper/pkg/nonkube/api"
 	"github.com/spf13/cobra"
 )
@@ -40,6 +41,7 @@ func (cmd *CmdSystemUninstall) NewClient(cobraCommand *cobra.Command, args []str
 
 func (cmd *CmdSystemUninstall) ValidateInput(args []string) error {
 	var validationErrors []error
+	namespaceStringValidator := validator.NamespaceStringValidator()
 
 	if len(args) > 0 {
 		validationErrors = append(validationErrors, fmt.Errorf("this command does not accept arguments"))
@@ -47,6 +49,13 @@ func (cmd *CmdSystemUninstall) ValidateInput(args []string) error {
 
 	if config.GetPlatform() != types.PlatformPodman && config.GetPlatform() != types.PlatformDocker {
 		validationErrors = append(validationErrors, fmt.Errorf("the selected platform is not supported by this command. There is nothing to uninstall"))
+	}
+
+	if cmd.Namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.Namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
 	}
 
 	if cmd.Flags != nil && !cmd.Flags.Force {

--- a/internal/cmd/skupper/system/nonkube/system_uninstall_test.go
+++ b/internal/cmd/skupper/system/nonkube/system_uninstall_test.go
@@ -25,6 +25,7 @@ type CmdSiteStatus struct {
 func TestCmdSystemUnInstall_ValidateInput(t *testing.T) {
 	type test struct {
 		name          string
+		namespace     string
 		args          []string
 		flags         *common.CommandSystemUninstallFlags
 		platform      string
@@ -69,6 +70,12 @@ func TestCmdSystemUnInstall_ValidateInput(t *testing.T) {
 			platform:      "linux",
 			expectedError: "the selected platform is not supported by this command. There is nothing to uninstall",
 		},
+		{
+			name:          "invalid-namespace",
+			namespace:     "Invalid",
+			platform:      "podman",
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+		},
 	}
 
 	for _, test := range testTable {
@@ -81,6 +88,7 @@ func TestCmdSystemUnInstall_ValidateInput(t *testing.T) {
 			command := newCmdSystemUninstallWithMocks(false)
 			command.CheckActiveSites = test.mock
 			command.Flags = test.flags
+			command.Namespace = test.namespace
 
 			testutils.CheckValidateInput(t, command, test.expectedError, test.args)
 		})

--- a/internal/cmd/skupper/token/nonkube/token_redeem.go
+++ b/internal/cmd/skupper/token/nonkube/token_redeem.go
@@ -3,12 +3,13 @@ package nonkube
 import (
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/skupperproject/skupper/internal/nonkube/client/fs"
 	nonkubecommon "github.com/skupperproject/skupper/internal/nonkube/common"
 	"github.com/skupperproject/skupper/internal/utils/validator"
 	"github.com/skupperproject/skupper/pkg/apis/skupper/v2alpha1"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-	"os"
 
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/pkg/generated/client/clientset/versioned/scheme"
@@ -42,6 +43,14 @@ func (cmd *CmdTokenRedeem) NewClient(cobraCommand *cobra.Command, args []string)
 func (cmd *CmdTokenRedeem) ValidateInput(args []string) error {
 	var validationErrors []error
 	tokenStringValidator := validator.NewFilePathStringValidator()
+	namespaceStringValidator := validator.NamespaceStringValidator()
+
+	if cmd.Namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.Namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
+		}
+	}
 
 	// Validate token file name
 	if len(args) < 1 {

--- a/internal/cmd/skupper/version/nonkube/version.go
+++ b/internal/cmd/skupper/version/nonkube/version.go
@@ -3,10 +3,11 @@ package nonkube
 import (
 	"errors"
 	"fmt"
-	internalclient "github.com/skupperproject/skupper/internal/nonkube/client/compat"
-	"github.com/skupperproject/skupper/pkg/nonkube/api"
 	"os"
 	"text/tabwriter"
+
+	internalclient "github.com/skupperproject/skupper/internal/nonkube/client/compat"
+	"github.com/skupperproject/skupper/pkg/nonkube/api"
 
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common/utils"
@@ -44,6 +45,7 @@ func (cmd *CmdVersion) NewClient(cobraCommand *cobra.Command, args []string) {
 func (cmd *CmdVersion) ValidateInput(args []string) error {
 	var validationErrors []error
 	outputTypeValidator := validator.NewOptionValidator(common.OutputTypes)
+	namespaceStringValidator := validator.NamespaceStringValidator()
 
 	if cmd.Flags != nil && cmd.Flags.Output != "" {
 		ok, err := outputTypeValidator.Evaluate(cmd.Flags.Output)
@@ -51,6 +53,13 @@ func (cmd *CmdVersion) ValidateInput(args []string) error {
 			validationErrors = append(validationErrors, fmt.Errorf("output type is not valid: %s", err))
 		} else {
 			cmd.output = cmd.Flags.Output
+		}
+	}
+
+	if cmd.namespace != "" {
+		ok, err := namespaceStringValidator.Evaluate(cmd.namespace)
+		if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("namespace is not valid: %s", err))
 		}
 	}
 

--- a/internal/cmd/skupper/version/nonkube/version_test.go
+++ b/internal/cmd/skupper/version/nonkube/version_test.go
@@ -54,6 +54,11 @@ func TestCmdVersion_ValidateInput(t *testing.T) {
 			flags:         common.CommandVersionFlags{},
 			expectedError: "there is no definition for namespace \"unknown\"",
 		},
+		{
+			name:          "invalid-namespace",
+			namespace:     "Invalid",
+			expectedError: "namespace is not valid: value does not match this regular expression: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$\nthere is no definition for namespace \"Invalid\"",
+		},
 	}
 
 	for _, test := range testTable {

--- a/internal/utils/validator/simple_validator.go
+++ b/internal/utils/validator/simple_validator.go
@@ -48,6 +48,12 @@ func NewFilePathStringValidator() *stringValidator {
 	}
 }
 
+func NamespaceStringValidator() *stringValidator {
+	return &stringValidator{
+		Expression: regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`),
+	}
+}
+
 func (s stringValidator) Evaluate(value interface{}) (bool, error) {
 	v, ok := value.(string)
 


### PR DESCRIPTION
When creating a site verify the namespace configured follows proper format.

fixes #2207