### PR TITLE
Fix prefix and workloads; new options

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,6 +2,13 @@ ROOT_PATH := $(shell pwd)
 EXTRA_VARS := --extra-vars "@$(ROOT_PATH)/vars.yml"
 COLLECTION_PATH := $(ROOT_PATH)/e2e/collections/ansible_collections/e2e/tests
 TESTS_CI := attached-connector,ha,hello-world,expose-pods-by-name
+PYTHON ?= python3
+
+# The caller may set a TEST_PREFIX, so they can deal with all namespaces created
+# by these tests with -l e2e.prefix=$TEST_PREFIX.  If not set, we create a random one
+RANDOM != echo $$RANDOM
+TEST_PREFIX ?= $(RANDOM)
+export TEST_PREFIX
 
 # E2E Test directories
 E2E_TEST_DIRS := $(sort $(wildcard $(ROOT_PATH)/e2e/scenarios/*))
@@ -13,7 +20,7 @@ create-venv:
 		echo "Removing old environment if it exists..."; \
 		rm -rf /tmp/e2e-venv; \
 		echo "Creating virtual environment..."; \
-		cd /tmp && python3 -m venv e2e-venv; \
+		cd /tmp && $(PYTHON) -m venv e2e-venv; \
 		if [ -d "/tmp/e2e-venv" ]; then \
 			echo "Virtual environment created successfully at /tmp/e2e-venv"; \
 			. /tmp/e2e-venv/bin/activate && \
@@ -58,15 +65,16 @@ test: create-venv
 		exit 1; \
 	fi
 
-	@export TEST_PREFIX=$$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 5 | head -n 1); \
-	echo "Running the test for directory: $(TEST) with prefix: $$TEST_PREFIX"; \
+	@echo "Running the test for directory: $(TEST) with prefix: $(TEST_PREFIX)";
+
 	. /tmp/e2e-venv/bin/activate && \
 	mkdir -p /tmp/e2e/$(TEST) && \
 	ANSIBLE_LOG_PATH=/tmp/e2e/$(TEST)/ansible_$$(date +%Y%m%d_%H%M%S).log \
 	ANSIBLE_CONFIG=$(ROOT_PATH)/e2e/ansible.cfg \
 	ansible-playbook $(ROOT_PATH)/e2e/scenarios/$(TEST)/test.yml \
 	-i $(ROOT_PATH)/e2e/scenarios/$(TEST)/inventory $(EXTRA_VARS) \
-	-e namespace_prefix=$$TEST_PREFIX; \
+	$(OPTIONS) \
+	-e namespace_prefix=$(TEST_PREFIX); \
 	EXIT_CODE=$$?; \
 	if [ $$EXIT_CODE -ne 0 ]; then \
 		echo "Test $(TEST) failed with exit code $$EXIT_CODE"; \

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,7 +19,7 @@ Note: If you are running the tests from the Makefile, this is not needed, as the
 
 ```
 tests/
-├── e2e/  
+├── e2e/
 ├── scenarios/                 # End-to-end tests directory
 │    ├── hello-world/          # Basic Skupper functionality test
 │    ├── attached-connector/   # Network performance test with attached connectors
@@ -163,6 +163,25 @@ make test-subset TESTS="test1,test2"
 # Run CI tests
 make ci-tests
 ```
+
+3. **Make variables**
+
+The following `make` variables are available:
+
+* `OPTIONS` will provide additional options to the `ansible-playbook` invocation.
+
+  `make e2e-tests OPTIONS="-v"`
+
+* `PYTHON` allows the `venv` to be created with a specific Python binary
+
+  `make create-venv PYTHON=python3.12`
+
+* `TEST_PREFIX` allows one to select a prefix to be added to the name of the tests' namespaces:
+
+  `make e2e-tests TEST_PREFIX=123`
+
+  By default, a random prefix is generated for each run.  The namespaces can be selected on Kubernetes
+  with the label `e2e.prefix`, allowing for easy removal of failed tests, for example.
 
 ### Example summary
 

--- a/tests/e2e/collections/ansible_collections/e2e/tests/roles/generate_namespaces/tasks/main.yml
+++ b/tests/e2e/collections/ansible_collections/e2e/tests/roles/generate_namespaces/tasks/main.yml
@@ -10,6 +10,7 @@
         name: "{{ namespace_prefix }}-{{ namespace_name }}"
         labels:
           e2e.id: "{{ generate_namespaces_namespace_label }}"
+          e2e.prefix: "{{ namespace_prefix }}"
     kubeconfig: "{{ kubeconfig }}"
   register: namespace
 

--- a/tests/e2e/scenarios/hello-world/test.yml
+++ b/tests/e2e/scenarios/hello-world/test.yml
@@ -17,11 +17,15 @@
           include_tasks: skupper-sites.yml
           vars:
             site_name: west
+          when:
+            - "'west' in inventory_hostname"
 
         - name: Create Skupper resources for east site
           include_tasks: skupper-sites.yml
           vars:
             site_name: east
+          when:
+            - "'east' in inventory_hostname"
 
         - name: Issue a Skupper access token from west namespace
           skupper.v2.token:


### PR DESCRIPTION
Fixes:

- Creation of TEST_PREFIX failed on some environments (stuck forever)
- Test workloads were being created in duplication (on both east and west sites)

Improvements:

- Allow selection of PYTHON binary
- Allow definition of additional OPTIONS to the `ansible-playbook` call
- Allow user to override value of TEST_PREFIX