### PR TITLE
Fix CI Image Build docker dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 version: 2.1
 orbs:
-    docker: circleci/docker@1.0.1
     kube-orb: circleci/kubernetes@0.11.0
     go: circleci/go@1.7.1
     helm: circleci/helm@3.1.0
@@ -429,7 +428,6 @@ jobs:
         type: string
         default: "quay.io/skupper"
     steps:
-      - docker/install-docker
       - skopeo-install
       - checkout
       - run: docker buildx create --use --name skupper-buildx


### PR DESCRIPTION
Removes superfluous docker install step from build-oci-images CI Job. Installed version was conflicting with containerd running in CircleCI VM image.