### PR TITLE
Add system-controller image in the manifest command output 

### DIFF
--- a/internal/cmd/skupper/manifest/kube/manifest.go
+++ b/internal/cmd/skupper/manifest/kube/manifest.go
@@ -79,9 +79,9 @@ func (cmd *CmdManifest) InputToOptions() {
 	}
 
 	if cmd.output != "" {
-		cmd.manifest = configs.ManifestManager{Components: images.KubeComponents, EnableSHA: true, RunningPods: mapRunningPods}
+		cmd.manifest = configs.ManifestManager{Components: images.DefaultComponents, EnableSHA: true, RunningPods: mapRunningPods}
 	} else {
-		cmd.manifest = configs.ManifestManager{Components: images.KubeComponents, EnableSHA: false, RunningPods: mapRunningPods}
+		cmd.manifest = configs.ManifestManager{Components: images.DefaultComponents, EnableSHA: false, RunningPods: mapRunningPods}
 	}
 }
 

--- a/internal/cmd/skupper/manifest/nonkube/manifest.go
+++ b/internal/cmd/skupper/manifest/nonkube/manifest.go
@@ -89,9 +89,9 @@ func (cmd *CmdManifest) InputToOptions() {
 	}
 
 	if cmd.output != "" {
-		cmd.manifest = configs.ManifestManager{Components: images.NonKubeComponents, EnableSHA: true, RunningPods: mapRunningPods}
+		cmd.manifest = configs.ManifestManager{Components: images.DefaultComponents, EnableSHA: true, RunningPods: mapRunningPods}
 	} else {
-		cmd.manifest = configs.ManifestManager{Components: images.NonKubeComponents, EnableSHA: false, RunningPods: mapRunningPods}
+		cmd.manifest = configs.ManifestManager{Components: images.DefaultComponents, EnableSHA: false, RunningPods: mapRunningPods}
 	}
 
 }

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -16,8 +16,6 @@ const (
 )
 
 var (
-	KubeComponents       = []string{"router", "controller", "network-observer", "cli", "prometheus", "origin-oauth-proxy"}
-	NonKubeComponents    = []string{"router", "network-observer", "cli", "system-controller", "prometheus", "origin-oauth-proxy"}
-	DefaultComponents    = []string{"router", "prometheus", "origin-oauth-proxy"}
+	DefaultComponents    = []string{"router", "controller", "network-observer", "cli", "system-controller"}
 	DevelopmentImageTags = []string{"main", "v2-dev"}
 )


### PR DESCRIPTION
Fixes #2443 

It also removes the prometheus and oauth images from the manifest, given that they are not included in the skupper artifact.