### PR TITLE
increase resource retry value for expose-pods-by-name test

### DIFF
--- a/tests/e2e/scenarios/expose-pods-by-name/inventory/group_vars/all.yml
+++ b/tests/e2e/scenarios/expose-pods-by-name/inventory/group_vars/all.yml
@@ -5,5 +5,5 @@ debug: false
 namespace_prefix: "e2e"
 generate_namespaces_namespace_label: "xpbn"
 remove_namespaces: true
-resource_retry_value: 30
+resource_retry_value: 60
 resource_delay_value: 10

--- a/tests/e2e/scenarios/expose-pods-by-name/inventory/group_vars/all.yml
+++ b/tests/e2e/scenarios/expose-pods-by-name/inventory/group_vars/all.yml
@@ -6,4 +6,4 @@ namespace_prefix: "e2e"
 generate_namespaces_namespace_label: "xpbn"
 remove_namespaces: true
 resource_retry_value: 60
-resource_delay_value: 10
+resource_delay_value: 20


### PR DESCRIPTION
After merging #2202 (before merging it, e2e test passed), the CI pipeline is failing in main in this step:

```
FAILED - RETRYING: [west]: [ ExposePodsByNameTest - RunTest ] Wait for each old service to disappear (1 retries left).
failed: [west] (item=backend-8465dfcd48-ttvzv) => {"ansible_loop_var": "item", "api_found": true, "attempts": 30, "changed": false, "item": "backend-8465dfcd48-ttvzv", "resources": [{"apiVersion": "v1", "kind": "Service", "metadata": {"annotations": {"internal.skupper.io/controlled": "true"}, "creationTimestamp": "2025-08-20T18:27:25Z", "labels": {"internal.skupper.io/listener": "true"}, "managedFields": [{"apiVersion": "v1", "fieldsType": "FieldsV1", "fieldsV1": {"f:metadata": {"f:annotations": {".": {}, "f:internal.skupper.io/controlled": {}}, "f:labels": {".": {}, "f:internal.skupper.io/listener": {}}, "f:ownerReferences": {".": {}, "k:{\"uid\":\"84197c42-252f-4291-9f94-e41c4659580f\"}": {}}}, "f:spec": {"f:internalTrafficPolicy": {}, "f:ports": {".": {}, "k:{\"port\":8080,\"protocol\":\"TCP\"}": {".": {}, "f:name": {}, "f:port": {}, "f:protocol": {}, "f:targetPort": {}}}, "f:selector": {}, "f:sessionAffinity": {}, "f:type": {}}}, "manager": "controller", "operation": "Update", "time": "2025-08-20T18:27:25Z"}], "name": "backend-8465dfcd48-ttvzv", "namespace": "baif4-west", "ownerReferences": [{"apiVersion": "skupper.io/v2alpha1", "kind": "Site", "name": "west", "uid": "84197c42-252f-4291-9f94-e41c4659580f"}], "resourceVersion": "3171", "uid": "a60b73dc-c362-48c9-97ea-e3c076939424"}, "spec": {"clusterIP": "10.96.139.58", "clusterIPs": ["10.96.139.58"], "internalTrafficPolicy": "Cluster", "ipFamilies": ["IPv4"], "ipFamilyPolicy": "SingleStack", "ports": [{"name": "backend", "port": 8080, "protocol": "TCP", "targetPort": 1026}], "selector": {"application": "skupper-router", "skupper.io/component": "router"}, "sessionAffinity": "None", "type": "ClusterIP"}, "status": {"loadBalancer": {}}}]}
```

This pull request increases the number of retries to see if the issue is environmental.