### PR TITLE
Add new process that handles event duplication when a watched file is created or updated

### DIFF
--- a/internal/nonkube/controller/event_deduplicator.go
+++ b/internal/nonkube/controller/event_deduplicator.go
@@ -1,0 +1,84 @@
+package controller
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// EventDeduplicator handles deduplication of OnCreate and OnUpdate.
+// It collects events in a time window and processes only the final event after a quiet period.
+type EventDeduplicator struct {
+	eventCh       chan string
+	stopCh        chan struct{}
+	mutex         sync.Mutex
+	pendingEvents map[string]*time.Timer
+	handler       func(string)
+	logger        *slog.Logger
+}
+
+func NewEventDeduplicator(stopCh chan struct{}, handler func(string), logger *slog.Logger) *EventDeduplicator {
+	ed := &EventDeduplicator{
+		eventCh:       make(chan string, 10),
+		stopCh:        stopCh,
+		pendingEvents: make(map[string]*time.Timer),
+		handler:       handler,
+		logger:        logger,
+	}
+
+	go ed.processEvents()
+
+	return ed
+}
+
+func (ed *EventDeduplicator) processEvents() {
+	const delay = 150 * time.Millisecond
+
+	for {
+		select {
+		case filename := <-ed.eventCh:
+			ed.mutex.Lock()
+
+			if timer, exists := ed.pendingEvents[filename]; exists {
+				timer.Stop()
+			}
+
+			ed.pendingEvents[filename] = time.AfterFunc(delay, func() {
+				ed.handleDebouncedEvent(filename)
+			})
+
+			ed.mutex.Unlock()
+
+		case <-ed.stopCh:
+			ed.mutex.Lock()
+			for _, timer := range ed.pendingEvents {
+				timer.Stop()
+			}
+			ed.mutex.Unlock()
+			return
+		}
+	}
+}
+
+// handleDebouncedEvent processes an event after the delay period has passed.
+func (ed *EventDeduplicator) handleDebouncedEvent(filename string) {
+	ed.mutex.Lock()
+	delete(ed.pendingEvents, filename)
+	ed.mutex.Unlock()
+	ed.handler(filename)
+}
+
+func (ed *EventDeduplicator) QueueEvent(filename string) {
+	select {
+	case ed.eventCh <- filename:
+	default:
+		ed.logger.Warn(fmt.Sprintf("Event channel full, dropping event for: %s", filename))
+	}
+}
+
+func (ed *EventDeduplicator) Stop() {
+	if ed.stopCh != nil {
+		close(ed.stopCh)
+	}
+}

--- a/internal/nonkube/controller/event_deduplicator_test.go
+++ b/internal/nonkube/controller/event_deduplicator_test.go
@@ -1,0 +1,114 @@
+package controller
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestEventDeduplicator(t *testing.T) {
+	t.Run("deduplicates multiple events for same file", func(t *testing.T) {
+		var processedCount int
+		var mu sync.Mutex
+		var processedFiles []string
+
+		handler := func(filename string) {
+			mu.Lock()
+			defer mu.Unlock()
+			processedCount++
+			processedFiles = append(processedFiles, filename)
+		}
+
+		logger := slog.Default()
+		stopCh := make(chan struct{})
+		deduplicator := NewEventDeduplicator(stopCh, handler, logger)
+		defer deduplicator.Stop()
+
+		deduplicator.QueueEvent("test.yaml")
+		deduplicator.QueueEvent("test.yaml")
+		deduplicator.QueueEvent("test.yaml")
+
+		time.Sleep(200 * time.Millisecond)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		if processedCount != 1 {
+			t.Errorf("Expected 1 processing, got %d", processedCount)
+		}
+
+	})
+
+	t.Run("processes events for different files independently", func(t *testing.T) {
+		var processedCount int
+		var mu sync.Mutex
+		var processedFiles []string
+
+		handler := func(filename string) {
+			mu.Lock()
+			defer mu.Unlock()
+			processedCount++
+			processedFiles = append(processedFiles, filename)
+		}
+
+		logger := slog.Default()
+		stopCh := make(chan struct{})
+		deduplicator := NewEventDeduplicator(stopCh, handler, logger)
+		defer deduplicator.Stop()
+
+		deduplicator.QueueEvent("file1.yaml")
+		deduplicator.QueueEvent("file2.yaml")
+		deduplicator.QueueEvent("file3.yaml")
+
+		time.Sleep(200 * time.Millisecond)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		if processedCount != 3 {
+			t.Errorf("Expected 3 processing, got %d", processedCount)
+		}
+	})
+
+	t.Run("resets timer on new event for same file", func(t *testing.T) {
+		var processedCount int
+		var mu sync.Mutex
+
+		handler := func(filename string) {
+			mu.Lock()
+			defer mu.Unlock()
+			processedCount++
+		}
+
+		logger := slog.Default()
+		stopCh := make(chan struct{})
+		deduplicator := NewEventDeduplicator(stopCh, handler, logger)
+		defer deduplicator.Stop()
+
+		deduplicator.QueueEvent("test.yaml")
+		time.Sleep(100 * time.Millisecond)
+
+		deduplicator.QueueEvent("test.yaml")
+		time.Sleep(100 * time.Millisecond)
+
+		mu.Lock()
+		result := processedCount
+		mu.Unlock()
+
+		if result != 0 {
+			t.Errorf("Expected 0 processing at 200ms, got %d", result)
+		}
+
+		time.Sleep(100 * time.Millisecond)
+
+		mu.Lock()
+		result = processedCount
+		mu.Unlock()
+
+		if result != 1 {
+			t.Errorf("Expected 1 processing after full debounce, got %d", result)
+		}
+	})
+
+}

--- a/internal/nonkube/controller/event_deduplicator_test.go
+++ b/internal/nonkube/controller/event_deduplicator_test.go
@@ -4,11 +4,12 @@ import (
 	"log/slog"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
-func TestEventDeduplicator(t *testing.T) {
-	t.Run("deduplicates multiple events for same file", func(t *testing.T) {
+func TestEventDeduplicator_deduplicates_multiple_events_same_file(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
 		var processedCount int
 		var mu sync.Mutex
 		var processedFiles []string
@@ -37,10 +38,12 @@ func TestEventDeduplicator(t *testing.T) {
 		if processedCount != 1 {
 			t.Errorf("Expected 1 processing, got %d", processedCount)
 		}
-
 	})
+}
 
-	t.Run("processes events for different files independently", func(t *testing.T) {
+func TestEventDeduplicator_processes_events_for_diferent_files(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+
 		var processedCount int
 		var mu sync.Mutex
 		var processedFiles []string
@@ -69,9 +72,12 @@ func TestEventDeduplicator(t *testing.T) {
 		if processedCount != 3 {
 			t.Errorf("Expected 3 processing, got %d", processedCount)
 		}
-	})
 
-	t.Run("resets timer on new event for same file", func(t *testing.T) {
+	})
+}
+
+func TestEventDeduplicator_resets_timer_new_event_for_same_file(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
 		var processedCount int
 		var mu sync.Mutex
 
@@ -109,6 +115,6 @@ func TestEventDeduplicator(t *testing.T) {
 		if result != 1 {
 			t.Errorf("Expected 1 processing after full debounce, got %d", result)
 		}
-	})
 
+	})
 }

--- a/internal/nonkube/controller/input_resource_handler.go
+++ b/internal/nonkube/controller/input_resource_handler.go
@@ -20,6 +20,7 @@ import (
 // This feature is responsible for handling the creation of input resources and
 // execute the start/reload of the site configuration automatically.
 type InputResourceHandler struct {
+	stopCh            chan struct{}
 	logger            *slog.Logger
 	namespace         string
 	inputPath         string
@@ -31,13 +32,14 @@ type InputResourceHandler struct {
 	siteStateRenderer *compat.SiteStateRenderer
 	siteStateLoader   api.SiteStateLoader
 	siteHandler       *fs.SiteHandler
+	deduplicator      *EventDeduplicator
 }
 
 type Bootstrap func(config *bootstrap.Config) (*api.SiteState, error)
 type PostBootstrap func(config *bootstrap.Config, siteState *api.SiteState)
 type TearDown func(namespace string) error
 
-func NewInputResourceHandler(namespace string, inputPath string, bs Bootstrap, pbs PostBootstrap, td TearDown) *InputResourceHandler {
+func NewInputResourceHandler(stopCh chan struct{}, namespace string, inputPath string, bs Bootstrap, pbs PostBootstrap, td TearDown) *InputResourceHandler {
 
 	systemReloadType := utils.DefaultStr(os.Getenv(types.ENV_SYSTEM_AUTO_RELOAD),
 		types.SystemReloadTypeManual)
@@ -50,6 +52,7 @@ func NewInputResourceHandler(namespace string, inputPath string, bs Bootstrap, p
 	handler := &InputResourceHandler{
 		namespace: namespace,
 		inputPath: inputPath,
+		stopCh:    stopCh,
 	}
 
 	handler.logger = slog.Default().With("component", "input.resource.handler", "namespace", namespace)
@@ -95,26 +98,32 @@ func NewInputResourceHandler(namespace string, inputPath string, bs Bootstrap, p
 
 	handler.siteHandler = fs.NewSiteHandler(namespace)
 
+	handler.deduplicator = NewEventDeduplicator(
+		stopCh,
+		func(filename string) {
+			handler.lock.Lock()
+			defer handler.lock.Unlock()
+
+			err := handler.processInputFile()
+			if err != nil {
+				handler.logger.Error(err.Error())
+			}
+		},
+		handler.logger,
+	)
+
 	return handler
 }
 
 func (h *InputResourceHandler) OnCreate(name string) {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-
 	h.logger.Info(fmt.Sprintf("Resource has been created: %s", name))
-	err := h.processInputFile()
-	if err != nil {
-		h.logger.Error(err.Error())
-	}
+	h.deduplicator.QueueEvent(name)
 }
 
-// This function does not need to be implemented, given that when a file is updated,
-// the event OnCreate is triggered anyway. Having it implemented would cause
-// the resources to be reloaded multiple times, stopping and starting a router pod.
-// (issue: the router pod is still active while going to be deleted, and the controller
-// tries to create a new router pod, failing on this)
-func (h *InputResourceHandler) OnUpdate(name string) {}
+func (h *InputResourceHandler) OnUpdate(name string) {
+	h.logger.Info(fmt.Sprintf("Resource has been updated: %s", name))
+	h.deduplicator.QueueEvent(name)
+}
 func (h *InputResourceHandler) OnRemove(name string) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
@@ -199,5 +208,9 @@ func (h *InputResourceHandler) tearDownNamespace() error {
 		return err
 	}
 
+	if h.deduplicator != nil {
+		h.logger.Info("Stopping deduplicator")
+		h.deduplicator.Stop()
+	}
 	return nil
 }

--- a/internal/nonkube/controller/input_resource_handler_test.go
+++ b/internal/nonkube/controller/input_resource_handler_test.go
@@ -16,7 +16,8 @@ func TestInputResourceHandler(t *testing.T) {
 	t.Run("handler created for docker platform", func(t *testing.T) {
 		t.Setenv(types.ENV_SYSTEM_AUTO_RELOAD, "auto")
 		t.Setenv("CONTAINER_ENGINE", "docker")
-		inputResourceHandler := NewInputResourceHandler("test_namespace", "test_inputPath", mockBootstrap, mockPostExec, mockTearDown)
+		stopCh := make(chan struct{})
+		inputResourceHandler := NewInputResourceHandler(stopCh, "test_namespace", "test_inputPath", mockBootstrap, mockPostExec, mockTearDown)
 		expectedConfigBootstrap := bootstrap.Config{
 			Namespace: "test_namespace",
 			InputPath: "test_inputPath",
@@ -32,7 +33,8 @@ func TestInputResourceHandler(t *testing.T) {
 	t.Run("handler created for podman platform", func(t *testing.T) {
 		t.Setenv(types.ENV_SYSTEM_AUTO_RELOAD, "auto")
 		t.Setenv("CONTAINER_ENGINE", "podman")
-		inputResourceHandler := NewInputResourceHandler("test_namespace", "test_inputPath", mockBootstrap, mockPostExec, mockTearDown)
+		stopCh := make(chan struct{})
+		inputResourceHandler := NewInputResourceHandler(stopCh, "test_namespace", "test_inputPath", mockBootstrap, mockPostExec, mockTearDown)
 		expectedConfigBootstrap := bootstrap.Config{
 			Namespace: "test_namespace",
 			InputPath: "test_inputPath",
@@ -48,7 +50,8 @@ func TestInputResourceHandler(t *testing.T) {
 	t.Run("handler not created for linux platform", func(t *testing.T) {
 		t.Setenv(types.ENV_SYSTEM_AUTO_RELOAD, "auto")
 		t.Setenv("CONTAINER_ENGINE", "linux")
-		inputResourceHandler := NewInputResourceHandler("test_namespace", "test_inputPath", mockBootstrap, mockPostExec, mockTearDown)
+		stopCh := make(chan struct{})
+		inputResourceHandler := NewInputResourceHandler(stopCh, "test_namespace", "test_inputPath", mockBootstrap, mockPostExec, mockTearDown)
 
 		assert.Assert(t, inputResourceHandler == nil)
 
@@ -56,7 +59,8 @@ func TestInputResourceHandler(t *testing.T) {
 
 	t.Run("handler not created because the system reload is configured to be manual", func(t *testing.T) {
 		t.Setenv(types.ENV_SYSTEM_AUTO_RELOAD, "manual")
-		inputResourceHandler := NewInputResourceHandler("test_namespace", "test_inputPath", mockBootstrap, mockPostExec, mockTearDown)
+		stopCh := make(chan struct{})
+		inputResourceHandler := NewInputResourceHandler(stopCh, "test_namespace", "test_inputPath", mockBootstrap, mockPostExec, mockTearDown)
 
 		assert.Assert(t, inputResourceHandler == nil)
 
@@ -64,7 +68,8 @@ func TestInputResourceHandler(t *testing.T) {
 
 	t.Run("handler not created for unknown platform", func(t *testing.T) {
 		t.Setenv("CONTAINER_ENGINE", "unknown")
-		inputResourceHandler := NewInputResourceHandler("test_namespace", "test_inputPath", mockBootstrap, mockPostExec, mockTearDown)
+		stopCh := make(chan struct{})
+		inputResourceHandler := NewInputResourceHandler(stopCh, "test_namespace", "test_inputPath", mockBootstrap, mockPostExec, mockTearDown)
 
 		assert.Assert(t, inputResourceHandler == nil)
 
@@ -75,7 +80,8 @@ func TestInputResourceHandler(t *testing.T) {
 		namespace := "test-file-created-ns"
 		inputPath := "test-file-created-input-path"
 
-		handler := NewInputResourceHandler(namespace, inputPath, mockBootstrap, mockPostExec, mockTearDown)
+		stopCh := make(chan struct{})
+		handler := NewInputResourceHandler(stopCh, namespace, inputPath, mockBootstrap, mockPostExec, mockTearDown)
 
 		logSpy := &testLogHandler{
 			handler: slog.Default().Handler(),
@@ -97,7 +103,8 @@ func TestInputResourceHandler(t *testing.T) {
 		namespace := "test-file-ns"
 		inputPath := "test-file-input-path"
 
-		handler := NewInputResourceHandler(namespace, inputPath, mockBootstrap, mockPostExec, mockTearDown)
+		stopCh := make(chan struct{})
+		handler := NewInputResourceHandler(stopCh, namespace, inputPath, mockBootstrap, mockPostExec, mockTearDown)
 
 		logSpy := &testLogHandler{
 			handler: slog.Default().Handler(),

--- a/internal/nonkube/controller/namespace_controller.go
+++ b/internal/nonkube/controller/namespace_controller.go
@@ -45,7 +45,7 @@ func (w *NamespaceController) Start() {
 		routerConfigHandler.AddCallback(routerStateHandler)
 		collectorLifecycleHandler := NewCollectorLifecycleHandler(w.ns)
 		routerStateHandler.AddCallback(collectorLifecycleHandler)
-		inputResourceHandler := NewInputResourceHandler(w.ns, w.pathProvider.GetNamespace(), bootstrap.Bootstrap, bootstrap.PostBootstrap, bootstrap.Teardown)
+		inputResourceHandler := NewInputResourceHandler(w.stopCh, w.ns, w.pathProvider.GetNamespace(), bootstrap.Bootstrap, bootstrap.PostBootstrap, bootstrap.Teardown)
 		systemAdaptorHandler := NewSystemAdaptorHandler(w.ns)
 		if systemAdaptorHandler != nil {
 			routerStateHandler.AddCallback(systemAdaptorHandler)


### PR DESCRIPTION
Fixes #2432 

### Why was this approach chosen?
From `fsnotify` package[1]: 

>A single "write action" initiated by the user may show up as one or multiple                      writes, depending on when the system syncs things to disk. For example when compiling a large Go program you may get hundreds of Write events, and you may want to wait until you've stopped receiving them (see the dedup example in cmd/fsnotify).[2]

Following the dedup example, this change adds a new process called `EventDeduplicator`, that handles deduplication of _OnCreate_ and _OnUpdate_ events; collecting them in a time window and processing only the final event.

```mermaid
flowchart TD
   id1([new listener resource is created])-->|triggers|InputResourceHandler-->Q{site exists?}
   Q -->|Yes| A[Refresh Router Config]
   Q -->|No| B[Bootstrap]
   InputResourceHandler-->|sends event|EventDeduplicator
   EventDeduplicator-->|sends final event|InputResourceHandler
```

This new process gets stopped during the `teardown` (a site is deleted) or when the `NamespaceController` gets stopped as well.

[1]https://pkg.go.dev/github.com/fsnotify/fsnotify#section-readme
[2]https://github.com/fsnotify/fsnotify/blob/v1.10.1/cmd/fsnotify/dedup.go#L17