### PR TITLE
Remove expose-pods-by-name test from CI

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,9 @@
 ROOT_PATH := $(shell pwd)
 EXTRA_VARS := --extra-vars "@$(ROOT_PATH)/vars.yml"
 COLLECTION_PATH := $(ROOT_PATH)/e2e/collections/ansible_collections/e2e/tests
-TESTS_CI := attached-connector,ha,hello-world,expose-pods-by-name,labels-and-annotations
+# Remove expose-pods-by-name from the CI tests, until we close
+# this issue https://github.com/skupperproject/skupper/issues/2251
+TESTS_CI := attached-connector,ha,hello-world,labels-and-annotations
 
 # E2E Test directories
 E2E_TEST_DIRS := $(sort $(wildcard $(ROOT_PATH)/e2e/scenarios/*))


### PR DESCRIPTION
Remove the expose-pods-by-name from the CI tests until 
we fix the issue 2251