### PR TITLE
Create router access dynamically in case a site has link access is enabled

### DIFF
--- a/cmd/bootstrap/README.md
+++ b/cmd/bootstrap/README.md
@@ -107,7 +107,7 @@ that makes your running site meaningful, like Listeners and/or Connectors.
 To enable your local site to accept incoming links from other sites, you have two options:
 
 1. **Automatic RouterAccess Generation (Recommended)**: Set `spec.linkAccess: default` in your Site CR.
-   Skupper will automatically create a RouterAccess named "router-access-[SITE NAME]" with dynamically allocated ports
+   Skupper will automatically create a RouterAccess named "[SITE NAME]" with dynamically allocated ports
    (starting from 55671 for inter-router and 45671 for edge roles). 
 
 2. **Manual RouterAccess**: Explicitly provide a `RouterAccess` (CR) with your desired configuration.

--- a/cmd/bootstrap/README.md
+++ b/cmd/bootstrap/README.md
@@ -102,8 +102,16 @@ Place all your Custom Resources (CRs) on a local directory.
 You must always provide a `Site` (CR), plus some other resource
 that makes your running site meaningful, like Listeners and/or Connectors.
 
-In case you want your local site to accept incoming links from other sites,
-at present, you have to explicitly provide a `RouterAccess` (CR).
+#### Enabling link access
+
+To enable your local site to accept incoming links from other sites, you have two options:
+
+1. **Automatic RouterAccess Generation (Recommended)**: Set `spec.linkAccess: default` in your Site CR.
+   Skupper will automatically create a RouterAccess named "router-access-[SITE NAME]" with dynamically allocated ports
+   (starting from 55671 for inter-router and 45671 for edge roles). 
+
+2. **Manual RouterAccess**: Explicitly provide a `RouterAccess` (CR) with your desired configuration.
+   This gives you full control over ports, bind addresses, and other settings.
 
 If you want your non-kubernetes site to establish links to other sites, make
 sure you also provide `AccessToken` or `Link` (CRs).
@@ -265,6 +273,8 @@ apiVersion: skupper.io/v2alpha1
 kind: Site
 metadata:
   name: west
+spec:
+  linkAccess: default  # Enables automatic RouterAccess generation
 ```
 
 ##### Listener
@@ -280,7 +290,10 @@ spec:
   routingKey: backend-8080
 ```
 
-##### RouterAccess
+##### RouterAccess (Optional - Automatic Generation)
+
+When `spec.linkAccess: default` is set in the Site CR, Skupper automatically creates a RouterAccess
+with dynamically allocated ports. You can also manually define a RouterAccess for custom configuration:
 
 ```yaml
 apiVersion: skupper.io/v2alpha1
@@ -296,12 +309,13 @@ spec:
   bindHost: 127.0.0.1
 ```
 
-Equivalent in CLI commands: 
+Equivalent in CLI commands:
 ```
 skupper site create west --enable-link-access -n west
 skupper listener create backend 8080 -n west
 ```
-Note the CLI takes care of the creation of the RouterAccess resource.
+Note: The CLI automatically sets `spec.linkAccess: default` when `--enable-link-access` is used,
+triggering automatic RouterAccess generation with dynamic port allocation.
 
 
 ##### Bootstrap the west site
@@ -338,6 +352,7 @@ apiVersion: skupper.io/v2alpha1
 kind: Site
 metadata:
   name: east
+# Note: linkAccess not set, so no incoming links will be accepted
 ```
 
 **Connector**

--- a/internal/cmd/skupper/site/nonkube/site_create.go
+++ b/internal/cmd/skupper/site/nonkube/site_create.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
-	"github.com/skupperproject/skupper/internal/cmd/skupper/common/utils"
 	"github.com/skupperproject/skupper/internal/nonkube/client/fs"
 	"github.com/skupperproject/skupper/internal/utils/validator"
 	"github.com/skupperproject/skupper/pkg/apis/skupper/v2alpha1"
@@ -18,16 +17,13 @@ import (
 )
 
 type CmdSiteCreate struct {
-	siteHandler             *fs.SiteHandler
-	routerAccessHandler     *fs.RouterAccessHandler
-	CobraCmd                *cobra.Command
-	Flags                   *common.CommandSiteCreateFlags
-	siteName                string
-	linkAccessEnabled       bool
-	namespace               string
-	routerAccessName        string
-	subjectAlternativeNames []string
-	logger                  *slog.Logger
+	siteHandler       *fs.SiteHandler
+	CobraCmd          *cobra.Command
+	Flags             *common.CommandSiteCreateFlags
+	siteName          string
+	linkAccessEnabled bool
+	namespace         string
+	logger            *slog.Logger
 }
 
 func NewCmdSiteCreate() *CmdSiteCreate {
@@ -42,8 +38,6 @@ func (cmd *CmdSiteCreate) NewClient(cobraCommand *cobra.Command, args []string) 
 	}
 
 	cmd.siteHandler = fs.NewSiteHandler(cmd.namespace)
-	cmd.routerAccessHandler = fs.NewRouterAccessHandler(cmd.namespace)
-
 }
 
 func (cmd *CmdSiteCreate) ValidateInput(args []string) error {
@@ -84,14 +78,7 @@ func (cmd *CmdSiteCreate) ValidateInput(args []string) error {
 func (cmd *CmdSiteCreate) InputToOptions() {
 
 	if cmd.Flags.EnableLinkAccess {
-		sanByDefault, err := utils.GetSansByDefault()
-		if err != nil {
-			cmd.logger.Error("Error getting SANs by default")
-		}
-
 		cmd.linkAccessEnabled = true
-		cmd.routerAccessName = "router-access-" + cmd.siteName
-		cmd.subjectAlternativeNames = sanByDefault
 	}
 
 	if cmd.namespace == "" {
@@ -113,40 +100,13 @@ func (cmd *CmdSiteCreate) Run() error {
 		},
 	}
 
-	routerAccessResource := v2alpha1.RouterAccess{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "skupper.io/v2alpha1",
-			Kind:       "RouterAccess",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cmd.routerAccessName,
-			Namespace: cmd.namespace,
-		},
-		Spec: v2alpha1.RouterAccessSpec{
-			Roles: []v2alpha1.RouterAccessRole{
-				{
-					Name: "inter-router",
-					Port: 55671,
-				},
-				{
-					Name: "edge",
-					Port: 45671,
-				},
-			},
-			SubjectAlternativeNames: cmd.subjectAlternativeNames,
-		},
+	if cmd.linkAccessEnabled {
+		siteResource.Spec.LinkAccess = "default"
 	}
 
 	err := cmd.siteHandler.Add(siteResource)
 	if err != nil {
 		return err
-	}
-
-	if cmd.linkAccessEnabled == true {
-		err = cmd.routerAccessHandler.Add(routerAccessResource)
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/internal/cmd/skupper/site/nonkube/site_create_test.go
+++ b/internal/cmd/skupper/site/nonkube/site_create_test.go
@@ -134,14 +134,11 @@ func TestNonKubeCmdSiteCreate_InputToOptions(t *testing.T) {
 			cmd.siteName = "my-site"
 			cmd.namespace = test.namespace
 			cmd.siteHandler = fs.NewSiteHandler(cmd.namespace)
-			cmd.routerAccessHandler = fs.NewRouterAccessHandler(cmd.namespace)
 
 			cmd.InputToOptions()
 
 			assert.Check(t, cmd.namespace == test.expectedNamespace)
 			assert.Check(t, cmd.linkAccessEnabled == test.expectedLinkAccess)
-			assert.Check(t, cmd.routerAccessName == test.expectedRouterAccessName)
-			assert.Equal(t, len(cmd.subjectAlternativeNames) > 0, test.expectedSansByDefault)
 		})
 	}
 }
@@ -172,12 +169,9 @@ func TestNonKubeCmdSiteCreate_Run(t *testing.T) {
 		command := &CmdSiteCreate{}
 
 		command.siteName = test.siteName
-		command.routerAccessName = test.routerAccessName
 		command.linkAccessEnabled = test.linkAccessEnabled
 		command.siteHandler = fs.NewSiteHandler(command.namespace)
-		command.routerAccessHandler = fs.NewRouterAccessHandler(command.namespace)
 		defer command.siteHandler.Delete("my-site")
-		defer command.routerAccessHandler.Delete("my-site")
 		t.Run(test.name, func(t *testing.T) {
 
 			err := command.Run()

--- a/internal/cmd/skupper/site/nonkube/site_generate.go
+++ b/internal/cmd/skupper/site/nonkube/site_generate.go
@@ -18,17 +18,15 @@ import (
 )
 
 type CmdSiteGenerate struct {
-	siteHandler             *fs.SiteHandler
-	routerAccessHandler     *fs.RouterAccessHandler
-	CobraCmd                *cobra.Command
-	Flags                   *common.CommandSiteGenerateFlags
-	siteName                string
-	linkAccessEnabled       bool
-	output                  string
-	namespace               string
-	routerAccessName        string
-	subjectAlternativeNames []string
-	logger                  *slog.Logger
+	siteHandler         *fs.SiteHandler
+	routerAccessHandler *fs.RouterAccessHandler
+	CobraCmd            *cobra.Command
+	Flags               *common.CommandSiteGenerateFlags
+	siteName            string
+	linkAccessEnabled   bool
+	output              string
+	namespace           string
+	logger              *slog.Logger
 }
 
 func NewCmdSiteGenerate() *CmdSiteGenerate {
@@ -94,14 +92,7 @@ func (cmd *CmdSiteGenerate) ValidateInput(args []string) error {
 
 func (cmd *CmdSiteGenerate) InputToOptions() {
 	if cmd.Flags.EnableLinkAccess {
-		sanByDefault, err := utils.GetSansByDefault()
-		if err != nil {
-			cmd.logger.Error("Error getting SANs by default")
-		}
-
 		cmd.linkAccessEnabled = true
-		cmd.routerAccessName = "router-access-" + cmd.siteName
-		cmd.subjectAlternativeNames = sanByDefault
 	}
 
 	if cmd.namespace == "" {
@@ -125,28 +116,8 @@ func (cmd *CmdSiteGenerate) Run() error {
 		},
 	}
 
-	routerAccessResource := v2alpha1.RouterAccess{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "skupper.io/v2alpha1",
-			Kind:       "RouterAccess",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cmd.routerAccessName,
-			Namespace: cmd.namespace,
-		},
-		Spec: v2alpha1.RouterAccessSpec{
-			Roles: []v2alpha1.RouterAccessRole{
-				{
-					Name: "inter-router",
-					Port: 55671,
-				},
-				{
-					Name: "edge",
-					Port: 45671,
-				},
-			},
-			SubjectAlternativeNames: cmd.subjectAlternativeNames,
-		},
+	if cmd.linkAccessEnabled {
+		siteResource.Spec.LinkAccess = "default"
 	}
 
 	encodedSiteOutput, err := utils.Encode(cmd.output, siteResource)
@@ -154,15 +125,6 @@ func (cmd *CmdSiteGenerate) Run() error {
 		return err
 	}
 	fmt.Println(encodedSiteOutput)
-
-	if cmd.linkAccessEnabled == true {
-		fmt.Println("---")
-		encodedRouterAccessOutput, err := utils.Encode(cmd.output, routerAccessResource)
-		if err != nil {
-			return err
-		}
-		fmt.Println(encodedRouterAccessOutput)
-	}
 
 	return err
 }

--- a/internal/cmd/skupper/site/nonkube/site_generate_test.go
+++ b/internal/cmd/skupper/site/nonkube/site_generate_test.go
@@ -157,8 +157,6 @@ func TestNonKubeCmdSiteGenerate_InputToOptions(t *testing.T) {
 			assert.Check(t, cmd.output == test.expectedOutput)
 			assert.Check(t, cmd.namespace == test.expectedNamespace)
 			assert.Check(t, cmd.linkAccessEnabled == test.expectedLinkAccess)
-			assert.Check(t, cmd.routerAccessName == test.expectedRouterAccessName)
-			assert.Equal(t, len(cmd.subjectAlternativeNames) > 0, test.expectedSansByDefault)
 		})
 	}
 }
@@ -199,7 +197,6 @@ func TestNonKubeCmdSiteGenerate_Run(t *testing.T) {
 
 		command.siteName = test.siteName
 		command.output = test.output
-		command.routerAccessName = test.routerAccessName
 		command.linkAccessEnabled = test.linkAccessEnabled
 		command.siteHandler = fs.NewSiteHandler(command.namespace)
 		command.routerAccessHandler = fs.NewRouterAccessHandler(command.namespace)

--- a/internal/cmd/skupper/site/nonkube/site_update.go
+++ b/internal/cmd/skupper/site/nonkube/site_update.go
@@ -7,22 +7,17 @@ import (
 	"github.com/skupperproject/skupper/internal/cmd/skupper/common"
 	"github.com/skupperproject/skupper/internal/nonkube/client/fs"
 	"github.com/skupperproject/skupper/internal/utils/validator"
-	"github.com/skupperproject/skupper/pkg/apis/skupper/v2alpha1"
+
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type CmdSiteUpdate struct {
-	siteHandler             *fs.SiteHandler
-	routerAccessHandler     *fs.RouterAccessHandler
-	CobraCmd                *cobra.Command
-	Flags                   *common.CommandSiteUpdateFlags
-	siteName                string
-	namespace               string
-	linkAccessEnabled       bool
-	bindHost                string
-	routerAccessName        string
-	subjectAlternativeNames []string
+	siteHandler       *fs.SiteHandler
+	CobraCmd          *cobra.Command
+	Flags             *common.CommandSiteUpdateFlags
+	siteName          string
+	namespace         string
+	linkAccessEnabled bool
 }
 
 func NewCmdSiteUpdate() *CmdSiteUpdate {
@@ -35,7 +30,6 @@ func (cmd *CmdSiteUpdate) NewClient(cobraCommand *cobra.Command, args []string) 
 	}
 
 	cmd.siteHandler = fs.NewSiteHandler(cmd.namespace)
-	cmd.routerAccessHandler = fs.NewRouterAccessHandler(cmd.namespace)
 }
 
 func (cmd *CmdSiteUpdate) ValidateInput(args []string) error {
@@ -80,15 +74,11 @@ func (cmd *CmdSiteUpdate) ValidateInput(args []string) error {
 		site, err := cmd.siteHandler.Get(cmd.siteName, opts)
 		if site == nil || err != nil {
 			validationErrors = append(validationErrors, fmt.Errorf("site %s must exist to be updated", cmd.siteName))
-		}
-
-		routerAccessName := "router-access-" + cmd.siteName
-		routerAccess, err := cmd.routerAccessHandler.Update(routerAccessName)
-		if err == nil && routerAccess != nil {
-			// save existing values
-			cmd.bindHost = routerAccess.Spec.BindHost
-			cmd.subjectAlternativeNames = routerAccess.Spec.SubjectAlternativeNames
-			cmd.linkAccessEnabled = true
+		} else {
+			// Check current linkAccess setting
+			if site.Spec.LinkAccess != "" && site.Spec.LinkAccess != "none" {
+				cmd.linkAccessEnabled = true
+			}
 		}
 	}
 
@@ -99,75 +89,31 @@ func (cmd *CmdSiteUpdate) InputToOptions() {
 	// if EnableLinkAccess flag was explicitly set use value otherwise use value from
 	// previous create command
 	if cmd.CobraCmd.Flags().Changed(common.FlagNameEnableLinkAccess) {
-		if cmd.Flags.EnableLinkAccess == true {
-			cmd.linkAccessEnabled = true
-		} else {
-			cmd.linkAccessEnabled = false
-		}
+		cmd.linkAccessEnabled = cmd.Flags.EnableLinkAccess
 	}
-
-	cmd.routerAccessName = "router-access-" + cmd.siteName
 
 	if cmd.namespace == "" {
 		cmd.namespace = "default"
 	}
-
 }
 
 func (cmd *CmdSiteUpdate) Run() error {
-
-	siteResource := v2alpha1.Site{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "skupper.io/v2alpha1",
-			Kind:       "Site",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cmd.siteName,
-			Namespace: cmd.namespace,
-		},
+	// Get existing site to preserve other settings
+	opts := fs.GetOptions{RuntimeFirst: false, LogWarning: false}
+	existingSite, err := cmd.siteHandler.Get(cmd.siteName, opts)
+	if err != nil {
+		return fmt.Errorf("failed to get existing site: %w", err)
 	}
 
-	routerAccessResource := v2alpha1.RouterAccess{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "skupper.io/v2alpha1",
-			Kind:       "RouterAccess",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cmd.routerAccessName,
-			Namespace: cmd.namespace,
-		},
-		Spec: v2alpha1.RouterAccessSpec{
-			Roles: []v2alpha1.RouterAccessRole{
-				{
-					Name: "inter-router",
-					Port: 55671,
-				},
-				{
-					Name: "edge",
-					Port: 45671,
-				},
-			},
-			BindHost:                cmd.bindHost,
-			SubjectAlternativeNames: cmd.subjectAlternativeNames,
-		},
+	if cmd.linkAccessEnabled {
+		existingSite.Spec.LinkAccess = "default"
+	} else {
+		existingSite.Spec.LinkAccess = "none"
 	}
 
-	err := cmd.siteHandler.Add(siteResource)
+	err = cmd.siteHandler.Add(*existingSite)
 	if err != nil {
 		return err
-	}
-
-	if cmd.linkAccessEnabled == true {
-		err = cmd.routerAccessHandler.Add(routerAccessResource)
-		if err != nil {
-			return err
-		}
-	} else {
-		fmt.Println("link access not enabled, router access removed", cmd.routerAccessName)
-		err = cmd.routerAccessHandler.Delete(cmd.routerAccessName)
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/internal/cmd/skupper/site/nonkube/site_update_test.go
+++ b/internal/cmd/skupper/site/nonkube/site_update_test.go
@@ -98,46 +98,16 @@ func TestCmdSiteUpdate_ValidateInput(t *testing.T) {
 		},
 	}
 
-	routerAccessResource := v2alpha1.RouterAccess{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "skupper.io/v2alpha1",
-			Kind:       "RouterAccess",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "router-access-mysite",
-			Namespace: "test4",
-		},
-		Spec: v2alpha1.RouterAccessSpec{
-			Roles: []v2alpha1.RouterAccessRole{
-				{
-					Name: "inter-router",
-					Port: 55671,
-				},
-				{
-					Name: "edge",
-					Port: 45671,
-				},
-			},
-			BindHost:                "1.2.3.4",
-			SubjectAlternativeNames: []string{"test", "2.2.2.2"},
-		},
-	}
 	command := &CmdSiteUpdate{Flags: &common.CommandSiteUpdateFlags{}}
 	command.CobraCmd = &cobra.Command{Use: "test"}
 	command.namespace = "test4"
 	command.siteHandler = fs.NewSiteHandler(command.namespace)
-	command.routerAccessHandler = fs.NewRouterAccessHandler(command.namespace)
 
 	defer command.siteHandler.Delete("my-site")
-	defer command.routerAccessHandler.Delete("my-site")
 
 	content, err := command.siteHandler.EncodeToYaml(siteResource)
 	assert.Check(t, err == nil)
 	err = command.siteHandler.WriteFile(path, "my-site.yaml", content, common.Sites)
-	assert.Check(t, err == nil)
-	content, err = command.routerAccessHandler.EncodeToYaml(routerAccessResource)
-	assert.Check(t, err == nil)
-	err = command.routerAccessHandler.WriteFile(path, "router-access-my-site.yaml", content, common.RouterAccesses)
 	assert.Check(t, err == nil)
 
 	for _, test := range testTable {
@@ -212,7 +182,6 @@ func TestNonKubeCmdSiteUpdate_InputToOptions(t *testing.T) {
 
 			assert.Check(t, cmd.namespace == test.expectedNamespace)
 			assert.Check(t, cmd.linkAccessEnabled == test.expectedLinkAccess)
-			assert.Check(t, cmd.routerAccessName == test.expectedRouterAccessName)
 		})
 	}
 }
@@ -227,9 +196,15 @@ func TestCmdSiteUpdate_Run(t *testing.T) {
 		linkAccessEnabled bool
 	}
 
+	if os.Getuid() == 0 {
+		api.DefaultRootDataHome = t.TempDir()
+	} else {
+		t.Setenv("XDG_DATA_HOME", t.TempDir())
+	}
+
 	testTable := []test{
 		{
-			name:      "runs ok link enable",
+			name:      "runs ok with access link enabled",
 			namespace: "test4",
 			siteName:  "my-site",
 			flags: common.CommandSiteUpdateFlags{
@@ -243,35 +218,32 @@ func TestCmdSiteUpdate_Run(t *testing.T) {
 			siteName:  "my-site",
 			flags:     common.CommandSiteUpdateFlags{},
 		},
-		{
-			name:     "run ok output json",
-			siteName: "my-site",
-			flags: common.CommandSiteUpdateFlags{
-				EnableLinkAccess: true,
-			},
-			linkAccessEnabled: true,
-		},
-		{
-			name:     "run ok output yaml",
-			siteName: "my-site",
-			flags: common.CommandSiteUpdateFlags{
-				EnableLinkAccess: false,
-			},
-		},
 	}
 
 	for _, test := range testTable {
-		command := &CmdSiteUpdate{}
-		command.CobraCmd = &cobra.Command{Use: "test"}
-		command.Flags = &test.flags
-		command.siteName = test.siteName
-		command.siteHandler = fs.NewSiteHandler(command.namespace)
-		command.routerAccessHandler = fs.NewRouterAccessHandler(command.namespace)
-		command.linkAccessEnabled = test.linkAccessEnabled
-		defer command.siteHandler.Delete("my-site")
-		defer command.routerAccessHandler.Delete("my-site")
 		t.Run(test.name, func(t *testing.T) {
-			command.InputToOptions()
+			command := &CmdSiteUpdate{}
+			command.CobraCmd = &cobra.Command{Use: "test"}
+			command.Flags = &test.flags
+			command.siteName = test.siteName
+			command.namespace = test.namespace
+			command.siteHandler = fs.NewSiteHandler(command.namespace)
+			command.linkAccessEnabled = test.linkAccessEnabled
+			defer command.siteHandler.Delete("my-site")
+
+			// Create the site file first so it exists for update
+			siteResource := v2alpha1.Site{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "skupper.io/v2alpha1",
+					Kind:       "Site",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      test.siteName,
+					Namespace: command.namespace,
+				},
+			}
+			command.siteHandler.Add(siteResource)
+
 			err := command.Run()
 			if err != nil {
 				assert.Check(t, test.errorMessage == err.Error(), err.Error())

--- a/internal/nonkube/common/site_state_renderer_common.go
+++ b/internal/nonkube/common/site_state_renderer_common.go
@@ -8,6 +8,7 @@ import (
 	"github.com/skupperproject/skupper/pkg/apis/skupper/v2alpha1"
 	"github.com/skupperproject/skupper/pkg/nonkube/api"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func CopySiteState(siteState *api.SiteState) *api.SiteState {
@@ -65,6 +66,51 @@ func copySiteStateMap[T any](m map[string]T) map[string]T {
 		}
 	}
 	return newMap
+}
+
+func EnableLinkAccess(siteState *api.SiteState) error {
+
+	routerAccessName := "router-access-" + siteState.Site.Name
+
+	if _, exists := siteState.RouterAccesses[routerAccessName]; exists {
+		return nil
+	}
+
+	interRouterPort, edgePort, err := utils.AllocateRouterAccessPorts()
+	if err != nil {
+		return fmt.Errorf("failed to allocate ports for RouterAccess: %w", err)
+	}
+
+	sanByDefault, err := utils.GetSansByDefault()
+	if err != nil {
+		return fmt.Errorf("Error getting SANs by default: %s", err)
+	}
+
+	siteState.RouterAccesses[routerAccessName] = &v2alpha1.RouterAccess{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "skupper.io/v2alpha1",
+			Kind:       "RouterAccess",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routerAccessName,
+			Namespace: siteState.GetNamespace(),
+		},
+		Spec: v2alpha1.RouterAccessSpec{
+			Roles: []v2alpha1.RouterAccessRole{
+				{
+					Name: "inter-router",
+					Port: interRouterPort,
+				},
+				{
+					Name: "edge",
+					Port: edgePort,
+				},
+			},
+			SubjectAlternativeNames: sanByDefault,
+		},
+	}
+
+	return nil
 }
 
 func CreateRouterAccess(siteState *api.SiteState) error {

--- a/internal/nonkube/common/site_state_renderer_common.go
+++ b/internal/nonkube/common/site_state_renderer_common.go
@@ -70,7 +70,7 @@ func copySiteStateMap[T any](m map[string]T) map[string]T {
 
 func EnableLinkAccess(siteState *api.SiteState) error {
 
-	routerAccessName := "router-access-" + siteState.Site.Name
+	routerAccessName := siteState.Site.Name
 
 	if _, exists := siteState.RouterAccesses[routerAccessName]; exists {
 		return nil

--- a/internal/nonkube/common/site_state_renderer_common_test.go
+++ b/internal/nonkube/common/site_state_renderer_common_test.go
@@ -79,7 +79,7 @@ func TestCreateSiteRouterAccess(t *testing.T) {
 			name:                   "create router-access-west",
 			linkAccess:             "default",
 			existingRouterAccesses: map[string]*v2alpha1.RouterAccess{},
-			expectedName:           "router-access-test-site",
+			expectedName:           "test-site",
 			isBundle:               false,
 			expectRouterAccess:     true,
 		},
@@ -87,9 +87,9 @@ func TestCreateSiteRouterAccess(t *testing.T) {
 			name:       "router-access-test-site already exists, not recreated",
 			linkAccess: "default",
 			existingRouterAccesses: map[string]*v2alpha1.RouterAccess{
-				"router-access-test-site": {
+				"test-site": {
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "router-access-test-site",
+						Name: "test-site",
 					},
 					Spec: v2alpha1.RouterAccessSpec{
 						Roles: []v2alpha1.RouterAccessRole{

--- a/internal/nonkube/common/site_state_renderer_common_test.go
+++ b/internal/nonkube/common/site_state_renderer_common_test.go
@@ -4,7 +4,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/skupperproject/skupper/pkg/apis/skupper/v2alpha1"
+	"github.com/skupperproject/skupper/pkg/nonkube/api"
 	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCopySiteState(t *testing.T) {
@@ -47,4 +50,109 @@ func equalsButNotShallowCopy[T comparable](oldMap, newMap map[string]T) bool {
 		}
 	}
 	return true
+}
+
+func TestCreateSiteRouterAccess(t *testing.T) {
+	tests := []struct {
+		name                   string
+		linkAccess             string
+		existingRouterAccesses map[string]*v2alpha1.RouterAccess
+		isBundle               bool
+		expectRouterAccess     bool
+		expectedName           string
+	}{
+		{
+			name:                   "LinkAccess none does not create RouterAccess",
+			linkAccess:             "none",
+			existingRouterAccesses: map[string]*v2alpha1.RouterAccess{},
+			isBundle:               false,
+			expectRouterAccess:     false,
+		},
+		{
+			name:                   "Empty linkAccess does not create RouterAccess",
+			linkAccess:             "",
+			existingRouterAccesses: map[string]*v2alpha1.RouterAccess{},
+			isBundle:               false,
+			expectRouterAccess:     false,
+		},
+		{
+			name:                   "create router-access-west",
+			linkAccess:             "default",
+			existingRouterAccesses: map[string]*v2alpha1.RouterAccess{},
+			expectedName:           "router-access-test-site",
+			isBundle:               false,
+			expectRouterAccess:     true,
+		},
+		{
+			name:       "router-access-test-site already exists, not recreated",
+			linkAccess: "default",
+			existingRouterAccesses: map[string]*v2alpha1.RouterAccess{
+				"router-access-test-site": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "router-access-test-site",
+					},
+					Spec: v2alpha1.RouterAccessSpec{
+						Roles: []v2alpha1.RouterAccessRole{
+							{Name: "inter-router", Port: 99999},
+						},
+					},
+				},
+			},
+			isBundle:           false,
+			expectRouterAccess: false,
+		},
+		{
+			name:                   "Bundle mode doesn't create RouterAccess",
+			linkAccess:             "default",
+			existingRouterAccesses: map[string]*v2alpha1.RouterAccess{},
+			isBundle:               true,
+			expectRouterAccess:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ss := api.NewSiteState(tt.isBundle)
+			ss.Site = &v2alpha1.Site{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-site",
+					Namespace: "test-namespace",
+				},
+				Spec: v2alpha1.SiteSpec{
+					LinkAccess: tt.linkAccess,
+				},
+			}
+			ss.RouterAccesses = tt.existingRouterAccesses
+
+			err := EnableLinkAccess(ss)
+			assert.NilError(t, err)
+
+			if tt.expectRouterAccess {
+
+				ra, exists := ss.RouterAccesses[tt.expectedName]
+				assert.Assert(t, exists, "Expected RouterAccess to be created")
+				assert.Equal(t, tt.expectedName, ra.Name)
+
+				assert.Equal(t, 2, len(ra.Spec.Roles))
+
+				var interRouterRole, edgeRole *v2alpha1.RouterAccessRole
+				for i := range ra.Spec.Roles {
+					if ra.Spec.Roles[i].Name == "inter-router" {
+						interRouterRole = &ra.Spec.Roles[i]
+					} else if ra.Spec.Roles[i].Name == "edge" {
+						edgeRole = &ra.Spec.Roles[i]
+					}
+				}
+
+				assert.Assert(t, interRouterRole != nil, "Expected inter-router role")
+				assert.Assert(t, edgeRole != nil, "Expected edge role")
+
+				if !tt.isBundle {
+					// Non-bundle should have allocated ports
+					assert.Assert(t, interRouterRole.Port >= 55671)
+					assert.Assert(t, edgeRole.Port >= 45671)
+				}
+			}
+		})
+	}
 }

--- a/internal/nonkube/compat/site_state_renderer.go
+++ b/internal/nonkube/compat/site_state_renderer.go
@@ -124,6 +124,13 @@ func (s *SiteStateRenderer) Render(loadedSiteState *api.SiteState, reload bool) 
 	if err = common.CreateRouterAccess(s.siteState); err != nil {
 		return err
 	}
+
+	if s.siteState.Site.Spec.LinkAccess != "" && s.siteState.Site.Spec.LinkAccess != "none" {
+		if err = common.EnableLinkAccess(s.siteState); err != nil {
+			return err
+		}
+	}
+
 	s.siteState.CreateLinkAccessesCertificates()
 	s.siteState.CreateBridgeCertificates()
 	// rendering non-kube configuration files and certificates
@@ -399,6 +406,13 @@ func (s *SiteStateRenderer) Refresh(loadedSiteState *api.SiteState) error {
 	if err != nil {
 		return err
 	}
+
+	if s.siteState.Site.Spec.LinkAccess != "" && s.siteState.Site.Spec.LinkAccess != "none" {
+		if err = common.EnableLinkAccess(s.siteState); err != nil {
+			return err
+		}
+	}
+
 	s.siteState.CreateLinkAccessesCertificates()
 	s.siteState.CreateBridgeCertificates()
 

--- a/internal/nonkube/linux/site_state_renderer.go
+++ b/internal/nonkube/linux/site_state_renderer.go
@@ -82,6 +82,14 @@ func (s *SiteStateRenderer) Render(loadedSiteState *api.SiteState, reload bool) 
 	if err = common.CreateRouterAccess(s.siteState); err != nil {
 		return err
 	}
+
+	// Create Site RouterAccess if linkAccess is enabled
+	if s.siteState.Site.Spec.LinkAccess != "" && s.siteState.Site.Spec.LinkAccess != "none" {
+		if err = common.EnableLinkAccess(s.siteState); err != nil {
+			return err
+		}
+	}
+
 	s.siteState.CreateLinkAccessesCertificates()
 	s.siteState.CreateBridgeCertificates()
 	// rendering non-kube configuration files and certificates

--- a/internal/utils/access.go
+++ b/internal/utils/access.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+func GetSansByDefault() ([]string, error) {
+	sans := []string{"0.0.0.0", "::"}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+	sans = append(sans, hostname)
+
+	// Get all local IP addresses
+	addresses, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, addr := range addresses {
+
+		if ipnet, ok := addr.(*net.IPNet); ok {
+			// Add only non-loopback IPv4 and IPv6 addresses
+			if !ipnet.IP.IsLoopback() {
+				sans = append(sans, ipnet.IP.String())
+			}
+		}
+	}
+
+	return sans, nil
+}
+
+func AllocateRouterAccessPorts() (interRouterPort int, edgePort int, err error) {
+
+	defaultInterRouterPort := 55671
+	defaultEdgePort := 45671
+
+	interRouterPort, err = TcpPortNextFree(defaultInterRouterPort)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to allocate inter-router port: %w", err)
+	}
+
+	edgePort, err = TcpPortNextFree(defaultEdgePort)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to allocate edge port: %w", err)
+	}
+
+	if edgePort == interRouterPort {
+		edgePort, err = TcpPortNextFree(edgePort + 1)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to allocate alternative edge port: %w", err)
+		}
+	}
+
+	return interRouterPort, edgePort, nil
+}


### PR DESCRIPTION
Fixes #2127 

(Note: To see how the router access is created after updating a site, #2456 needs to be merged.)