### PR TITLE
Prefix tcpListener/tcpConnector names to avoid same-site collision with exposePodsByName. Added test in controller_test.go.

### DIFF
--- a/internal/kube/site/bindings_test.go
+++ b/internal/kube/site/bindings_test.go
@@ -284,8 +284,8 @@ func TestBindingAdaptor_updateBridgeConfigForConnector(t *testing.T) {
 				config: qdr.BridgeConfig{
 					TcpListeners: map[string]qdr.TcpEndpoint{},
 					TcpConnectors: map[string]qdr.TcpEndpoint{
-						"backend@192.168.1.1": qdr.TcpEndpoint{
-							Name:   "backend@192.168.1.1",
+						"connector/backend@192.168.1.1": qdr.TcpEndpoint{
+							Name:   "connector/backend@192.168.1.1",
 							Host:   "192.168.1.1",
 							Port:   "8080",
 							SiteId: "00000000-0000-0000-0000-000000000001",
@@ -325,8 +325,8 @@ func TestBindingAdaptor_updateBridgeConfigForConnector(t *testing.T) {
 				config: qdr.BridgeConfig{
 					TcpListeners: map[string]qdr.TcpEndpoint{},
 					TcpConnectors: map[string]qdr.TcpEndpoint{
-						"backend@10.244.0.9": qdr.TcpEndpoint{
-							Name:      "backend@10.244.0.9",
+						"connector/backend@10.244.0.9": qdr.TcpEndpoint{
+							Name:      "connector/backend@10.244.0.9",
 							Host:      "10.244.0.9",
 							Port:      "0",
 							SiteId:    "00000000-0000-0000-0000-000000000001",
@@ -591,9 +591,8 @@ func TestBindingAdaptor_updateBridgeConfigForListener(t *testing.T) {
 			expected: expected{
 				config: qdr.BridgeConfig{
 					TcpListeners: map[string]qdr.TcpEndpoint{
-						"backend": qdr.TcpEndpoint{
-
-							Name:    "backend",
+						"listener/backend": qdr.TcpEndpoint{
+							Name:    "listener/backend",
 							Port:    "1024",
 							Address: "backend",
 							SiteId:  "00000000-0000-0000-0000-000000000001",

--- a/internal/kube/site/per_target_listener.go
+++ b/internal/kube/site/per_target_listener.go
@@ -130,7 +130,7 @@ func (p *PerTargetListener) updateBridgeConfig(siteId string, config *qdr.Bridge
 	for target, port := range p.targets {
 		if p.definition.Spec.Type == "tcp" || p.definition.Spec.Type == "" {
 			if config.AddTcpListener(qdr.TcpEndpoint{
-				Name:       p.definition.Name + "@" + target,
+				Name:       qdr.TcpListenerNamePrefix + p.definition.Name + "@" + target,
 				SiteId:     siteId,
 				Port:       strconv.Itoa(port),
 				Address:    p.address(target),

--- a/internal/qdr/qdr.go
+++ b/internal/qdr/qdr.go
@@ -33,6 +33,11 @@ type RouterConfigHandler interface {
 
 type TcpEndpointMap map[string]TcpEndpoint
 
+const (
+	TcpListenerNamePrefix  = "listener/"
+	TcpConnectorNamePrefix = "connector/"
+)
+
 type BridgeConfig struct {
 	TcpListeners  TcpEndpointMap
 	TcpConnectors TcpEndpointMap
@@ -1190,7 +1195,7 @@ func GetRouterConfigForHeadlessProxy(definition types.ServiceInterface, siteId s
 	for iPort, ePort := range ports {
 		address := fmt.Sprintf("%s-%s:%d", definition.Address, "${POD_ID}", iPort)
 		if definition.IsOfLocalOrigin() {
-			name := fmt.Sprintf("egress:%d", ePort)
+			name := TcpConnectorNamePrefix + fmt.Sprintf("egress:%d", ePort)
 			host := definition.Headless.Name + "-${POD_ID}." + definition.Address + "." + namespace
 			// in the originating site, just have egress bindings
 			switch definition.Protocol {
@@ -1205,7 +1210,7 @@ func GetRouterConfigForHeadlessProxy(definition types.ServiceInterface, siteId s
 			default:
 			}
 		} else {
-			name := fmt.Sprintf("ingress:%d", ePort)
+			name := TcpListenerNamePrefix + fmt.Sprintf("ingress:%d", ePort)
 			// in all other sites, just have ingress bindings
 			switch definition.Protocol {
 			case "tcp":

--- a/internal/site/bindings_test.go
+++ b/internal/site/bindings_test.go
@@ -60,8 +60,8 @@ func TestBindings_Apply(t *testing.T) {
 			},
 			expected: expected{
 				tcpListeners: qdr.TcpEndpointMap{
-					"listener1": {
-						Name:    "listener1",
+					"listener/listener1": {
+						Name:    "listener/listener1",
 						Host:    "10.10.10.1",
 						Port:    "9090",
 						Address: "echo:9090",
@@ -101,8 +101,8 @@ func TestBindings_Apply(t *testing.T) {
 			expected: expected{
 				tcpListeners: qdr.TcpEndpointMap{},
 				tcpConnectors: qdr.TcpEndpointMap{
-					"connector1@10.10.10.1": {
-						Name:    "connector1@10.10.10.1",
+					"connector/connector1@10.10.10.1": {
+						Name:    "connector/connector1@10.10.10.1",
 						Host:    "10.10.10.1",
 						Port:    "9090",
 						Address: "echo:9090",
@@ -120,8 +120,8 @@ func TestBindings_Apply(t *testing.T) {
 			config: &qdr.RouterConfig{
 				Bridges: qdr.BridgeConfig{
 					TcpListeners: map[string]qdr.TcpEndpoint{
-						"listener1": qdr.TcpEndpoint{
-							Name:   "listener1",
+						"listener/listener1": qdr.TcpEndpoint{
+							Name:   "listener/listener1",
 							Host:   "10.10.10.1",
 							Port:   "9090",
 							SiteId: "site-1",
@@ -146,8 +146,8 @@ func TestBindings_Apply(t *testing.T) {
 				Bridges: qdr.BridgeConfig{
 					TcpListeners: map[string]qdr.TcpEndpoint{},
 					TcpConnectors: map[string]qdr.TcpEndpoint{
-						"connector1": qdr.TcpEndpoint{
-							Name:   "connector1",
+						"connector/connector1@10.10.10.1": qdr.TcpEndpoint{
+							Name:   "connector/connector1@10.10.10.1",
 							Host:   "10.10.10.1",
 							Port:   "9090",
 							SiteId: "site-1",
@@ -192,8 +192,8 @@ func TestBindings_Apply(t *testing.T) {
 			},
 			expected: expected{
 				tcpListeners: qdr.TcpEndpointMap{
-					"listener1": {
-						Name:       "listener1",
+					"listener/listener1": {
+						Name:       "listener/listener1",
 						Host:       "10.10.10.1",
 						Port:       "9090",
 						Address:    "echo:9090",
@@ -243,8 +243,8 @@ func TestBindings_Apply(t *testing.T) {
 			expected: expected{
 				tcpListeners: qdr.TcpEndpointMap{},
 				tcpConnectors: qdr.TcpEndpointMap{
-					"connector1@10.10.10.1": {
-						Name:           "connector1@10.10.10.1",
+					"connector/connector1@10.10.10.1": {
+						Name:           "connector/connector1@10.10.10.1",
 						Host:           "10.10.10.1",
 						Port:           "9090",
 						Address:        "echo:9090",
@@ -294,8 +294,8 @@ func TestBindings_Apply(t *testing.T) {
 			expected: expected{
 				tcpListeners: qdr.TcpEndpointMap{},
 				tcpConnectors: qdr.TcpEndpointMap{
-					"connector1@10.10.10.1": {
-						Name:           "connector1@10.10.10.1",
+					"connector/connector1@10.10.10.1": {
+						Name:           "connector/connector1@10.10.10.1",
 						Host:           "10.10.10.1",
 						Port:           "9090",
 						Address:        "echo:9090",
@@ -350,16 +350,16 @@ func TestBindings_Apply(t *testing.T) {
 			expected: expected{
 				tcpListeners: qdr.TcpEndpointMap{},
 				tcpConnectors: qdr.TcpEndpointMap{
-					"connector1@11.5.6.21": {
-						Name:      "connector1@11.5.6.21",
+					"connector/connector1@11.5.6.21": {
+						Name:      "connector/connector1@11.5.6.21",
 						Host:      "11.5.6.21",
 						Port:      "9090",
 						Address:   "echo:9090",
 						SiteId:    "site-1",
 						ProcessID: "pod1",
 					},
-					"connector1@11.5.6.22": {
-						Name:      "connector1@11.5.6.22",
+					"connector/connector1@11.5.6.22": {
+						Name:      "connector/connector1@11.5.6.22",
 						Host:      "11.5.6.22",
 						Port:      "9090",
 						Address:   "echo:9090",
@@ -399,8 +399,8 @@ func TestBindings_Apply(t *testing.T) {
 			},
 			expected: expected{
 				tcpListeners: qdr.TcpEndpointMap{
-					"listener1": {
-						Name:    "listener1",
+					"listener/listener1": {
+						Name:    "listener/listener1",
 						Host:    "my-host",
 						Port:    "5678",
 						Address: "echo:9090",
@@ -440,8 +440,8 @@ func TestBindings_Apply(t *testing.T) {
 			},
 			expected: expected{
 				tcpListeners: qdr.TcpEndpointMap{
-					"listener1": {
-						Name:    "listener1",
+					"listener/listener1": {
+						Name:    "listener/listener1",
 						Host:    "10.10.10.1",
 						Port:    "9090",
 						Address: "foo",
@@ -482,8 +482,8 @@ func TestBindings_Apply(t *testing.T) {
 			expected: expected{
 				tcpListeners: qdr.TcpEndpointMap{},
 				tcpConnectors: qdr.TcpEndpointMap{
-					"connector1@10.10.10.1": {
-						Name:    "connector1@10.10.10.1",
+					"connector/connector1@10.10.10.1": {
+						Name:    "connector/connector1@10.10.10.1",
 						Host:    "10.10.10.1",
 						Port:    "9090",
 						Address: "foo",

--- a/internal/site/connector.go
+++ b/internal/site/connector.go
@@ -9,17 +9,17 @@ import (
 
 func UpdateBridgeConfigForConnector(siteId string, connector *skupperv2alpha1.Connector, config *qdr.BridgeConfig) {
 	if connector.Spec.Host != "" {
-		updateBridgeConfigForConnector(connector.Name+"@"+connector.Spec.Host, siteId, connector, connector.Spec.Host, "", connector.Spec.RoutingKey, config)
+		updateBridgeConfigForConnector(qdr.TcpConnectorNamePrefix+connector.Name+"@"+connector.Spec.Host, siteId, connector, connector.Spec.Host, "", connector.Spec.RoutingKey, config)
 	}
 }
 
 func UpdateBridgeConfigForConnectorToPod(siteId string, connector *skupperv2alpha1.Connector, pod skupperv2alpha1.PodDetails, addQualifiedAddress bool, config *qdr.BridgeConfig) bool {
 	updated := false
-	if updateBridgeConfigForConnector(connector.Name+"@"+pod.IP, siteId, connector, pod.IP, pod.UID, connector.Spec.RoutingKey, config) {
+	if updateBridgeConfigForConnector(qdr.TcpConnectorNamePrefix+connector.Name+"@"+pod.IP, siteId, connector, pod.IP, pod.UID, connector.Spec.RoutingKey, config) {
 		updated = true
 	}
 	if addQualifiedAddress {
-		if updateBridgeConfigForConnector(connector.Name+"@"+pod.Name, siteId, connector, pod.IP, pod.UID, connector.Spec.RoutingKey+"."+pod.Name, config) {
+		if updateBridgeConfigForConnector(qdr.TcpConnectorNamePrefix+connector.Name+"@"+pod.Name, siteId, connector, pod.IP, pod.UID, connector.Spec.RoutingKey+"."+pod.Name, config) {
 			updated = true
 		}
 	}

--- a/internal/site/listener.go
+++ b/internal/site/listener.go
@@ -12,7 +12,7 @@ func UpdateBridgeConfigForListener(siteId string, listener *skupperv2alpha1.List
 }
 
 func UpdateBridgeConfigForListenerWithHostAndPort(siteId string, listener *skupperv2alpha1.Listener, host string, port int, config *qdr.BridgeConfig) {
-	name := listener.Name
+	name := qdr.TcpListenerNamePrefix + listener.Name
 	if listener.Spec.Type == "tcp" || listener.Spec.Type == "" {
 		config.AddTcpListener(qdr.TcpEndpoint{
 			Name:       name,


### PR DESCRIPTION

Fixes #2058