### PR TITLE
Changes kube-adaptor startup conditions

### DIFF
--- a/internal/qdr/messaging.go
+++ b/internal/qdr/messaging.go
@@ -3,6 +3,7 @@ package qdr
 import (
 	"context"
 	"crypto/tls"
+	"time"
 
 	amqp "github.com/interconnectedcloud/go-amqp"
 
@@ -14,19 +15,20 @@ type TlsConfigRetriever interface {
 }
 
 type ConnectionFactory struct {
-	url    string
-	config TlsConfigRetriever
+	url            string
+	config         TlsConfigRetriever
+	connectTimeout time.Duration
 }
 
 func (f *ConnectionFactory) Connect() (messaging.Connection, error) {
 	if f.config == nil {
-		return dial(f.url, amqp.ConnMaxFrameSize(4294967295))
+		return dial(f.url, amqp.ConnMaxFrameSize(4294967295), amqp.ConnConnectTimeout(f.connectTimeout))
 	} else {
 		tlsConfig, err := f.config.GetTlsConfig()
 		if err != nil {
 			return nil, err
 		}
-		return dial(f.url, amqp.ConnSASLExternal(), amqp.ConnMaxFrameSize(4294967295), amqp.ConnTLSConfig(tlsConfig))
+		return dial(f.url, amqp.ConnSASLExternal(), amqp.ConnMaxFrameSize(4294967295), amqp.ConnConnectTimeout(f.connectTimeout), amqp.ConnTLSConfig(tlsConfig))
 	}
 }
 


### PR DESCRIPTION
Removes kube-adaptor startup logic that waits for kube-api to have all
router Pods in phase Running. Adds logic to wait for an active skupper
router management endpoint before continuing to handle configuration
events.

Also includes a qdr Agent connection timeout to protect against
transient connection issues blocking the retry loop.

Fixes https://github.com/skupperproject/skupper/issues/2252