### PR TITLE
Improve Container Image build times with caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Misc CI/CD
+.circleci
+.github
+.codespellrc
+
+# Documentation
+README.md
+LICENSE
+PROJECT
+doc/
+
+# Build artifacts and binaries
+skupper
+controller
+kube-adaptor
+network-observer
+system-controller
+generate-doc
+oci-archives/
+cover.out
+bundle/
+bundle.Dockerfile
+*.tgz
+artifacthub-repo.yml
+must-gather.local.*
+
+# Test files
+tests/
+*_test.go
+
+# Top-level generated manifests
+skupper-*-scope.yaml
+skupper-network-observer.yaml
+skupper-network-observer-*.yaml
+manifest.json
+network-observer-operator/

--- a/Dockerfile.ci-test
+++ b/Dockerfile.ci-test
@@ -10,10 +10,13 @@ WORKDIR /go/src/app
 
 COPY go.mod .
 COPY go.sum .
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY . .
-RUN make GOOS=$TARGETOS GOARCH=$TARGETARCH
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    make GOOS=$TARGETOS GOARCH=$TARGETARCH
 
 FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9-minimal
 

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -8,11 +8,14 @@ RUN apt update && apt install -y jq
 WORKDIR /go/src/app
 COPY go.mod .
 COPY go.sum .
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 COPY . .
 
 ENV CGO_ENABLED=0
-RUN make -B build-cli GOARCH=$TARGETARCH
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    make -B build-cli GOARCH=$TARGETARCH
 
 # Use scratch for minimal image size
 FROM scratch

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -8,12 +8,15 @@ RUN apt update && apt install -y jq
 WORKDIR /go/src/app
 COPY go.mod .
 COPY go.sum .
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 COPY . .
 
 # Build statically linked binary
 ENV CGO_ENABLED=0
-RUN make -B build-controller GOARCH=$TARGETARCH
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    make -B build-controller GOARCH=$TARGETARCH
 
 # Use scratch for minimal image size
 FROM scratch

--- a/Dockerfile.kube-adaptor
+++ b/Dockerfile.kube-adaptor
@@ -9,11 +9,14 @@ WORKDIR /go/src/app
 
 COPY go.mod .
 COPY go.sum .
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY . .
 ENV CGO_ENABLED=0
-RUN make -B build-kube-adaptor GOARCH=$TARGETARCH
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    make -B build-kube-adaptor GOARCH=$TARGETARCH
 
 # Use scratch for minimal image size
 FROM scratch

--- a/Dockerfile.network-observer
+++ b/Dockerfile.network-observer
@@ -1,28 +1,31 @@
 ARG GO_IMAGE_BASE_TAG=1.24
+ARG CONSOLE_VERSION=development
 FROM --platform=$BUILDPLATFORM golang:${GO_IMAGE_BASE_TAG} AS builder
 
 ARG TARGETARCH
+ARG CONSOLE_VERSION
 
-RUN apt update && apt install -y jq
+RUN apt-get update && apt-get install -y jq wget && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /go/src/app
 
 COPY go.mod .
 COPY go.sum .
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY . .
 
 ENV CGO_ENABLED=0
-RUN make -B GOARCH=$TARGETARCH build-network-observer
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    make -B GOARCH=$TARGETARCH build-network-observer
 
-FROM --platform=$BUILDPLATFORM node:20.18.0 AS console-builder
-
-WORKDIR /skupper-console/
-ADD https://github.com/skupperproject/skupper-console/archive/main.tar.gz .
-RUN tar -zxf main.tar.gz
-WORKDIR ./skupper-console-main
-RUN yarn install && yarn build
+# Download console release
+WORKDIR /console
+RUN wget --progress=dot:giga -O /tmp/console.tgz \
+    "https://github.com/skupperproject/skupper-console/releases/download/${CONSOLE_VERSION}/console.tgz" && \
+    tar -xzf /tmp/console.tgz && rm /tmp/console.tgz
 
 # Use scratch for minimal image size
 FROM scratch
@@ -34,7 +37,7 @@ WORKDIR /app
 
 # Copy the statically linked binary
 COPY --from=builder /go/src/app/network-observer .
-COPY --from=console-builder /skupper-console/skupper-console-main/build/ console
+COPY --from=builder /console/ console
 
 # Use numeric user ID (no need to create user in scratch)
 USER 10000

--- a/Dockerfile.system-controller
+++ b/Dockerfile.system-controller
@@ -8,11 +8,14 @@ RUN apt update && apt install -y jq
 WORKDIR /go/src/app
 COPY go.mod .
 COPY go.sum .
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 COPY . .
 
 ENV CGO_ENABLED=0
-RUN make -B system-controller GOARCH=$TARGETARCH
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    make -B system-controller GOARCH=$TARGETARCH
 
 # Use scratch for minimal image size
 FROM scratch


### PR DESCRIPTION
Adds cache mounts to all Dockerfiles for Go build artifacts (GOCACHE) and downloaded modules (GOMODCACHE) to reduce subsequent build times.

Adds .dockerignore to exclude test files, documentation, and build artifacts from the Docker build context.

Changes network-observer to download prebuilt skupper-console releases from GitHub instead of building from source to reduce build time and eliminate a node.js image dependency.