### PR TITLE
Fix rendering of system site with LinkAccess specified

### DIFF
--- a/internal/nonkube/common/fs_config_renderer.go
+++ b/internal/nonkube/common/fs_config_renderer.go
@@ -139,14 +139,23 @@ func (c *FileSystemConfigurationRenderer) Render(siteState *api.SiteState) error
 					slog.Int("port", role.Port),
 				)
 				endpoints = append(endpoints, v2alpha1.Endpoint{
-					Name: fmt.Sprintf("%s-%s", raName, role.Name),
-					Host: ra.Spec.BindHost,
-					Port: strconv.Itoa(role.Port),
+					Name:  fmt.Sprintf("%s-%s", raName, role.Name),
+					Host:  ra.Spec.BindHost,
+					Port:  strconv.Itoa(role.Port),
+					Group: "skupper-router",
 				})
 			}
 		}
 	}
 	siteState.Site.Status.Endpoints = endpoints
+	if len(endpoints) > 0 {
+		for _, ra := range siteState.RouterAccesses {
+			if ra.FindRole("inter-router") != nil || ra.FindRole("edge") != nil {
+				ra.Resolve(endpoints, "skupper-router")
+			}
+		}
+		siteState.Site.SetEndpoints(endpoints)
+	}
 	return nil
 }
 


### PR DESCRIPTION
The original issue has been reported through the `skupper-ansible` repository: https://github.com/skupperproject/skupper/issues/2294 

Basically if a system Site is defined with `linkAccess: default`, the Site state never
transitions to Ready, as this particular configuration requires the `Resolved` condition
to be set to true.

This PR fixes it, by setting that condition to the respective RouterAccess and Site.

Fixes #2294