### PR TITLE
Updates deprecated ansible configuration in e2e

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -45,6 +45,11 @@ test-role: create-venv
 	. /tmp/e2e-venv/bin/activate && \
 	ANSIBLE_CONFIG=$(ROOT_PATH)/e2e/ansible.cfg ansible-playbook roles/$(ROLE)/tests/test_playbook.yml -i roles/$(ROLE)/tests/inventory $(EXTRA_VARS)
 
+version: create-venv
+	. /tmp/e2e-venv/bin/activate && \
+	ANSIBLE_CONFIG=$(ROOT_PATH)/e2e/ansible.cfg \
+	ansible-playbook --version
+
 # Run a specific test (use relative path from e2e/ directory)
 test: FORCE=false
 test: create-venv

--- a/tests/e2e/ansible.cfg
+++ b/tests/e2e/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 # Define the default roles path
-collections_paths = ./collections
+collections_path = ./collections
 roles_path = ./collections/ansible_collections/e2e/tests/roles
 deprecation_warnings=False
 interpreter_python_warnings=False


### PR DESCRIPTION
The collections_paths option in ansible.cfg is deprecated and was removed in ansible 2.19. Switches to the preferred collections_path variable.

Fixes https://github.com/skupperproject/skupper/issues/2255