### PR TITLE
Fixes HA router deployment selector overlap

### DIFF
--- a/internal/kube/controller/controller_test.go
+++ b/internal/kube/controller/controller_test.go
@@ -1200,7 +1200,7 @@ func (f *factory) routerDeployment(name string, namespace string) *unstructured.
 	content := map[string]interface{}{
 		"spec": map[string]interface{}{
 			"selector": map[string]interface{}{
-				"matchLabels": f.routerSelector(false),
+				"matchLabels": f.routerSelectorWithGroup(name),
 			},
 			"template": map[string]interface{}{
 				"spec": map[string]interface{}{
@@ -1325,7 +1325,7 @@ func (r *ExpectedResources) deployment(name string, namespace string) *unstructu
 	content := map[string]interface{}{
 		"spec": map[string]interface{}{
 			"selector": map[string]interface{}{
-				"matchLabels": f.routerSelector(false),
+				"matchLabels": f.routerSelectorWithGroup(name),
 			},
 			"template": map[string]interface{}{
 				"spec": map[string]interface{}{

--- a/internal/kube/site/resources/skupper-router-deployment.yaml
+++ b/internal/kube/site/resources/skupper-router-deployment.yaml
@@ -44,6 +44,7 @@ spec:
   selector:
     matchLabels:
       skupper.io/component: router
+      skupper.io/group: {{ .Group }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
In HA mode, both router deployments (skupper-router and skupper-router-2) share identical label selectors (skupper.io/component: router), causing kubectl to select pods from either deployment unpredictably.

Adds the skupper.io/group label to each deployment's matchLabels selector so that each deployment only selects its own pods. Fixes https://github.com/skupperproject/skupper/issues/2299