### PR TITLE
Adds skupper event processing prometheus metrics

### DIFF
--- a/internal/kube/adaptor/config_sync.go
+++ b/internal/kube/adaptor/config_sync.go
@@ -34,8 +34,8 @@ func sslSecretsWatcher(namespace string, eventProcessor *watchers.EventProcessor
 	}
 }
 
-func NewConfigSync(cli internalclient.Clients, namespace string, path string, routerConfigMap string) *ConfigSync {
-	controller := watchers.NewEventProcessor("config-sync", cli)
+func NewConfigSync(cli internalclient.Clients, namespace string, path string, routerConfigMap string, metrics watchers.MetricsProvider) *ConfigSync {
+	controller := watchers.NewEventProcessor("config-sync", cli, watchers.WithMetricsProvider(metrics))
 	configSync := &ConfigSync{
 		agentPool:       qdr.NewAgentPool("amqp://localhost:5672", nil),
 		controller:      controller,

--- a/internal/kube/controller/controller.go
+++ b/internal/kube/controller/controller.go
@@ -83,11 +83,9 @@ func labelling() internalinterfaces.TweakListOptionsFunc {
 	}
 }
 
-var eventProcessorCustomizers []watchers.EventProcessorCustomizer
-
-func NewController(cli internalclient.Clients, config *Config) (*Controller, error) {
+func NewController(cli internalclient.Clients, config *Config, options ...watchers.EventProcessorCustomizer) (*Controller, error) {
 	controller := &Controller{
-		eventProcessor:       watchers.NewEventProcessor("Controller", cli, eventProcessorCustomizers...),
+		eventProcessor:       watchers.NewEventProcessor("Controller", cli, options...),
 		sites:                map[string]*site.Site{},
 		siteSizing:           sizing.NewRegistry(),
 		labelling:            labels.NewLabelsAndAnnotations(config.Namespace),

--- a/internal/kube/controller/controller_test.go
+++ b/internal/kube/controller/controller_test.go
@@ -761,9 +761,11 @@ func TestUpdate(t *testing.T) {
 			},
 		},
 	}
-	defer func() {
-		eventProcessorCustomizers = nil
-	}()
+	eventProcessorResyncShort := []watchers.EventProcessorCustomizer{
+		func(e *watchers.EventProcessor) {
+			e.SetResyncShort(time.Second)
+		},
+	}
 	for _, tt := range testTable {
 		t.Run(tt.name, func(t *testing.T) {
 			flags := &flag.FlagSet{}
@@ -776,12 +778,7 @@ func TestUpdate(t *testing.T) {
 			clients, err := fakeclient.NewFakeClient(config.Namespace, tt.k8sObjects, tt.skupperObjects, "")
 			assert.Assert(t, err)
 			enableSSA(clients.GetDynamicClient())
-			eventProcessorCustomizers = []watchers.EventProcessorCustomizer{
-				func(e *watchers.EventProcessor) {
-					e.SetResyncShort(time.Second)
-				},
-			}
-			controller, err := NewController(clients, config)
+			controller, err := NewController(clients, config, eventProcessorResyncShort...)
 			assert.Assert(t, err)
 			stopCh := make(chan struct{})
 			err = controller.init(stopCh)

--- a/internal/kube/metrics/eventprocessor.go
+++ b/internal/kube/metrics/eventprocessor.go
@@ -1,0 +1,69 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/skupperproject/skupper/internal/kube/watchers"
+)
+
+func MustRegisterEventProcessorMetrics(registry *prometheus.Registry) watchers.MetricsProvider {
+	provider := eventProcessorMetrics{
+		adds: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "skupper",
+			Subsystem: "workqueue",
+			Name:      "adds_total",
+			Help:      "Total number of events queued.",
+		}, []string{"kind"}),
+		depth: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "skupper",
+			Subsystem: "workqueue",
+			Name:      "depth",
+			Help:      "Current depth of event queue.",
+		}, []string{"kind"}),
+		delayDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "skupper",
+			Subsystem: "workqueue",
+			Name:      "delay_seconds",
+			Help:      "How long in seconds an event is queued before it is handled.",
+			Buckets:   prometheus.ExponentialBuckets(1e-9, 10, 12),
+		}, []string{"kind"}),
+		workDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "skupper",
+			Subsystem: "workqueue",
+			Name:      "duration_seconds",
+			Help:      "How long in seconds handling a watch event takes.",
+			Buckets:   prometheus.ExponentialBuckets(1e-9, 10, 12),
+		}, []string{"kind"}),
+		retries: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "skupper",
+			Subsystem: "workqueue",
+			Name:      "retries_total",
+			Help:      "Total number of retries queued.",
+		}, []string{"kind"}),
+	}
+	registry.MustRegister(provider.adds, provider.depth, provider.delayDuration, provider.workDuration, provider.retries)
+	return provider
+}
+
+type eventProcessorMetrics struct {
+	adds          *prometheus.CounterVec
+	depth         *prometheus.GaugeVec
+	delayDuration *prometheus.HistogramVec
+	workDuration  *prometheus.HistogramVec
+	retries       *prometheus.CounterVec
+}
+
+func (p eventProcessorMetrics) NewAddedMetric(kind string) watchers.CounterMetric {
+	return p.adds.WithLabelValues(kind)
+}
+func (p eventProcessorMetrics) NewDepthMetric(kind string) watchers.GaugeMetric {
+	return p.depth.WithLabelValues(kind)
+}
+func (p eventProcessorMetrics) NewDelayedMetric(kind string) watchers.ObservableMetric {
+	return p.delayDuration.WithLabelValues(kind)
+}
+func (p eventProcessorMetrics) NewWorkDurationMetric(kind string) watchers.ObservableMetric {
+	return p.workDuration.WithLabelValues(kind)
+}
+func (p eventProcessorMetrics) NewRetriesMetric(kind string) watchers.CounterMetric {
+	return p.retries.WithLabelValues(kind)
+}

--- a/internal/kube/watchers/metrics.go
+++ b/internal/kube/watchers/metrics.go
@@ -1,0 +1,114 @@
+package watchers
+
+import (
+	"sync"
+	"time"
+)
+
+type MetricsProvider interface {
+	NewAddedMetric(kind string) CounterMetric
+	NewDepthMetric(kind string) GaugeMetric
+	NewDelayedMetric(kind string) ObservableMetric
+	NewWorkDurationMetric(kind string) ObservableMetric
+	NewRetriesMetric(kind string) CounterMetric
+}
+
+type CounterMetric interface {
+	Inc()
+}
+type GaugeMetric interface {
+	CounterMetric
+	Dec()
+}
+type ObservableMetric interface {
+	Observe(float64)
+}
+
+type noopMetric struct{}
+
+func (noopMetric) Inc()            {}
+func (noopMetric) Dec()            {}
+func (noopMetric) Observe(float64) {}
+
+type noopMetricsProvider struct{}
+
+func (noopMetricsProvider) NewAddedMetric(kind string) CounterMetric           { return noopMetric{} }
+func (noopMetricsProvider) NewDepthMetric(kind string) GaugeMetric             { return noopMetric{} }
+func (noopMetricsProvider) NewDelayedMetric(kind string) ObservableMetric      { return noopMetric{} }
+func (noopMetricsProvider) NewWorkDurationMetric(kind string) ObservableMetric { return noopMetric{} }
+func (noopMetricsProvider) NewRetriesMetric(kind string) CounterMetric         { return noopMetric{} }
+
+type metricsSet struct {
+	Added        CounterMetric
+	Depth        GaugeMetric
+	Delayed      ObservableMetric
+	WorkDuration ObservableMetric
+	Retries      CounterMetric
+}
+
+type metricsQueue struct {
+	provider MetricsProvider
+
+	metricsMu sync.Mutex
+	metrics   map[string]metricsSet
+	pendingMu sync.Mutex
+	pending   map[ResourceChange]time.Time
+}
+
+func (q *metricsQueue) add(evt ResourceChange) {
+	q.pendingMu.Lock()
+	defer q.pendingMu.Unlock()
+	if _, ok := q.pending[evt]; ok {
+		return
+	}
+	q.pending[evt] = time.Now()
+	ms := q.metricsFor(evt.Handler.Kind())
+	ms.Added.Inc()
+	ms.Depth.Inc()
+}
+
+type metricsClose func(evt ResourceChange, retry bool)
+
+func (q *metricsQueue) get(evt ResourceChange) metricsClose {
+	q.pendingMu.Lock()
+	defer q.pendingMu.Unlock()
+	queuedAt, ok := q.pending[evt]
+	if !ok {
+		return q.done(time.Now())
+	}
+	q.metricsFor(evt.Handler.Kind()).Delayed.Observe(time.Since(queuedAt).Seconds())
+	delete(q.pending, evt)
+	return q.done(time.Now())
+}
+
+func (q *metricsQueue) done(startTime time.Time) metricsClose {
+	return func(evt ResourceChange, retry bool) {
+		ms := q.metricsFor(evt.Handler.Kind())
+		ms.WorkDuration.Observe(time.Since(startTime).Seconds())
+		ms.Depth.Dec()
+		if retry {
+			ms.Retries.Inc()
+			q.add(evt)
+		}
+	}
+}
+
+func (q *metricsQueue) metricsFor(kind string) metricsSet {
+	q.metricsMu.Lock()
+	defer q.metricsMu.Unlock()
+	if q.metrics == nil {
+		q.metrics = map[string]metricsSet{}
+	}
+	if m, ok := q.metrics[kind]; ok {
+		return m
+	}
+	m := metricsSet{
+		Added:        q.provider.NewAddedMetric(kind),
+		Depth:        q.provider.NewDepthMetric(kind),
+		Delayed:      q.provider.NewDelayedMetric(kind),
+		WorkDuration: q.provider.NewWorkDurationMetric(kind),
+		Retries:      q.provider.NewRetriesMetric(kind),
+	}
+	q.metrics[kind] = m
+	return m
+}

--- a/internal/kube/watchers/resources.go
+++ b/internal/kube/watchers/resources.go
@@ -149,3 +149,7 @@ func (w ResourceWatcher[T]) Sync(stopCh <-chan struct{}) bool {
 func (w ResourceWatcher[T]) IsStopped() bool {
 	return w.informer.IsStopped()
 }
+
+func (w ResourceWatcher[T]) Kind() string {
+	return w.gvk.GroupVersion().String() + " " + w.gvk.Kind
+}

--- a/internal/kube/watchers/watchers_test.go
+++ b/internal/kube/watchers/watchers_test.go
@@ -321,6 +321,9 @@ func (s *stubErrResourceChangeHandler) Handle(e ResourceChange) error {
 func (stubErrResourceChangeHandler) Describe(e ResourceChange) string {
 	return fmt.Sprintf("StubHandler:%s", e.Key)
 }
+func (stubErrResourceChangeHandler) Kind() string {
+	return "stub"
+}
 
 func TestProcessRequeueLimit(t *testing.T) {
 	client, _ := fakeclient.NewFakeClient("test", nil, nil, "")


### PR DESCRIPTION
Exposes a new set of prometheus metrics from kubernetes control plane components to inform on the event processing load and capacity of each process (controller and adaptor.)

- "skupper_workqueue_adds_total": count of events queued by kind.
- "skupper_workqueue_depth": current depth of the work queue by kind.
- "skupper_workqueue_delay_seconds": duration in seconds an event is queued before it is pulled for processing by kind.
- "skupper_workqueue_retries_total": count of event processing retires by kind.