### PR TITLE
Small test fixes and enhancements

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,7 +9,7 @@ PYTHON ?= python3
 
 # The caller may set a TEST_PREFIX, so they can deal with all namespaces created
 # by these tests with -l e2e.prefix=$TEST_PREFIX.  If not set, we create a random one
-RANDOM != echo $$RANDOM
+RANDOM := $(shell bash -c 'echo $$RANDOM')
 TEST_PREFIX ?= $(RANDOM)
 export TEST_PREFIX
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -89,6 +89,7 @@ e2e-tests:
 	@echo "Running all tests in sequence..."
 	@for test_dir in $(E2E_TEST_DIRS); do \
 		test_name=$$(basename $$test_dir); \
+		[ "$$test_name" == "expose-pods-by-name" ] && continue; \
 		echo "\n=== Running test: $$test_name ==="; \
 		$(MAKE) test TEST="$$test_name" || exit 1; \
 	done

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,9 +1,17 @@
 ROOT_PATH := $(shell pwd)
 EXTRA_VARS := --extra-vars "@$(ROOT_PATH)/vars.yml"
 COLLECTION_PATH := $(ROOT_PATH)/e2e/collections/ansible_collections/e2e/tests
+
 # Remove expose-pods-by-name from the CI tests, until we close
 # this issue https://github.com/skupperproject/skupper/issues/2251
 TESTS_CI := attached-connector,ha,hello-world,labels-and-annotations
+PYTHON ?= python3
+
+# The caller may set a TEST_PREFIX, so they can deal with all namespaces created
+# by these tests with -l e2e.prefix=$TEST_PREFIX.  If not set, we create a random one
+RANDOM != echo $$RANDOM
+TEST_PREFIX ?= $(RANDOM)
+export TEST_PREFIX
 
 # E2E Test directories
 E2E_TEST_DIRS := $(sort $(wildcard $(ROOT_PATH)/e2e/scenarios/*))
@@ -15,7 +23,7 @@ create-venv:
 		echo "Removing old environment if it exists..."; \
 		rm -rf /tmp/e2e-venv; \
 		echo "Creating virtual environment..."; \
-		cd /tmp && python3 -m venv e2e-venv; \
+		cd /tmp && $(PYTHON) -m venv e2e-venv; \
 		if [ -d "/tmp/e2e-venv" ]; then \
 			echo "Virtual environment created successfully at /tmp/e2e-venv"; \
 			. /tmp/e2e-venv/bin/activate && \
@@ -60,15 +68,16 @@ test: create-venv
 		exit 1; \
 	fi
 
-	@export TEST_PREFIX=$$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 5 | head -n 1); \
-	echo "Running the test for directory: $(TEST) with prefix: $$TEST_PREFIX"; \
+	@echo "Running the test for directory: $(TEST) with prefix: $(TEST_PREFIX)";
+
 	. /tmp/e2e-venv/bin/activate && \
 	mkdir -p /tmp/e2e/$(TEST) && \
 	ANSIBLE_LOG_PATH=/tmp/e2e/$(TEST)/ansible_$$(date +%Y%m%d_%H%M%S).log \
 	ANSIBLE_CONFIG=$(ROOT_PATH)/e2e/ansible.cfg \
 	ansible-playbook $(ROOT_PATH)/e2e/scenarios/$(TEST)/test.yml \
 	-i $(ROOT_PATH)/e2e/scenarios/$(TEST)/inventory $(EXTRA_VARS) \
-	-e namespace_prefix=$$TEST_PREFIX -e test_name=$$TEST; \
+	$(OPTIONS) \
+	-e namespace_prefix=$(TEST_PREFIX) -e test_name=$$TEST; \
 	EXIT_CODE=$$?; \
 	if [ $$EXIT_CODE -ne 0 ]; then \
 		echo "Test $(TEST) failed with exit code $$EXIT_CODE"; \

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,7 +19,7 @@ Note: If you are running the tests from the Makefile, this is not needed, as the
 
 ```
 tests/
-├── e2e/  
+├── e2e/
 ├── scenarios/                 # End-to-end tests directory
 │    ├── hello-world/          # Basic Skupper functionality test
 │    ├── attached-connector/   # Network performance test with attached connectors
@@ -163,6 +163,25 @@ make test-subset TESTS="test1,test2"
 # Run CI tests
 make ci-tests
 ```
+
+3. **Make variables**
+
+The following `make` variables are available:
+
+* `OPTIONS` will provide additional options to the `ansible-playbook` invocation.
+
+  `make e2e-tests OPTIONS="-v"`
+
+* `PYTHON` allows the `venv` to be created with a specific Python binary
+
+  `make create-venv PYTHON=python3.12`
+
+* `TEST_PREFIX` allows one to select a prefix to be added to the name of the tests' namespaces:
+
+  `make e2e-tests TEST_PREFIX=123`
+
+  By default, a random prefix is generated for each run.  The namespaces can be selected on Kubernetes
+  with the label `e2e.prefix`, allowing for easy removal of failed tests, for example.
 
 ### Example summary
 

--- a/tests/e2e/collections/ansible_collections/e2e/tests/roles/generate_namespaces/tasks/main.yml
+++ b/tests/e2e/collections/ansible_collections/e2e/tests/roles/generate_namespaces/tasks/main.yml
@@ -10,6 +10,7 @@
         name: "{{ namespace_prefix }}-{{ namespace_name }}"
         labels:
           e2e.id: "{{ generate_namespaces_namespace_label }}"
+          e2e.prefix: "{{ namespace_prefix }}"
     kubeconfig: "{{ kubeconfig }}"
   register: namespace_result
 

--- a/tests/e2e/scenarios/hello-world/test.yml
+++ b/tests/e2e/scenarios/hello-world/test.yml
@@ -17,11 +17,15 @@
           include_tasks: skupper-sites.yml
           vars:
             site_name: west
+          when:
+            - "'west' in inventory_hostname"
 
         - name: Create Skupper resources for east site
           include_tasks: skupper-sites.yml
           vars:
             site_name: east
+          when:
+            - "'east' in inventory_hostname"
 
         - name: Issue a Skupper access token from west namespace
           skupper.v2.token:

--- a/tests/e2e/scenarios/redis/README.md
+++ b/tests/e2e/scenarios/redis/README.md
@@ -100,10 +100,10 @@ kubeconfig: "{{ kubeconfig_1 }}"
 namespace_name: redis-west
 
 # West CRs
-site: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/west-crs/site-west.yaml"
-connector: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/west-crs/connector-west.yaml"
-listener: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/west-crs/listener-west.yaml"
-redis: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/west-crs/redis-west.yaml"
+site: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/west-crs/site-west.yaml"
+connector: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/west-crs/connector-west.yaml"
+listener: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/west-crs/listener-west.yaml"
+redis: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/west-crs/redis-west.yaml"
 ```
 
 #### East Cluster (host_vars/east.yml)
@@ -117,10 +117,10 @@ kubeconfig: "{{ kubeconfig_2 }}"
 namespace_name: redis-east
 
 # East CRs
-site: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/east-crs/site-east.yaml"
-connector: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/east-crs/connector-east.yaml"
-listener: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/east-crs/listener-east.yaml"
-redis: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/east-crs/redis-east.yaml"
+site: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/east-crs/site-east.yaml"
+connector: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/east-crs/connector-east.yaml"
+listener: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/east-crs/listener-east.yaml"
+redis: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/east-crs/redis-east.yaml"
 ```
 
 #### North Cluster (host_vars/north.yml)
@@ -134,10 +134,10 @@ kubeconfig: "{{ kubeconfig_3 }}"
 namespace_name: redis-north
 
 # North CRs
-site: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/north-crs/site-north.yaml"
-connector: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/north-crs/connector-north.yaml"
-listener: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/north-crs/listener-north.yaml"
-redis: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/north-crs/redis-north.yaml"
+site: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/north-crs/site-north.yaml"
+connector: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/north-crs/connector-north.yaml"
+listener: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/north-crs/listener-north.yaml"
+redis: "https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/north-crs/redis-north.yaml"
 ```
 
 ### Other Key Variables

--- a/tests/e2e/scenarios/redis/test.yml
+++ b/tests/e2e/scenarios/redis/test.yml
@@ -88,8 +88,8 @@
                 path: "{{ item }}"
                 platform: podman
               with_items:
-                - https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/podman-crs/listener-podman.yaml
-                - https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/podman-crs/site-podman.yaml
+                - https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/podman-crs/listener-podman.yaml
+                - https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/podman-crs/site-podman.yaml
 
             - name: "[ {{ test_identifier }} ] - Apply token to podman site"
               skupper.v2.resource:


### PR DESCRIPTION
Mostly cherry-picks from #2266 (2.1)

-	Ability to select python binary
-	Fix for test-prefix generation (was failing on Jenkins)
-	hello-world fix: do not duplicate workloads
-	Addition of OPTIONS to the Makefile
-	Label e2e.prefix added to namespaces
-	Add "Make variables" on README

Not cherry-picks:

-	Redis: s_/v2/_/main/_g: test was pointing to no longer existing branch
-	Skip expose-pods-by-name test due to #2251
