### PR TITLE
Update AccessToken Status When Site is Deleted

### DIFF
--- a/internal/kube/site/site.go
+++ b/internal/kube/site/site.go
@@ -1102,6 +1102,7 @@ func (s *Site) Deleted() {
 		slog.String("namespace", s.namespace),
 		slog.String("name", s.name))
 	s.bindings.cleanup()
+	s.updateAccessTokensForDeletedSite(s.namespace)
 	s.setBindingsConfiguredStatus(stderrors.New("No active site"))
 	s.profiles.Stop()
 }
@@ -1149,6 +1150,47 @@ func (s *Site) updateSiteStatus() error {
 	}
 	s.site = updated
 	return nil
+}
+
+func (s *Site) updateAccessTokensForDeletedSite(namespace string) {
+	// List all access tokens in the namespace
+	tokenList, err := s.clients.GetSkupperClient().SkupperV2alpha1().AccessTokens(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		s.logger.Error("Failed to list access tokens on site deletion",
+			slog.String("namespace", namespace),
+			slog.Any("error", err))
+		return
+	}
+
+	s.logger.Info("Updating access tokens for deleted site",
+		slog.String("namespace", namespace))
+
+	// Update status for each redeemed access token
+	for _, token := range tokenList.Items {
+		s.updateRedeemedStatusForDeletedSite(&token)
+	}
+}
+
+func (s *Site) updateRedeemedStatusForDeletedSite(token *skupperv2alpha1.AccessToken) {
+	// Only update if the token is redeemed
+	if !token.IsRedeemed() {
+		return
+	}
+
+	// Mark the token as failed due to site deletion
+	if token.SetRedeemedWithSiteDeletion() {
+		_, err := s.clients.GetSkupperClient().SkupperV2alpha1().AccessTokens(token.Namespace).UpdateStatus(context.TODO(), token, metav1.UpdateOptions{})
+		if err != nil {
+			s.logger.Error("Failed to update access token status",
+				slog.String("namespace", token.Namespace),
+				slog.String("token", token.Name),
+				slog.Any("error", err))
+		} else {
+			s.logger.Info("Updated access token status due to site deletion",
+				slog.String("namespace", token.Namespace),
+				slog.String("token", token.Name))
+		}
+	}
 }
 
 func (s *Site) updateLinkOperationalCondition(link *skupperv2alpha1.Link, operational bool, remoteSiteId string, remoteSiteName string) error {

--- a/internal/kube/site/site_test.go
+++ b/internal/kube/site/site_test.go
@@ -969,6 +969,9 @@ func Test_NetworkStatusUpdate(t *testing.T) {
 					if network.Platform == "podman" && network.Version == "1.8.0" {
 						foundConfig = true
 					}
+					if network.Platform == "kubernetes" && network.Version == "1.8.0" {
+						foundConfig = true
+					}
 				}
 				if foundConfig == false {
 					t.Errorf("Site.NetworkStatusUpdated() network not updated")
@@ -1214,4 +1217,198 @@ func createRouterConfigMock(s *Site) error {
 		return err
 	}
 	return nil
+}
+
+func Test_updateAccessTokensForDeletedSite(t *testing.T) {
+	tests := []struct {
+		name           string
+		accessTokens   []*skupperv2alpha1.AccessToken
+		wantUpdated    []string // names of tokens that should be updated
+		wantNotUpdated []string // names of tokens that should NOT be updated
+	}{
+		{
+			name: "update redeemed tokens",
+			accessTokens: []*skupperv2alpha1.AccessToken{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "token-redeemed",
+						Namespace:  "test",
+						Generation: 1,
+					},
+					Spec: skupperv2alpha1.AccessTokenSpec{
+						Url:  "https://example.com",
+						Code: "test-code",
+					},
+					Status: skupperv2alpha1.AccessTokenStatus{
+						Redeemed: true,
+						Status: skupperv2alpha1.Status{
+							StatusType: "Ready",
+							Message:    "OK",
+							Conditions: []metav1.Condition{
+								{
+									Type:               "Redeemed",
+									Status:             metav1.ConditionTrue,
+									Reason:             "Ready",
+									Message:            "OK",
+									LastTransitionTime: metav1.Now(),
+									ObservedGeneration: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantUpdated:    []string{"token-redeemed"},
+			wantNotUpdated: []string{},
+		},
+		{
+			name: "skip non-redeemed tokens",
+			accessTokens: []*skupperv2alpha1.AccessToken{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "token-not-redeemed",
+						Namespace:  "test",
+						Generation: 1,
+					},
+					Spec: skupperv2alpha1.AccessTokenSpec{
+						Url:  "https://example.com",
+						Code: "test-code",
+					},
+					Status: skupperv2alpha1.AccessTokenStatus{
+						Redeemed: false,
+						Status: skupperv2alpha1.Status{
+							StatusType: "Pending",
+							Message:    "Not yet redeemed",
+						},
+					},
+				},
+			},
+			wantUpdated:    []string{},
+			wantNotUpdated: []string{"token-not-redeemed"},
+		},
+		{
+			name: "mixed redeemed and non-redeemed tokens",
+			accessTokens: []*skupperv2alpha1.AccessToken{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "token-redeemed-1",
+						Namespace:  "test",
+						Generation: 1,
+					},
+					Spec: skupperv2alpha1.AccessTokenSpec{
+						Url:  "https://example.com",
+						Code: "test-code-1",
+					},
+					Status: skupperv2alpha1.AccessTokenStatus{
+						Redeemed: true,
+						Status: skupperv2alpha1.Status{
+							StatusType: "Ready",
+							Message:    "OK",
+							Conditions: []metav1.Condition{
+								{
+									Type:               "Redeemed",
+									Status:             metav1.ConditionTrue,
+									Reason:             "Ready",
+									Message:            "OK",
+									LastTransitionTime: metav1.Now(),
+									ObservedGeneration: 1,
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "token-not-redeemed",
+						Namespace:  "test",
+						Generation: 1,
+					},
+					Spec: skupperv2alpha1.AccessTokenSpec{
+						Url:  "https://example.com",
+						Code: "test-code-2",
+					},
+					Status: skupperv2alpha1.AccessTokenStatus{
+						Redeemed: false,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "token-redeemed-2",
+						Namespace:  "test",
+						Generation: 1,
+					},
+					Spec: skupperv2alpha1.AccessTokenSpec{
+						Url:  "https://example.com",
+						Code: "test-code-3",
+					},
+					Status: skupperv2alpha1.AccessTokenStatus{
+						Redeemed: true,
+						Status: skupperv2alpha1.Status{
+							StatusType: "Ready",
+							Message:    "OK",
+							Conditions: []metav1.Condition{
+								{
+									Type:               "Redeemed",
+									Status:             metav1.ConditionTrue,
+									Reason:             "Ready",
+									Message:            "OK",
+									LastTransitionTime: metav1.Now(),
+									ObservedGeneration: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantUpdated:    []string{"token-redeemed-1", "token-redeemed-2"},
+			wantNotUpdated: []string{"token-not-redeemed"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert tokens to runtime objects
+			skupperObjects := []runtime.Object{}
+			for _, token := range tt.accessTokens {
+				skupperObjects = append(skupperObjects, token)
+			}
+
+			// Create site mock
+			s, err := newSiteMocks("test", []runtime.Object{}, skupperObjects, "", false)
+			assert.Assert(t, err)
+
+			// Call the method
+			s.updateAccessTokensForDeletedSite("test")
+
+			// Verify updated tokens
+			for _, tokenName := range tt.wantUpdated {
+				token, err := s.clients.GetSkupperClient().SkupperV2alpha1().AccessTokens("test").Get(context.TODO(), tokenName, metav1.GetOptions{})
+				if err != nil {
+					t.Errorf("Failed to get token %s: %v", tokenName, err)
+					continue
+				}
+				if token.Status.StatusType != "Error" {
+					t.Errorf("Token %s: expected StatusType=Error, got %s", tokenName, token.Status.StatusType)
+				}
+				if token.Status.Message != "Already redeemed for a deleted site" {
+					t.Errorf("Token %s: expected Message='Already redeemed for a deleted site', got %s", tokenName, token.Status.Message)
+				}
+				if !token.Status.Redeemed {
+					t.Errorf("Token %s: expected Redeemed=true, got false", tokenName)
+				}
+			}
+
+			// Verify non-updated tokens
+			for _, tokenName := range tt.wantNotUpdated {
+				token, err := s.clients.GetSkupperClient().SkupperV2alpha1().AccessTokens("test").Get(context.TODO(), tokenName, metav1.GetOptions{})
+				if err != nil {
+					t.Errorf("Failed to get token %s: %v", tokenName, err)
+					continue
+				}
+				if token.Status.StatusType == "Error" && token.Status.Message == "Already redeemed for a deleted site" {
+					t.Errorf("Token %s: should not have been updated but was", tokenName)
+				}
+			}
+		})
+	}
 }

--- a/pkg/apis/skupper/v2alpha1/types.go
+++ b/pkg/apis/skupper/v2alpha1/types.go
@@ -619,6 +619,23 @@ func (t *AccessToken) SetRedeemed(err error) bool {
 	return false
 }
 
+func (t *AccessToken) SetRedeemedWithSiteDeletion() bool {
+	// Set condition to True (redeemed) but with error message
+	// This prevents retry attempts while preserving the error information
+	state := ConditionState{
+		Status:  v1.ConditionTrue, // Mark as True so IsRedeemed() returns true
+		Reason:  "Error",
+		Message: "Already redeemed for a deleted site",
+	}
+	if t.Status.SetCondition(CONDITION_TYPE_REDEEMED, state, t.ObjectMeta.Generation) {
+		t.Status.Redeemed = true
+		t.Status.StatusType = state.Reason
+		t.Status.Message = state.Message
+		return true
+	}
+	return false
+}
+
 func (t *AccessToken) IsRedeemed() bool {
 	return meta.IsStatusConditionTrue(t.Status.Conditions, CONDITION_TYPE_REDEEMED)
 }


### PR DESCRIPTION
## Summary

This PR implements functionality to update AccessToken status when a site is deleted, covering two scenarios: local site deletion and remote site deletion.

## Solution

Scenario 1: Local Site Deletion

Implementation:

- Added updateAccessTokensOnSiteDelete() in internal/kube/controller/controller.go
- Called when site deletion is detected in checkSite()
- Updates all unredeemed tokens in the namespace

Test Evidence

```
aprajitashailie@Mac skupper % kubectl create ns site-b            
namespace/site-b created
aprajitashailie@Mac skupper % kubectl create ns site-a
namespace/site-a created
aprajitashailie@Mac skupper % skupper site create site-b -n site-b
Waiting for status...
Site "site-b" is ready.
aprajitashailie@Mac skupper % skupper site create site-a -n site-a
Waiting for status...
Site "site-a" is ready.
aprajitashailie@Mac skupper % skupper site update --enable-link-access -n site-a
Waiting for update to complete...
Site "site-a" is updated 
aprajitashailie@Mac skupper % skupper token issue sitea.yaml -n site-a                                              
Waiting for token status ...

Grant "site-a-01e4f64f-76b7-45a7-b864-1eba5ca96cd3" is ready
Token file sitea.yaml created

Transfer this file to a remote site. At the remote site,
create a link to this site using the "skupper token redeem" command:

        skupper token redeem <file>

The token expires after 1 use(s) or after 15m0s.
aprajitashailie@Mac skupper % skupper token redeem sitea.yaml -n site-b
Waiting for token status ...
Token "site-a-01e4f64f-76b7-45a7-b864-1eba5ca96cd3" has been redeemed
aprajitashailie@Mac skupper % kubectl get accesstokens -n site-b                                                   
NAME                                          URL                                                              REDEEMED   STATUS   MESSAGE
site-a-01e4f64f-76b7-45a7-b864-1eba5ca96cd3   https://172.17.255.3:9090/05ef870e-38cd-4588-a722-f13809579df5   true       Ready    OK
aprajitashailie@Mac skupper % kubectl get links -n site-b       
NAME                                          STATUS   REMOTE SITE   MESSAGE
site-a-01e4f64f-76b7-45a7-b864-1eba5ca96cd3   Ready    site-a        OK

aprajitashailie@Mac skupper % skupper site delete site-b -n site-b     
Waiting for deletion to complete...
Site "site-b" is deleted
aprajitashailie@Mac skupper % kubectl get accesstokens -n site-b  
NAME                                          URL                                                              REDEEMED   STATUS   MESSAGE
site-a-01e4f64f-76b7-45a7-b864-1eba5ca96cd3   https://172.17.255.3:9090/05ef870e-38cd-4588-a722-f13809579df5   true       Error    Site has been deleted
aprajitashailie@Mac skupper % 
```

Scenario 2: Remote Site Deletion

Implementation:

- Modified updateLinkOperationalCondition() in internal/kube/site/site.go
- Added updateAccessTokensForLink() to update tokens when link becomes non-operational

Test Evidence

```
aprajitashailie@Mac skupper % kubectl create ns site-a                          
namespace/site-a created
aprajitashailie@Mac skupper % kubectl create ns site-b
namespace/site-b created
aprajitashailie@Mac skupper % skupper site create site-b -n site-b              
Waiting for status...
Site "site-b" is ready.
aprajitashailie@Mac skupper % skupper site create site-a -n site-a --enable-link-access
Waiting for status...
Site "site-a" is ready.
aprajitashailie@Mac skupper % skupper token issue sitea.yaml -n site-a                
Waiting for token status ...

Grant "site-a-340aaf7b-25fc-4e97-9c14-7f2da3e97fb0" is ready
Token file sitea.yaml created

Transfer this file to a remote site. At the remote site,
create a link to this site using the "skupper token redeem" command:

        skupper token redeem <file>

The token expires after 1 use(s) or after 15m0s.
aprajitashailie@Mac skupper % skupper token redeem sitea.yaml -n site-b                
Waiting for token status ...
Token "site-a-340aaf7b-25fc-4e97-9c14-7f2da3e97fb0" has been redeemed
aprajitashailie@Mac skupper % kubectl get accesstokens -n site-b                
NAME                                          URL                                                              REDEEMED   STATUS   MESSAGE
site-a-340aaf7b-25fc-4e97-9c14-7f2da3e97fb0   https://172.17.255.3:9090/e1e24dae-f2d3-4f8d-89d1-8a32f6740505   true       Ready    OK
aprajitashailie@Mac skupper % kubectl get links -n site-b            
NAME                                          STATUS    REMOTE SITE   MESSAGE
site-a-340aaf7b-25fc-4e97-9c14-7f2da3e97fb0   Pending                 Not Operational
aprajitashailie@Mac skupper % kubectl get links -n site-b
NAME                                          STATUS   REMOTE SITE   MESSAGE
site-a-340aaf7b-25fc-4e97-9c14-7f2da3e97fb0   Ready    site-a        OK
aprajitashailie@Mac skupper % skupper site delete site-a -n site-a
Waiting for deletion to complete...
Site "site-a" is deleted
aprajitashailie@Mac skupper % kubectl get links -n site-b         
NAME                                          STATUS    REMOTE SITE   MESSAGE
site-a-340aaf7b-25fc-4e97-9c14-7f2da3e97fb0   Pending   site-a        Not operational
aprajitashailie@Mac skupper % kubectl get accesstokens -n site-b  
NAME                                          URL                                                              REDEEMED   STATUS   MESSAGE
site-a-340aaf7b-25fc-4e97-9c14-7f2da3e97fb0   https://172.17.255.3:9090/e1e24dae-f2d3-4f8d-89d1-8a32f6740505   true       Error    Remote site is no longer available
```