### PR TITLE
Fix typo in listener status update error handling

### DIFF
--- a/internal/kube/site/site.go
+++ b/internal/kube/site/site.go
@@ -867,7 +867,7 @@ func (s *Site) CheckConnector(name string, connector *skupperv2alpha1.Connector)
 func (s *Site) updateListenerStatus(listener *skupperv2alpha1.Listener, err error) error {
 	if listener.SetConfigured(err) {
 		updated, err := s.clients.GetSkupperClient().SkupperV2alpha1().Listeners(listener.ObjectMeta.Namespace).UpdateStatus(context.TODO(), listener, metav1.UpdateOptions{})
-		if err == nil {
+		if err != nil {
 			return err
 		}
 		s.bindings.UpdateListener(updated.Name, updated)


### PR DESCRIPTION
Fixes an error condition where an invalid Listener can be added to the router bridge configuration resulting in a router crash on startup.

Found while investigating an unrelated issue https://github.com/skupperproject/skupper/issues/2267