### PR TITLE
Update nonkube uninstall command with force flag

### DIFF
--- a/internal/cmd/skupper/common/flags.go
+++ b/internal/cmd/skupper/common/flags.go
@@ -82,7 +82,7 @@ for other Kubernetes flavors, loadbalancer is the default.`
 	FlagNameType  = "type"
 	FlagDescType  = "The bundle type to be produced. Choices: tarball, shell-script"
 
-	FlagDescUninstallForce = "option to override even with sites present"
+	FlagDescUninstallForce = "all existing sites (active or not) will be deleted"
 
 	FlagNameHA = "enable-ha"
 	FlagDescHA = "Configure the site for high availability (EnableHA). EnableHA sites have two active routers"

--- a/internal/nonkube/bootstrap/uninstall.go
+++ b/internal/nonkube/bootstrap/uninstall.go
@@ -60,6 +60,8 @@ func Uninstall(platform string) error {
 	err = cli.ContainerRemove(containerName)
 	if err != nil {
 		return fmt.Errorf("failed to remove system-controller container: %v", err)
+	} else {
+		fmt.Println("System-controller has been removed")
 	}
 
 	systemdService, err := controller.NewSystemdServiceInfo(*container, platform)
@@ -86,6 +88,7 @@ func Uninstall(platform string) error {
 }
 
 func CheckActiveSites() (bool, error) {
+	activeSites := false
 
 	entries, err := os.ReadDir(path.Join(api.GetHostDataHome(), "namespaces/"))
 	if err != nil {
@@ -94,9 +97,19 @@ func CheckActiveSites() (bool, error) {
 
 	for _, entry := range entries {
 		if entry.IsDir() {
-			return true, nil
+			runtimeDir := "namespaces/" + entry.Name() + "/runtime/"
+			_, err := os.ReadDir(path.Join(api.GetHostDataHome(), runtimeDir))
+			if err == nil {
+				activeSites = true
+				fmt.Printf("site %s active\n", entry.Name())
+			}
+
 		}
 	}
 
-	return false, nil
+	if activeSites == true {
+		return true, nil
+	} else {
+		return false, nil
+	}
 }


### PR DESCRIPTION
Add logs to indicate what is being uninstalled.
Add logs to help user understand when uninstall fails. 
Add code to delete directory structure, and router sites when force flag is set even if sites are active.

fixes #2192