### PR TITLE
Fixes race with Network Status Handler

### DIFF
--- a/internal/nonkube/controller/network_status_handler.go
+++ b/internal/nonkube/controller/network_status_handler.go
@@ -159,4 +159,5 @@ func (n *NetworkStatusHandler) Filter(name string) bool {
 }
 
 func (n *NetworkStatusHandler) OnCreate(name string) {
+	n.OnUpdate(name)
 }


### PR DESCRIPTION
The NetworkStatusHandler test was failing because the NetworkStatusHandler was expecting
that the configmap was already added, capturing only update events.

But if the path is added to the watcher and the configmap is written in between the startup of
the file watcher and the moment the configmap is flushed to the filesystem, the update event
was not being triggered, and instead it was triggering a create event, which was not captured.