### PR TITLE
Adds nginx.command template value to network observer chart

### DIFF
--- a/charts/network-observer/templates/_deployment.yaml
+++ b/charts/network-observer/templates/_deployment.yaml
@@ -27,6 +27,10 @@
 {{- define "network-observer.nginxProxySpec" -}}
 image: "{{ .Values.nginx.repository }}:{{ .Values.nginx.tag }}"
 imagePullPolicy: {{ .Values.nginx.pullPolicy }}
+{{- with .Values.nginx.command }}
+command:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with .Values.nginx.securityContext }}
 securityContext:
   {{- toYaml . | nindent 2 }}

--- a/charts/network-observer/values.yaml
+++ b/charts/network-observer/values.yaml
@@ -27,6 +27,11 @@ prometheus:
 
 # nginx configuration for reverse proxy (excluding openshift auth)
 nginx:
+  # nginx container command
+  command:
+  #   - nginx
+  #   - "-g"
+  #   - "daemon off;"
   repository: "mirror.gcr.io/nginxinc/nginx-unprivileged"
   tag: "1.27.3-alpine"
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Adds nginx.command template value to the network observer chart for the network-observer deployment's nginx proxy container. Allows for alternate images and configurations to be used where the command needs to be specified.