### PR TITLE
Fixes network observer traffic metrics bug

### DIFF
--- a/cmd/network-observer/internal/collector/connections.go
+++ b/cmd/network-observer/internal/collector/connections.go
@@ -122,11 +122,13 @@ func (c *connectionManager) handleTransportFlow(record vanflow.TransportBiflowRe
 	bs, br := dref(record.Octets), dref(record.OctetsReverse)
 	sentInc := float64(bs - state.BytesSent)
 	receivedInc := float64(br - state.BytesReceived)
-	if receivedInc != 0 {
-		metrics.sent.Add(sentInc)
+	if receivedInc > 0 {
 		metrics.received.Add(receivedInc)
-		state.BytesSent = bs
 		state.BytesReceived = br
+	}
+	if sentInc > 0 {
+		metrics.sent.Add(sentInc)
+		state.BytesSent = bs
 	}
 	c.transportFlows.Push(record.ID, state)
 }


### PR DESCRIPTION
Previously traffic metrics (skupper_sent_bytes_total) was only updated when skupper_received_bytes_total was also incremented. This is especially visible in asymetric applications when data flows in one direction like iperf.

Fixes https://github.com/skupperproject/skupper/issues/2309