### PR TITLE
Fixes empty SubjectAlternativeName in Certificates

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -98,10 +98,10 @@ func getCAFromSecret(secret *corev1.Secret) (*CertificateAuthority, error) {
 // GenerateSecret generates a kubernetes secret.
 // name is the corev1.Secret's name.
 // subject is the x509 certificate's common name.
-// hosts are the host names in the x509 certificate. Comma separated if more than one hostname
+// hosts are the host names in the x509 certificate subject alternative names extension.
 // expiration is when the secret expires, if zero is passed in, the expiration is set to 5 years from now
 // ca is the certificate authority, if nil a ca cert will be created.
-func GenerateSecret(name string, subject string, hosts string, expiration time.Duration, ca *corev1.Secret) (*corev1.Secret, error) {
+func GenerateSecret(name string, subject string, hosts []string, expiration time.Duration, ca *corev1.Secret) (*corev1.Secret, error) {
 	caCert, err := getCAFromSecret(ca)
 
 	if err != nil {
@@ -138,8 +138,7 @@ func GenerateSecret(name string, subject string, hosts string, expiration time.D
 		BasicConstraintsValid: true,
 	}
 
-	hosts_list := strings.Split(hosts, ",")
-	for _, h := range hosts_list {
+	for _, h := range hosts {
 		// Remove leading and trailing whitespaces from the string
 		h = strings.TrimSpace(h)
 		if ip := net.ParseIP(h); ip != nil {

--- a/internal/certs/certs_test.go
+++ b/internal/certs/certs_test.go
@@ -23,12 +23,9 @@ import (
 )
 
 func TestGenerateCASecret(t *testing.T) {
-	host1 := "134.565.56.77"
-	host2 := "172.345.82.7"
 	name := "ca-secret"
-	host := host1 + ", " + host2
 	cn := "www.example.com"
-	ca_secret, err := GenerateSecret(name, cn, host, 0, nil)
+	ca_secret, err := GenerateSecret(name, cn, nil, 0, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -42,8 +39,7 @@ func TestGenerateCASecret(t *testing.T) {
 		t.Error("Error decoding certificate")
 	}
 
-	assert.Equal(t, host1, cert.DNSNames[0])
-	assert.Equal(t, host2, cert.DNSNames[1])
+	assert.Equal(t, 0, len(cert.DNSNames))
 	assert.Equal(t, cn, cert.Issuer.CommonName)
 	assert.Equal(t, cert.IsCA, true)
 	assert.Equal(t, name, ca_secret.Name)
@@ -51,13 +47,13 @@ func TestGenerateCASecret(t *testing.T) {
 
 func TestGenerateSecret(t *testing.T) {
 	ca_cn := "www.example.com"
-	ca_secret, err := GenerateSecret("test-secret", ca_cn, "134.565.56.77", 0, nil)
+	ca_secret, err := GenerateSecret("test-secret", ca_cn, []string{"134.565.56.77"}, 0, nil)
 	if err != nil {
 		t.Error(err)
 	}
 	my_secret_cn := "www.my.example.com"
 	my_secret_host := "172.565.56.77"
-	my_secret, err := GenerateSecret("my_secret", my_secret_cn, my_secret_host, 86400000000000 /*duration of 1 day*/, ca_secret)
+	my_secret, err := GenerateSecret("my_secret", my_secret_cn, []string{my_secret_host}, 86400000000000 /*duration of 1 day*/, ca_secret)
 	if err != nil {
 		t.Error(err)
 	}
@@ -85,7 +81,7 @@ func TestGenerateSecret(t *testing.T) {
 		Type: corev1.SecretTypeOpaque,
 	}
 
-	_, err = GenerateSecret("test-secret", ca_cn, "134.565.56.77", 0, caSecret)
+	_, err = GenerateSecret("test-secret", ca_cn, []string{"134.565.56.77"}, 0, caSecret)
 	errorText := err.Error()
 	assert.Equal(t, errorText, "error reading CA Certificate from Secret \"emptyCASecret\": failed to read PEM encoded data from \"tls.crt\"")
 }

--- a/internal/kube/certificates/mgr.go
+++ b/internal/kube/certificates/mgr.go
@@ -330,7 +330,7 @@ func (m *CertificateManagerImpl) generateSecret(certificate *skupperv2alpha1.Cer
 	var secret *corev1.Secret
 	var err error
 	if certificate.Spec.Signing {
-		secret, err = certs.GenerateSecret(certificate.Name, certificate.Spec.Subject, "", 0, nil)
+		secret, err = certs.GenerateSecret(certificate.Name, certificate.Spec.Subject, nil, 0, nil)
 		if err != nil {
 			return secret, err
 		}
@@ -343,7 +343,7 @@ func (m *CertificateManagerImpl) generateSecret(certificate *skupperv2alpha1.Cer
 			return nil, fmt.Errorf("CA %q not found", caKey)
 		}
 		// TODO: handle server and client roles properly
-		secret, err = certs.GenerateSecret(certificate.Name, certificate.Spec.Subject, strings.Join(certificate.Spec.Hosts, ","), expiration, ca)
+		secret, err = certs.GenerateSecret(certificate.Name, certificate.Spec.Subject, certificate.Spec.Hosts, expiration, ca)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/kube/certificates/mgr_test.go
+++ b/internal/kube/certificates/mgr_test.go
@@ -541,7 +541,7 @@ func (c *Call) eventcount(events int) *Call {
 
 func fixtureCASecret(t *testing.T, name, namespace string) *corev1.Secret {
 	t.Helper()
-	secret, err := certs.GenerateSecret(name, "skupper test CA", "", time.Hour*8, nil)
+	secret, err := certs.GenerateSecret(name, "skupper test CA", nil, time.Hour*8, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/kube/grants/common_test.go
+++ b/internal/kube/grants/common_test.go
@@ -3,7 +3,6 @@ package grants
 import (
 	"errors"
 	"io"
-	"strings"
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -133,7 +132,7 @@ func (*factory) grant(name string, namespace string, uid string) *v2alpha1.Acces
 }
 
 func (*factory) secret(name string, namespace string, subject string, hosts []string) (*corev1.Secret, error) {
-	secret, err := certs.GenerateSecret(name, subject, strings.Join(hosts, ","), 0, nil)
+	secret, err := certs.GenerateSecret(name, subject, hosts, 0, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/kube/grants/tokens.go
+++ b/internal/kube/grants/tokens.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,7 +88,7 @@ func (g *TokenGenerator) setValidHostsFromSite(site *skupperv2alpha1.Site) bool 
 }
 
 func (g *TokenGenerator) NewCertToken(name string, subject string) (Token, error) {
-	cert, err := certs.GenerateSecret(name, subject, strings.Join(g.hosts, ","), 0, g.ca)
+	cert, err := certs.GenerateSecret(name, subject, g.hosts, 0, g.ca)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/nonkube/client/runtime/certs_test.go
+++ b/internal/nonkube/client/runtime/certs_test.go
@@ -38,7 +38,7 @@ func TestTlsConfigRetriever(t *testing.T) {
 	t.Run("tls-config-retriever-valid-certs", func(t *testing.T) {
 		validity, err := time.ParseDuration("1h")
 		assert.Assert(t, err)
-		ca, err := certs.GenerateSecret("my-ca", "my-ca", "my-ca.host", validity, nil)
+		ca, err := certs.GenerateSecret("my-ca", "my-ca", []string{"my-ca.host"}, validity, nil)
 		if err != nil {
 			t.Error(err)
 		}

--- a/internal/nonkube/common/fs_config_renderer.go
+++ b/internal/nonkube/common/fs_config_renderer.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"strconv"
-	"strings"
 	"syscall"
 
 	"github.com/skupperproject/skupper/internal/certs"
@@ -371,7 +370,7 @@ func (c *FileSystemConfigurationRenderer) createTlsCertificates(siteState *api.S
 		if certificate.Spec.Signing == false {
 			continue
 		}
-		secret, err := certs.GenerateSecret(name, certificate.Spec.Subject, "", 0, nil)
+		secret, err := certs.GenerateSecret(name, certificate.Spec.Subject, nil, 0, nil)
 		if err != nil {
 			return err
 		}
@@ -403,7 +402,7 @@ func (c *FileSystemConfigurationRenderer) createTlsCertificates(siteState *api.S
 		}
 		if certificate.Spec.Client {
 			purpose = "client"
-			secret, err = certs.GenerateSecret(name, certificate.Spec.Subject, strings.Join(certificate.Spec.Hosts, ","), 0, caSecret)
+			secret, err = certs.GenerateSecret(name, certificate.Spec.Subject, certificate.Spec.Hosts, 0, caSecret)
 			if err != nil {
 				return err
 			}
@@ -413,7 +412,7 @@ func (c *FileSystemConfigurationRenderer) createTlsCertificates(siteState *api.S
 			}
 		} else if certificate.Spec.Server {
 			purpose = "server"
-			secret, err = certs.GenerateSecret(name, certificate.Spec.Subject, strings.Join(certificate.Spec.Hosts, ","), 0, caSecret)
+			secret, err = certs.GenerateSecret(name, certificate.Spec.Subject, certificate.Spec.Hosts, 0, caSecret)
 			if err != nil {
 				return err
 			}

--- a/internal/nonkube/common/fs_config_renderer_test.go
+++ b/internal/nonkube/common/fs_config_renderer_test.go
@@ -122,8 +122,8 @@ func compareCertificates(t *testing.T, customOutputPath string) {
 
 func createInputCertificates(t *testing.T, customOutputPath string) {
 	// preparing certificates
-	fakeHosts := "10.0.0.1,10.0.0.2,fake.domain"
-	ca, err := certs.GenerateSecret("fake-ca", "fake-ca", "", 0, nil)
+	fakeHosts := []string{"10.0.0.1", "10.0.0.2", "fake.domain"}
+	ca, err := certs.GenerateSecret("fake-ca", "fake-ca", nil, 0, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -131,7 +131,7 @@ func createInputCertificates(t *testing.T, customOutputPath string) {
 	if err != nil {
 		t.Error(err)
 	}
-	client, err := certs.GenerateSecret("fake-client-cert", "fake-client-cert", "", 0, ca)
+	client, err := certs.GenerateSecret("fake-client-cert", "fake-client-cert", nil, 0, ca)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/nonkube/api/token_test.go
+++ b/pkg/nonkube/api/token_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/skupperproject/skupper/internal/certs"
@@ -206,11 +205,11 @@ func fakeRouterAccessWithSANs(sans ...string) v2alpha1.RouterAccess {
 }
 
 func fakeServerSecretBad(t *testing.T) *v1.Secret {
-	ca, err := certs.GenerateSecret("fake-ca", "fake-ca", "", 0, nil)
+	ca, err := certs.GenerateSecret("fake-ca", "fake-ca", nil, 0, nil)
 	if err != nil {
 		t.Error(err)
 	}
-	serverCert, err := certs.GenerateSecret("fake-server-cert", "fake-server-cert", "", 0, ca)
+	serverCert, err := certs.GenerateSecret("fake-server-cert", "fake-server-cert", nil, 0, ca)
 	if err != nil {
 		t.Error(err)
 	}
@@ -220,12 +219,11 @@ func fakeServerSecretBad(t *testing.T) *v1.Secret {
 }
 
 func fakeServerSecret(hosts []string, t *testing.T) *v1.Secret {
-	hostsCsv := strings.Join(hosts, ",")
-	ca, err := certs.GenerateSecret("fake-ca", "fake-ca", "", 0, nil)
+	ca, err := certs.GenerateSecret("fake-ca", "fake-ca", nil, 0, nil)
 	if err != nil {
 		t.Error(err)
 	}
-	serverCert, err := certs.GenerateSecret("fake-server-cert", "fake-server-cert", hostsCsv, 0, ca)
+	serverCert, err := certs.GenerateSecret("fake-server-cert", "fake-server-cert", hosts, 0, ca)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Certificates generated by Skupper without additional hosts contain an unintended Subject Alternative Name DNS entry containing the empty string due to a bug in the internal/certs.GenerateSecret. This change to the certs.GenerateSecret function signature fixes the problem of unintended empty DNS entries and alleviates any ambiguity for the caller.

Fixes https://github.com/skupperproject/skupper/issues/2277