### PR TITLE
add http proxy vanflow record to Link records

### DIFF
--- a/cmd/network-observer/internal/api/types_gen.go
+++ b/cmd/network-observer/internal/api/types_gen.go
@@ -49,6 +49,12 @@ const (
 	Unbound ProcessBindingType = "unbound"
 )
 
+// Defines values for ProxyProtocolType.
+const (
+	HTTP ProxyProtocolType = "HTTP"
+	NONE ProxyProtocolType = "NONE"
+)
+
 // Defines values for SitePlatformType.
 const (
 	SitePlatformTypeDocker     SitePlatformType = "docker"
@@ -426,10 +432,11 @@ type RouterLinkRecord struct {
 	EndTime uint64 `json:"endTime"`
 
 	// Identity The unique identifier for the record.
-	Identity          string `json:"identity"`
-	Name              string `json:"name"`
-	OctetCount        uint64 `json:"octetCount"`
-	OctetReverseCount uint64 `json:"octetReverseCount"`
+	Identity          string             `json:"identity"`
+	Name              string             `json:"name"`
+	OctetCount        uint64             `json:"octetCount"`
+	OctetReverseCount uint64             `json:"octetReverseCount"`
+	ProxyProtocol     *ProxyProtocolType `json:"proxyProtocol"`
 
 	// Role The class of skupper link
 	Role LinkRoleType `json:"role"`
@@ -444,9 +451,6 @@ type RouterLinkRecord struct {
 	// StartTime The creation time in microseconds of the record in Unix timestamp format. The value 0 means that the record is not terminated
 	StartTime uint64         `json:"startTime"`
 	Status    OperStatusType `json:"status"`
-
-	// HttpProxy true when the link connection is established through an HTTP proxy.
-	HttpProxy *bool `json:"httpProxy"`
 }
 
 // RouterLinkResponse defines model for RouterLinkResponse.
@@ -602,6 +606,9 @@ type OperStatusType string
 
 // ProcessBindingType Indicates whether a process is exposed or not in a skupper network
 type ProcessBindingType string
+
+// ProxyProtocolType The proxy protocol used when the link connection is established.
+type ProxyProtocolType string
 
 // ServiceIdentifierType a special string for identifying services uses the form `name@identity@protocol`
 type ServiceIdentifierType = AtmarkDelimitedString

--- a/cmd/network-observer/internal/api/types_gen.go
+++ b/cmd/network-observer/internal/api/types_gen.go
@@ -444,6 +444,9 @@ type RouterLinkRecord struct {
 	// StartTime The creation time in microseconds of the record in Unix timestamp format. The value 0 means that the record is not terminated
 	StartTime uint64         `json:"startTime"`
 	Status    OperStatusType `json:"status"`
+
+	// HttpProxy When connected, whether this link uses an HTTP proxy.
+	HttpProxy *string `json:"httpProxy"`
 }
 
 // RouterLinkResponse defines model for RouterLinkResponse.

--- a/cmd/network-observer/internal/api/types_gen.go
+++ b/cmd/network-observer/internal/api/types_gen.go
@@ -445,8 +445,8 @@ type RouterLinkRecord struct {
 	StartTime uint64         `json:"startTime"`
 	Status    OperStatusType `json:"status"`
 
-	// HttpProxy When connected, whether this link uses an HTTP proxy.
-	HttpProxy *string `json:"httpProxy"`
+	// HttpProxy true when the link connection is established through an HTTP proxy.
+	HttpProxy *bool `json:"httpProxy"`
 }
 
 // RouterLinkResponse defines model for RouterLinkResponse.

--- a/cmd/network-observer/internal/server/links_test.go
+++ b/cmd/network-observer/internal/server/links_test.go
@@ -78,7 +78,7 @@ func TestRouterlinks(t *testing.T) {
 					DestinationSiteName:   ptrTo("site a"),
 					DestinationRouterId:   ptrTo("router-a-1"),
 					DestinationRouterName: ptrTo("router a.1"),
-					HttpProxy:             ptrTo("yes"),
+					HttpProxy:             ptrTo(true),
 				})
 			},
 		},

--- a/cmd/network-observer/internal/server/links_test.go
+++ b/cmd/network-observer/internal/server/links_test.go
@@ -51,6 +51,7 @@ func TestRouterlinks(t *testing.T) {
 						Status:     ptrTo("up"),
 						Peer:       ptrTo("routeraccess-a-1"),
 						LinkCost:   ptrTo(uint64(3)),
+						HttpProxy:  ptrTo("yes"),
 					},
 				)...,
 			),
@@ -77,6 +78,7 @@ func TestRouterlinks(t *testing.T) {
 					DestinationSiteName:   ptrTo("site a"),
 					DestinationRouterId:   ptrTo("router-a-1"),
 					DestinationRouterName: ptrTo("router a.1"),
+					HttpProxy:             ptrTo("yes"),
 				})
 			},
 		},

--- a/cmd/network-observer/internal/server/links_test.go
+++ b/cmd/network-observer/internal/server/links_test.go
@@ -78,7 +78,7 @@ func TestRouterlinks(t *testing.T) {
 					DestinationSiteName:   ptrTo("site a"),
 					DestinationRouterId:   ptrTo("router-a-1"),
 					DestinationRouterName: ptrTo("router a.1"),
-					HttpProxy:             ptrTo(true),
+					ProxyProtocol:         ptrTo(api.HTTP),
 				})
 			},
 		},

--- a/cmd/network-observer/internal/server/views/views.go
+++ b/cmd/network-observer/internal/server/views/views.go
@@ -450,6 +450,7 @@ func NewRouterLinkProvider(graph collector.Graph) func(vanflow.LinkRecord) (api.
 		setOpt(&out.RouterName, sourceRouter.Name)
 		setOpt(&out.SourceSiteName, sourceSite.Name)
 		setOpt(&out.Name, link.Name)
+		out.HttpProxy = link.HttpProxy
 
 		if link.Role != nil {
 			role := *link.Role

--- a/cmd/network-observer/internal/server/views/views.go
+++ b/cmd/network-observer/internal/server/views/views.go
@@ -450,7 +450,7 @@ func NewRouterLinkProvider(graph collector.Graph) func(vanflow.LinkRecord) (api.
 		setOpt(&out.RouterName, sourceRouter.Name)
 		setOpt(&out.SourceSiteName, sourceSite.Name)
 		setOpt(&out.Name, link.Name)
-		out.HttpProxy = link.HttpProxy
+		out.HttpProxy = linkHttpProxy(link.HttpProxy)
 
 		if link.Role != nil {
 			role := *link.Role
@@ -663,6 +663,22 @@ func vanflowTimes(b vanflow.BaseRecord) (start, end uint64) {
 		end = uint64(b.EndTime.UnixMicro())
 	}
 	return
+}
+
+func linkHttpProxy(v *string) *bool {
+	if v == nil {
+		return nil
+	}
+	switch strings.ToLower(*v) {
+	case "yes":
+		b := true
+		return &b
+	case "no":
+		b := false
+		return &b
+	default:
+		return nil
+	}
 }
 
 func setOpt[T any](target *T, val *T) {

--- a/cmd/network-observer/internal/server/views/views.go
+++ b/cmd/network-observer/internal/server/views/views.go
@@ -450,7 +450,7 @@ func NewRouterLinkProvider(graph collector.Graph) func(vanflow.LinkRecord) (api.
 		setOpt(&out.RouterName, sourceRouter.Name)
 		setOpt(&out.SourceSiteName, sourceSite.Name)
 		setOpt(&out.Name, link.Name)
-		out.HttpProxy = linkHttpProxy(link.HttpProxy)
+		out.ProxyProtocol = linkProxyProtocol(link.HttpProxy)
 
 		if link.Role != nil {
 			role := *link.Role
@@ -665,17 +665,17 @@ func vanflowTimes(b vanflow.BaseRecord) (start, end uint64) {
 	return
 }
 
-func linkHttpProxy(v *string) *bool {
+func linkProxyProtocol(v *string) *api.ProxyProtocolType {
 	if v == nil {
 		return nil
 	}
 	switch strings.ToLower(*v) {
 	case "yes":
-		b := true
-		return &b
+		p := api.HTTP
+		return &p
 	case "no":
-		b := false
-		return &b
+		p := api.NONE
+		return &p
 	default:
 		return nil
 	}

--- a/cmd/network-observer/spec/openapi.yaml
+++ b/cmd/network-observer/spec/openapi.yaml
@@ -1126,6 +1126,10 @@ components:
               type: string
               nullable: true
               description: When connected, the name of the destitation (peer) site.
+            httpProxy:
+              type: string
+              nullable: true
+              description: When connected, whether this link uses an HTTP proxy.
     RouterAccessRecord:
       allOf:
         - $ref: '#/components/schemas/baseRecord'

--- a/cmd/network-observer/spec/openapi.yaml
+++ b/cmd/network-observer/spec/openapi.yaml
@@ -785,6 +785,12 @@ components:
         - inter-router
         - edge
         - unknown
+    proxyProtocolType:
+      type: string
+      description: The proxy protocol used when the link connection is established.
+      enum:
+        - NONE
+        - HTTP
     SiteRecord:
       allOf:
         - $ref: '#/components/schemas/baseRecord'
@@ -1126,10 +1132,10 @@ components:
               type: string
               nullable: true
               description: When connected, the name of the destitation (peer) site.
-            httpProxy:
-              type: boolean
+            proxyProtocol:
+              allOf:
+                - $ref: '#/components/schemas/proxyProtocolType'
               nullable: true
-              description: true when the link connection is established through an HTTP proxy
     RouterAccessRecord:
       allOf:
         - $ref: '#/components/schemas/baseRecord'

--- a/cmd/network-observer/spec/openapi.yaml
+++ b/cmd/network-observer/spec/openapi.yaml
@@ -1127,9 +1127,9 @@ components:
               nullable: true
               description: When connected, the name of the destitation (peer) site.
             httpProxy:
-              type: string
+              type: boolean
               nullable: true
-              description: When connected, whether this link uses an HTTP proxy.
+              description: true when the link connection is established through an HTTP proxy
     RouterAccessRecord:
       allOf:
         - $ref: '#/components/schemas/baseRecord'
@@ -1356,4 +1356,3 @@ tags:
     description: >
       requests involving flow aggregates:
       pairs of peers communicating through the skupper network
-

--- a/pkg/vanflow/records.go
+++ b/pkg/vanflow/records.go
@@ -85,6 +85,8 @@ type LinkRecord struct {
 	LastUp    *uint64 `vflow:"55"`
 	LastDown  *uint64 `vflow:"56"`
 	DownCount *uint64 `vflow:"57"`
+
+	HttpProxy *string `vflow:"67"`
 }
 
 func (r LinkRecord) GetTypeMeta() TypeMeta {


### PR DESCRIPTION
added a new attribute on the LinkRecord to pick up the new HTTP_PROXY record from the router that indicates if a proxy is being used on the link

Fixes #2361 