### PR TITLE
Chart Network Observer incldue ServiceMonitor

### DIFF
--- a/charts/network-observer/templates/_deployment.yaml
+++ b/charts/network-observer/templates/_deployment.yaml
@@ -65,6 +65,9 @@ args:
   - -tls-cert=/etc/certificates/tls.crt
   - -tls-key=/etc/certificates/tls.key
   - -cookie-secret-file=/etc/session-secrets/secret
+  {{ if .Values.auth.openshift.bearerTokenAuth.enabled -}}
+  - -openshift-delegate-urls={{ include "network-observer.bearerTokenAuth" . | fromYaml | toJson }}
+  {{- end }}
 ports:
   - name: https
     containerPort: 8443

--- a/charts/network-observer/templates/_helpers.tpl
+++ b/charts/network-observer/templates/_helpers.tpl
@@ -94,3 +94,27 @@ Create the nginx configmap name
 {{- define "network-observer.setupJobName" -}}
 {{- printf "%s-setup" (include "network-observer.fullname" .) }}
 {{- end }}
+
+{{- define "network-observer.clusterRoleName" -}}
+{{- .Values.auth.openshift.bearerTokenAuth.clusterRoleName | default (include "network-observer.fullname" .) }}
+{{- end }}
+
+{{- define "network-observer.bearerTokenSecret" -}}
+{{- printf "%s-servicemonitor" (include "network-observer.fullname" .) | trunc 63 | trimSuffix "-"}}
+{{- end }}
+
+{{- define "network-observer.serviceMonitorName" -}}
+{{- .Values.serviceMonitor.nameOverride | default (include "network-observer.fullname" .) }}
+{{- end }}
+
+{{- define "network-observer.bearerTokenAuth" -}}
+{{- with .Values.auth.openshift.bearerTokenAuth -}}
+{{- if .enabled -}}
+"/":
+{{ if .resourceAttributes.namespaced }}  namespace: {{ $.Release.Namespace }}{{- end }}
+{{ if .resourceAttributes.group }}  group: {{ .resourceAttributes.group }}{{- end }}
+{{ if .resourceAttributes.resource }}  resource: {{ .resourceAttributes.resource }}{{- end }}
+{{ if .resourceAttributes.verb }}  verb: {{ .resourceAttributes.verb }}{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/network-observer/templates/cluster_rbac.yaml
+++ b/charts/network-observer/templates/cluster_rbac.yaml
@@ -1,0 +1,40 @@
+{{- if and (eq .Values.auth.strategy "openshift") .Values.auth.openshift.bearerTokenAuth.enabled -}}
+{{- if .Values.auth.openshift.bearerTokenAuth.createClusterRole }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ (include "network-observer.clusterRoleName" .) }}
+  labels:
+    {{- include "network-observer.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - "authentication.k8s.io"
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - "authorization.k8s.io"
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+{{- end }}
+{{- if .Values.auth.openshift.bearerTokenAuth.createClusterRoleBinding }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ (include "network-observer.serviceAccountName" .) }}
+  labels:
+    {{- include "network-observer.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ (include "network-observer.clusterRoleName" .) }}
+subjects:
+- kind: ServiceAccount
+  name: {{ (include "network-observer.serviceAccountName" .) }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/network-observer/templates/service_monitor.yaml
+++ b/charts/network-observer/templates/service_monitor.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.serviceMonitor.create }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ (include "network-observer.serviceMonitorName" .) }}
+  labels:
+    {{- include "network-observer.labels" . | nindent 4 }}
+spec:
+  endpoints:
+  - port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+    {{- if .Values.serviceMonitor.bearerTokenSecret.enabled }}
+    {{- if ne .Values.auth.strategy "openshift" }}
+      {{- fail "Configuration Error: serviceMonitor.bearerTokenSecret.enabled can only be set when auth.strategy is 'openshift'" }}
+    {{- end }}
+    bearerTokenSecret:
+      key: {{ .Values.serviceMonitor.bearerTokenSecret.key }}
+      name: {{ (include "network-observer.bearerTokenSecret" .) }}
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "network-observer.selectorLabels" . | nindent 6 }}
+{{- if .Values.serviceMonitor.bearerTokenSecret.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ (include "network-observer.bearerTokenSecret" .) }}
+  labels:
+    {{- include "network-observer.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ (include "network-observer.bearerTokenSecret" .) }}
+  labels:
+    {{- include "network-observer.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - "skupper.io"
+  resources:
+  - sites
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ (include "network-observer.bearerTokenSecret" .) }}
+  labels:
+    {{- include "network-observer.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ (include "network-observer.bearerTokenSecret" .) }}
+subjects:
+- kind: ServiceAccount
+  name: {{ (include "network-observer.bearerTokenSecret" .) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: {{ (include "network-observer.bearerTokenSecret" .) }}
+  labels:
+    {{- include "network-observer.labels" . | nindent 4 }}
+  name: {{ (include "network-observer.bearerTokenSecret" .) }}
+type: kubernetes.io/service-account-token
+{{- end }}
+{{- end }}

--- a/charts/network-observer/values.yaml
+++ b/charts/network-observer/values.yaml
@@ -1,4 +1,4 @@
-# Default values for network-observer.
+# Default bvalues for network-observer.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
@@ -97,7 +97,28 @@ auth:
     serviceAccount:
       create: true
       nameOverride: ""
-
+    # bearerTokenAuth configures the oauth proxy to authenticate http
+    # requests with bearer tokens with the OpenShift master. Requires
+    # additional cluster scoped RBAC.
+    bearerTokenAuth:
+      enabled: true
+      # clusterRoleName is the name of the ClusterRole to create and/or
+      # reference from the ClusterRoleBinding.
+      clusterRoleName: ""
+      # Set createClusterRole to create ClusterRole .clusterRoleName. Defaults
+      # to chart release name.
+      createClusterRole: false
+      # Set createClusterRoleBinding  to create the ClusterRoleBinding for
+      # bearer token auth.
+      createClusterRoleBinding: false
+      # resourceAttributes configures the required access.
+      resourceAttributes:
+        # Set to scope the bearer access to the Chart namespace, otherwise is
+        # cluster scoped.
+        namespaced: true
+        group: skupper.io
+        resource: sites
+        verb: get
 
 # This is for setting Kubernetes Annotations to a Pod.
 podAnnotations: {}
@@ -153,4 +174,13 @@ securityContext:
     drop:
       - ALL
 
+serviceMonitor:
+  create: false
+  nameOverride: ""
+  bearerTokenSecret:
+    enabled: false
+    nameOverride: ""
+    key: token
+    create: true
+  
 skipManagementLabels: false


### PR DESCRIPTION
Adds options to enable configuring a ServiceMonitor in conjunction with auth.strategy = "openshift".

Conditionally creates:
- auth.openshift.bearerTokenAuth configuration to allow bearer token delegation by default when openshift auth is selected.
- New ClusterRole and ClusterRoleBindings Resources to grant openshift auth proxy access to subjectaccessreviews for passed bearer tokens when enabled.
- ServiceMonitor configuration
- New ServiceAccount, Role, RoleBinding, and service-account-token Secret for ServiceMonitor to authenticate with auth proxy when enabled. Works with default configuration of auth.openshift.bearerTokenAuth.