### PR TITLE
upgrade circleci docker orb to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,7 +429,6 @@ jobs:
         type: string
         default: "quay.io/skupper"
     steps:
-      - docker/install-docker
       - skopeo-install
       - checkout
       - run: docker buildx create --use --name skupper-buildx


### PR DESCRIPTION
attempting to resolve broken compatibility between circleci machine image docker client package and the installed version of docker.