### PR TITLE
add common labels and annotations for network-observer resources

### DIFF
--- a/charts/network-observer/templates/_deployment.yaml
+++ b/charts/network-observer/templates/_deployment.yaml
@@ -39,7 +39,11 @@ ports:
   - name: https
     containerPort: 8443
     protocol: TCP
-{{- with .Values.resources.proxy }}
+{{- $resources := .Values.resources }}
+{{- with .Values.containerResources.proxy }}
+{{- $resources = . }}
+{{- end }}
+{{- with $resources }}
 resources:
   {{- toYaml . | nindent 2 }}
 {{- end }}
@@ -73,7 +77,11 @@ ports:
   - name: https
     containerPort: 8443
     protocol: TCP
-{{- with .Values.resources.proxy }}
+{{- $resources := .Values.resources }}
+{{- with .Values.containerResources.proxy }}
+{{- $resources = . }}
+{{- end }}
+{{- with $resources }}
 resources:
   {{- toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/network-observer/templates/_deployment.yaml
+++ b/charts/network-observer/templates/_deployment.yaml
@@ -39,6 +39,10 @@ ports:
   - name: https
     containerPort: 8443
     protocol: TCP
+{{- with .Values.resources.proxy }}
+resources:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 volumeMounts:
   - mountPath: /etc/certificates/
     name: {{ include "network-observer.tlsSecretName" . }}
@@ -69,10 +73,13 @@ ports:
   - name: https
     containerPort: 8443
     protocol: TCP
+{{- with .Values.resources.proxy }}
+resources:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 volumeMounts:
   - mountPath: /etc/certificates/
     name: {{ include "network-observer.tlsSecretName" . }}
   - mountPath: /etc/session-secrets/
     name: session-cookie-secret
 {{- end -}}
-

--- a/charts/network-observer/templates/_helpers.tpl
+++ b/charts/network-observer/templates/_helpers.tpl
@@ -43,6 +43,9 @@ helm.sh/chart: {{ include "network-observer.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 app.kubernetes.io/part-of: skupper-network-observer
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/network-observer/templates/client_certificate.yaml
+++ b/charts/network-observer/templates/client_certificate.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ include "network-observer.clientCertificateName" . }}
   labels:
     {{- include "network-observer.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ca: skupper-local-ca
   hosts:

--- a/charts/network-observer/templates/deployment.yaml
+++ b/charts/network-observer/templates/deployment.yaml
@@ -71,8 +71,14 @@ spec:
             - name: metrics
               containerPort: 9000
               protocol: TCP
+          {{- $resources := .Values.resources }}
+          {{- with .Values.containerResources.networkObserver }}
+          {{- $resources = . }}
+          {{- end }}
+          {{- with $resources }}
           resources:
-            {{- toYaml .Values.resources.networkObserver | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /etc/messaging/
               name: skupper-management-client
@@ -99,8 +105,14 @@ spec:
             - name: prom
               containerPort: 9090
               protocol: TCP
+          {{- $resources := .Values.resources }}
+          {{- with .Values.containerResources.prometheus }}
+          {{- $resources = . }}
+          {{- end }}
+          {{- with $resources }}
           resources:
-            {{- toYaml .Values.resources.prometheus | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /etc/prometheus
               name: prometheus-config

--- a/charts/network-observer/templates/deployment.yaml
+++ b/charts/network-observer/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "network-observer.fullname" . }}
   labels:
     {{- include "network-observer.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -14,9 +18,14 @@ spec:
   {{- end }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- if or .Values.commonAnnotations .Values.podAnnotations }}
       annotations:
+        {{- with .Values.commonAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "network-observer.labels" . | nindent 8 }}
@@ -63,7 +72,7 @@ spec:
               containerPort: 9000
               protocol: TCP
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.networkObserver | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/messaging/
               name: skupper-management-client
@@ -91,7 +100,7 @@ spec:
               containerPort: 9090
               protocol: TCP
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.prometheus | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/prometheus
               name: prometheus-config

--- a/charts/network-observer/templates/ingress.yaml
+++ b/charts/network-observer/templates/ingress.yaml
@@ -5,9 +5,14 @@ metadata:
   name: {{ include "network-observer.fullname" . }}
   labels:
     {{- include "network-observer.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- if or .Values.commonAnnotations .Values.ingress.annotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   {{- with .Values.ingress.className }}

--- a/charts/network-observer/templates/job_setup_secrets.yaml
+++ b/charts/network-observer/templates/job_setup_secrets.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     {{- include "network-observer.labels" . | nindent 4 }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
@@ -16,6 +19,10 @@ spec:
       name: "{{ .Release.Name }}"
       labels:
         {{- include "network-observer.labels" . | nindent 8 }}
+      {{- with .Values.commonAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "network-observer.setupJobName" . }}
       restartPolicy: Never
@@ -44,16 +51,22 @@ metadata:
   labels:
     {{- include "network-observer.labels" . | nindent 4 }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind : Role
+kind: Role
 metadata:
   labels:
     {{- include "network-observer.labels" . | nindent 4 }}
   name: {{ include "network-observer.setupJobName" . }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": hook-succeeded
 rules:
@@ -73,6 +86,9 @@ metadata:
     {{- include "network-observer.labels" . | nindent 4 }}
   name: {{ include "network-observer.setupJobName" . }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": hook-succeeded
 subjects:

--- a/charts/network-observer/templates/nginx_config.yaml
+++ b/charts/network-observer/templates/nginx_config.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ include "network-observer.nginxConfigMapName" . }}
   labels:
     {{- include "network-observer.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   nginx.conf: |
     worker_processes auto;
@@ -39,4 +43,3 @@ data:
         }
     }
 {{- end }}
-

--- a/charts/network-observer/templates/prometheus-pvc.yaml
+++ b/charts/network-observer/templates/prometheus-pvc.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "network-observer.fullname" . }}-prometheus
   labels:
     {{- include "network-observer.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.prometheus.persistence.storageClass }}
   storageClassName: {{ .Values.prometheus.persistence.storageClass }}

--- a/charts/network-observer/templates/prometheusconfig.yaml
+++ b/charts/network-observer/templates/prometheusconfig.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "network-observer.fullname" . }}-prometheus
   labels:
     {{- include "network-observer.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   prometheus.yml: |
 {{ .Values.prometheus.config | nindent 4 }}

--- a/charts/network-observer/templates/route.yaml
+++ b/charts/network-observer/templates/route.yaml
@@ -5,8 +5,26 @@ kind: Route
 metadata:
   labels:
     {{- include "network-observer.labels" . | nindent 4 }}
+    {{- with .Values.route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.commonAnnotations .Values.route.annotations }}
+  annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.route.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
   name: {{ include "network-observer.fullname" . }}
 spec:
+  {{- with .Values.route.host }}
+  host: {{ . }}
+  {{- end }}
+  {{- with .Values.route.subdomain }}
+  subdomain: {{ . }}
+  {{- end }}
   tls:
     termination: "reencrypt"
     insecureEdgeTerminationPolicy: Redirect

--- a/charts/network-observer/templates/server_certificate.yaml
+++ b/charts/network-observer/templates/server_certificate.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ (include "network-observer.tlsSecretName" .) }}
   labels:
     {{- include "network-observer.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ca: skupper-local-ca
   hosts:

--- a/charts/network-observer/templates/service.yaml
+++ b/charts/network-observer/templates/service.yaml
@@ -5,10 +5,15 @@ metadata:
   name: {{ include "network-observer.fullname" . }}
   labels:
     {{- include "network-observer.labels" . | nindent 4 }}
+  {{- if or .Values.commonAnnotations .Values.tls.openshiftIssued }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- if .Values.tls.openshiftIssued }}
     service.beta.openshift.io/serving-cert-secret-name: {{ include "network-observer.tlsSecretName" . }}
     {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -24,8 +29,12 @@ kind: Service
 metadata:
   name: {{ include "network-observer.fullname" . }}-metrics
   labels:
-    {{ include "network-observer.labels" . | nindent 4 }}
+    {{- include "network-observer.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/network-observer/templates/service_account.yaml
+++ b/charts/network-observer/templates/service_account.yaml
@@ -6,5 +6,8 @@ metadata:
   labels:
     {{- include "network-observer.labels" . | nindent 4 }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"{{ include "network-observer.fullname" . }}"}}'
 {{- end }}

--- a/charts/network-observer/values.yaml
+++ b/charts/network-observer/values.yaml
@@ -184,9 +184,11 @@ route:
   labels: {}
   annotations: {}
 
+# Deprecated: use containerResources instead.
+resources: {}
 
 # Per-container resources for the network-observer Deployment.
-resources:
+containerResources:
   networkObserver: {}
   #   requests:
   #     cpu: 100m

--- a/charts/network-observer/values.yaml
+++ b/charts/network-observer/values.yaml
@@ -141,6 +141,10 @@ auth:
       create: true
       nameOverride: ""
 
+# This is for setting Kubernetes Annotations to all resources.
+commonAnnotations: {}
+# This is for setting Kubernetes Labels to all resources.
+commonLabels: {}
 
 # This is for setting Kubernetes Annotations to a Pod.
 podAnnotations: {}
@@ -175,14 +179,35 @@ ingress:
 # observer
 route:
   enabled: false
+  host: ""
+  subdomain: ""
+  labels: {}
+  annotations: {}
 
-resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+
+# Per-container resources for the network-observer Deployment.
+resources:
+  networkObserver: {}
+  #   requests:
+  #     cpu: 100m
+  #     memory: 256Mi
+  #   limits:
+  #     cpu: 500m
+  #     memory: 512Mi
+  prometheus: {}
+  #   requests:
+  #     cpu: 200m
+  #     memory: 512Mi
+  #   limits:
+  #     cpu: 500m
+  #     memory: 1Gi
+  proxy: {}
+  #   requests:
+  #     cpu: 50m
+  #     memory: 64Mi
+  #   limits:
+  #     cpu: 200m
+  #     memory: 256Mi
 
 # pod level securityContext
 podSecurityContext:


### PR DESCRIPTION
- adds a common set of labels and annotations to be applied to all resources generated by the network-observer helm chart
- adds configurability to the route hostname
- adds resource configurability per container

fixes #2438 