### PR TITLE
Network Observer Chart Proxy Args

### DIFF
--- a/charts/network-observer/templates/_deployment.yaml
+++ b/charts/network-observer/templates/_deployment.yaml
@@ -31,6 +31,13 @@ imagePullPolicy: {{ .Values.nginx.pullPolicy }}
 securityContext:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+
+{{- if .Values.nginx.args }}
+args:
+{{- range .Values.nginx.args }}
+  - {{ . }}
+{{- end }}
+{{- end }}
 ports:
   - name: https
     containerPort: 8443
@@ -61,6 +68,9 @@ args:
   - -tls-cert=/etc/certificates/tls.crt
   - -tls-key=/etc/certificates/tls.key
   - -cookie-secret-file=/etc/session-secrets/secret
+  {{- range .Values.openshiftOauthProxy.extraArgs }}
+  - {{ . }}
+  {{- end }}
 ports:
   - name: https
     containerPort: 8443

--- a/charts/network-observer/values.yaml
+++ b/charts/network-observer/values.yaml
@@ -30,6 +30,8 @@ nginx:
   repository: "mirror.gcr.io/nginxinc/nginx-unprivileged"
   tag: "1.27.3-alpine"
   pullPolicy: IfNotPresent
+  # args to pass to the nginx proxy container
+  args: []
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
@@ -46,6 +48,9 @@ openshiftOauthProxy:
     capabilities:
       drop:
         - ALL
+  # extraArgs to pass to the oauth proxy container
+  extraArgs: []
+
 
 # extraArgs to pass to the network-observer container
 extraArgs:


### PR DESCRIPTION
Adds values and templates for adding arguments to the proxy containers in the network-observer deployment.