### PR TITLE
Revert "Fixes HA router deployment selector overlap (#2363)"

### DIFF
--- a/internal/kube/controller/controller_test.go
+++ b/internal/kube/controller/controller_test.go
@@ -1293,7 +1293,7 @@ func (f *factory) routerDeployment(name string, namespace string) *unstructured.
 	content := map[string]interface{}{
 		"spec": map[string]interface{}{
 			"selector": map[string]interface{}{
-				"matchLabels": f.routerSelectorWithGroup(name),
+				"matchLabels": f.routerSelector(false),
 			},
 			"template": map[string]interface{}{
 				"spec": map[string]interface{}{
@@ -1418,7 +1418,7 @@ func (r *ExpectedResources) deployment(name string, namespace string) *unstructu
 	content := map[string]interface{}{
 		"spec": map[string]interface{}{
 			"selector": map[string]interface{}{
-				"matchLabels": f.routerSelectorWithGroup(name),
+				"matchLabels": f.routerSelector(false),
 			},
 			"template": map[string]interface{}{
 				"spec": map[string]interface{}{

--- a/internal/kube/site/resources/skupper-router-deployment.yaml
+++ b/internal/kube/site/resources/skupper-router-deployment.yaml
@@ -44,7 +44,6 @@ spec:
   selector:
     matchLabels:
       skupper.io/component: router
-      skupper.io/group: {{ .Group }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
This reverts commit fcb7f45fb8d18d1c6c8e8e5b4671d19a07938f6f.

Resolves https://github.com/skupperproject/skupper/issues/2440