### PR TITLE
Clearify error message if user tries to uninstall a nonkube site.

### DIFF
--- a/internal/cmd/skupper/system/nonkube/system_uninstall.go
+++ b/internal/cmd/skupper/system/nonkube/system_uninstall.go
@@ -3,6 +3,7 @@ package nonkube
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path"
 
@@ -99,7 +100,12 @@ func (cmd *CmdSystemUninstall) Run() error {
 	err := cmd.SystemUninstall(string(config.GetPlatform()))
 
 	if err != nil {
-		return fmt.Errorf("failed to uninstall : %s", err)
+		opErr := &net.OpError{}
+		if errors.As(err, &opErr) {
+			return fmt.Errorf("Unable to communicate with the Container Engine.\nRun: \"skupper system install\" to prepare the local environment and start the controller.\n\nError: %s", err)
+		} else {
+			return fmt.Errorf("Unable to uninstall.\nError: %s", err.Error())
+		}
 	}
 
 	return nil

--- a/internal/cmd/skupper/system/nonkube/system_uninstall_test.go
+++ b/internal/cmd/skupper/system/nonkube/system_uninstall_test.go
@@ -139,7 +139,7 @@ func TestCmdSystemUninstall_Run(t *testing.T) {
 		{
 			name:               "disable socket fails",
 			disableSocketFails: true,
-			errorMessage:       "failed to uninstall : disable socket fails",
+			errorMessage:       "Unable to uninstall.\nError: disable socket fails",
 			flags:              &common.CommandSystemUninstallFlags{Force: false},
 		},
 	}

--- a/internal/nonkube/bootstrap/uninstall.go
+++ b/internal/nonkube/bootstrap/uninstall.go
@@ -44,7 +44,7 @@ func Uninstall(platform string) error {
 
 	cli, err := internalclient.NewCompatClient(endpoint, "")
 	if err != nil {
-		return fmt.Errorf("failed to create container client: %v", err)
+		return fmt.Errorf("failed to create container client: %w", err)
 	}
 
 	container, err := cli.ContainerInspect(containerName)


### PR DESCRIPTION
If system-controller or podman socket endpoint is not installed and user issued a "skupper system uninstall" command 
the error message is confusing.   This fix simplifies the error message and provides help on what user should do.

fixes #2281