### PR TITLE
Collect pod resource usage and cgroup metrics in must-gather

### DIFF
--- a/internal/cmd/skupper/token/kube/token_issue.go
+++ b/internal/cmd/skupper/token/kube/token_issue.go
@@ -101,6 +101,12 @@ func (cmd *CmdTokenIssue) ValidateInput(args []string) error {
 		if !ok {
 			validationErrors = append(validationErrors, fmt.Errorf("there is no active skupper site in this namespace"))
 		} else {
+			for _, site := range siteList.Items {
+				if site.IsReady() && site.Spec.Edge {
+					validationErrors = append(validationErrors, fmt.Errorf("Edge sites cannot accept incoming links from remote sites"))
+					return errors.Join(validationErrors...)
+				}
+			}
 			ok, siteName = utils.SiteLinkAccessEndpoints(siteList)
 			if !ok {
 				validationErrors = append(validationErrors, fmt.Errorf("You must enable link access for this site before you can create a token."))

--- a/internal/cmd/skupper/token/kube/token_issue_test.go
+++ b/internal/cmd/skupper/token/kube/token_issue_test.go
@@ -721,6 +721,59 @@ func TestCmdTokenIssue_ValidateInput(t *testing.T) {
 			expectedError: `You must enable link access for this site before you can create a token.`,
 		},
 		{
+			name: "edge site cannot create token",
+			args: []string{"/tmp/token.yaml"},
+			flags: common.CommandTokenIssueFlags{
+				ExpirationWindow:   15 * time.Minute,
+				RedemptionsAllowed: 1,
+				Timeout:            60 * time.Second,
+				Cost:               "1",
+			},
+			skupperObjects: []runtime.Object{
+				&v2alpha1.SiteList{
+					Items: []v2alpha1.Site{
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name:      "site1",
+								Namespace: "test",
+							},
+							Spec: v2alpha1.SiteSpec{
+								LinkAccess: "default",
+								Edge:       true,
+							},
+							Status: v2alpha1.SiteStatus{
+								Status: v2alpha1.Status{
+									Conditions: []v1.Condition{
+										{
+											Type:   "Configured",
+											Status: "True",
+										},
+										{
+											Type:   "Running",
+											Status: "True",
+										},
+										{
+											Type:   "Ready",
+											Status: "True",
+										},
+									},
+								},
+								Endpoints: []v2alpha1.Endpoint{
+									{
+										Name:  "inter-router",
+										Host:  "127.0.0.1",
+										Port:  "8080",
+										Group: "skupper-router-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: "Edge sites cannot accept incoming links from remote sites",
+		},
+		{
 			name: "flags all valid",
 			args: []string{"/tmp/token.yaml"},
 			flags: common.CommandTokenIssueFlags{

--- a/internal/kube/grants/grant_test.go
+++ b/internal/kube/grants/grant_test.go
@@ -434,6 +434,16 @@ func Test_checkGrant(t *testing.T) {
 			UID:       "0bde3bc8-a4a2-404a-bfbe-44fdf7bf3231",
 		},
 	}
+	edgeSiteGrant := &v2alpha1.AccessGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "edge",
+			Namespace: "test",
+			UID:       "0bde3bc8-a4a2-404a-bfbe-44fdf7bf3232",
+		},
+		Spec: v2alpha1.AccessGrantSpec{
+			RedemptionsAllowed: 1,
+		},
+	}
 	badExpirationWindow := &v2alpha1.AccessGrant{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bad-expiration",
@@ -447,7 +457,27 @@ func Test_checkGrant(t *testing.T) {
 
 	skupperObjects := []runtime.Object{
 		good,
+		edgeSiteGrant,
 		badExpirationWindow,
+		&v2alpha1.Site{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "site1",
+				Namespace: "test",
+			},
+			Spec: v2alpha1.SiteSpec{
+				Edge: true,
+			},
+			Status: v2alpha1.SiteStatus{
+				Status: v2alpha1.Status{
+					Conditions: []metav1.Condition{
+						{
+							Type:   v2alpha1.CONDITION_TYPE_READY,
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
 	}
 	var tests = []struct {
 		name  string
@@ -459,6 +489,15 @@ func Test_checkGrant(t *testing.T) {
 				{
 					key:   good.Namespace + "/" + good.Name,
 					grant: good,
+				},
+			},
+		},
+		{
+			name: "edge site blocked",
+			calls: []CheckGrantTestInvocation{
+				{
+					key:   edgeSiteGrant.Namespace + "/" + edgeSiteGrant.Name,
+					grant: edgeSiteGrant,
 				},
 			},
 		},
@@ -608,6 +647,12 @@ func Test_checkGrant(t *testing.T) {
 				if call.recheckCa != "" {
 					registry.setCA(call.recheckCa)
 					registry.recheckCa()
+				}
+				if tt.name == "edge site blocked" {
+					latest, err := client.GetSkupperClient().SkupperV2alpha1().AccessGrants(call.grant.Namespace).Get(context.TODO(), call.grant.Name, metav1.GetOptions{})
+					assert.Assert(t, err)
+					assert.Equal(t, latest.Status.Message, "Edge sites cannot accept incoming links from remote sites")
+					assert.Assert(t, !latest.IsReady())
 				}
 			}
 		})

--- a/internal/kube/grants/grants.go
+++ b/internal/kube/grants/grants.go
@@ -198,6 +198,16 @@ func (g *Grants) checkGrant(key string, grant *skupperv2alpha1.AccessGrant) erro
 	g.record(key, grant)
 	changed := false
 	var status []string
+
+	if sites, err := g.clients.GetSkupperClient().SkupperV2alpha1().Sites(grant.Namespace).List(context.TODO(), metav1.ListOptions{}); err == nil && sites != nil {
+		for _, site := range sites.Items {
+			if site.IsReady() && site.Spec.Edge {
+				status = append(status, "Edge sites cannot accept incoming links from remote sites")
+				break
+			}
+		}
+	}
+
 	if g.checkUrl(key, grant) {
 		changed = true
 	}

--- a/internal/kube/grants/redeem_test.go
+++ b/internal/kube/grants/redeem_test.go
@@ -380,7 +380,7 @@ func Test_RedeemAccessToken(t *testing.T) {
 			name:           "no resolved endpoints",
 			scheme:         "https",
 			tokenName:      "my-token",
-			expectedStatus: "Controller got failed response: 500 (Internal Server Error) Could not resolve any endpoints for requested link",
+			expectedStatus: "Controller got failed response: 500 (Internal Server Error) No valid endpoints found for site",
 		},
 		{
 			name:           "bad default issuer",

--- a/internal/kube/grants/tokens.go
+++ b/internal/kube/grants/tokens.go
@@ -52,9 +52,9 @@ func NewTokenGenerator(site *skupperv2alpha1.Site, clients internalclient.Client
 			slog.Any("error", err))
 		return nil, errors.New("Could not get issuer for requested certificate")
 	}
-	if ok := generator.setValidHostsFromSite(site); !ok {
+	if err := generator.setValidHostsFromSite(site); err != nil {
 		generator.logger.Error("Could not resolve any target endpoints for site", slog.String("namespace", site.Namespace), slog.String("name", site.Name))
-		return nil, errors.New("Could not resolve any endpoints for requested link")
+		return nil, err
 	}
 	return generator, nil
 }
@@ -68,15 +68,16 @@ func (g *TokenGenerator) loadCA(name string) error {
 	return nil
 }
 
-func (g *TokenGenerator) setValidHostsFromSite(site *skupperv2alpha1.Site) bool {
-	//TODO: if site is edge site, then return an error as it
-	//cannot issue certificates
+func (g *TokenGenerator) setValidHostsFromSite(site *skupperv2alpha1.Site) error {
+	if site.Spec.Edge {
+		return errors.New("Edge sites cannot accept incoming links from remote sites")
+	}
 	var hosts []string
 	for _, endpoint := range site.Status.Endpoints {
 		hosts = append(hosts, endpoint.Host)
 	}
 	if len(hosts) == 0 {
-		return false
+		return errors.New("No valid endpoints found for site")
 	}
 	byGroup := map[string][]skupperv2alpha1.Endpoint{}
 	//TODO: should only include groups that are valid for the defined issuer
@@ -90,7 +91,7 @@ func (g *TokenGenerator) setValidHostsFromSite(site *skupperv2alpha1.Site) bool 
 	}
 	g.logger.Info("Endpoints for grant by group", slog.Any("endpoints", g.endpoints), slog.Any("byGroup", byGroup))
 	g.hosts = hosts
-	return true
+	return nil
 }
 
 func (g *TokenGenerator) NewCertToken(name string, subject string) (Token, error) {

--- a/internal/kube/grants/tokens_test.go
+++ b/internal/kube/grants/tokens_test.go
@@ -5,9 +5,10 @@ import (
 	"io"
 	"testing"
 
-	"gotest.tools/v3/assert"
-
+	"github.com/skupperproject/skupper/internal/kube/client/fake"
 	"github.com/skupperproject/skupper/pkg/apis/skupper/v2alpha1"
+	"gotest.tools/v3/assert"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func Test_CertTokenWrite(t *testing.T) {
@@ -90,4 +91,51 @@ func Test_CertTokenWrite(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_NewTokenGenerator(t *testing.T) {
+	site := tf.site("my-site", "test")
+	site.Status.Endpoints = []v2alpha1.Endpoint{
+		{
+			Name:  "inter-router",
+			Host:  "my-host",
+			Port:  "55671",
+			Group: "default",
+		},
+	}
+	caSecret, err := tf.secret("skupper-site-ca", "test", "site-ca", nil)
+	assert.Assert(t, err == nil)
+	client, err := fake.NewFakeClient("test", []runtime.Object{caSecret}, nil, "")
+	assert.Assert(t, err == nil)
+
+	t.Run("Working Site", func(t *testing.T) {
+		site.Spec.Edge = false
+		generator, err := NewTokenGenerator(site, client)
+		assert.Assert(t, err == nil)
+		assert.Assert(t, generator != nil)
+	})
+
+	t.Run("Edge Site Fail", func(t *testing.T) {
+		site.Spec.Edge = true
+		generator, err := NewTokenGenerator(site, client)
+		assert.ErrorContains(t, err, "Edge sites cannot accept incoming links from remote sites")
+		assert.Assert(t, generator == nil)
+	})
+
+	t.Run("No Endpoints Fail", func(t *testing.T) {
+		site.Spec.Edge = false
+		site.Status.Endpoints = nil
+		generator, err := NewTokenGenerator(site, client)
+		assert.ErrorContains(t, err, "No valid endpoints found for site")
+		assert.Assert(t, generator == nil)
+	})
+
+	t.Run("Missing CA", func(t *testing.T) {
+		emptyClient, err := fake.NewFakeClient("test", nil, nil, "")
+		site.Spec.Edge = false
+		site.Status.Endpoints = []v2alpha1.Endpoint{{Host: "foo", Name: "inter-router"}}
+		generator, err := NewTokenGenerator(site, emptyClient)
+		assert.ErrorContains(t, err, "Could not get issuer for requested certificate")
+		assert.Assert(t, generator == nil)
+	})
 }

--- a/scripts/skupper-gather.sh
+++ b/scripts/skupper-gather.sh
@@ -16,6 +16,95 @@ get_log_collection_args() {
   fi
 }
 
+function getPodResources() {
+  local ns="${1}"
+  local podName="${2}"
+  local container="${3}"
+  local podDirName="${podName##"pod/"}"
+
+  local resourcePath=${BASE_COLLECTION_PATH}/namespaces/${ns}/pods/${podDirName}/${container}/${container}/resources
+  mkdir -p "${resourcePath}"
+
+  echo "Collecting resource usage for pod ${podName} in ${ns}"
+
+  # Memory Info
+  oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c '
+    curr=$(cat /sys/fs/cgroup/memory.current)
+    max=$(cat /sys/fs/cgroup/memory.max)
+    curr_kb=$((curr / 1024))
+    curr_mb=$((curr / 1024 / 1024))
+
+    if [ "$max" = "max" ]; then
+      limit_str="max (uncapped)"
+    else
+      max_kb=$((max / 1024))
+      max_mb=$((max / 1024 / 1024))
+      limit_str="$max bytes ($max_kb KiB / $max_mb MiB)"
+    fi
+
+    echo "Usage: $curr bytes ($curr_kb KiB / $curr_mb MiB) - Limit: $limit_str" > /tmp/memory.info
+  ' 2>/dev/null
+  oc exec -n "${ns}" "${podName}" -c "${container}" -- cat /tmp/memory.info > "${resourcePath}/memory.info" 2>&1
+
+  # Memory pressure
+oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c '
+    if [ -f /sys/fs/cgroup/memory.pressure ]; then
+      cat /sys/fs/cgroup/memory.pressure
+    else
+      echo "PSI not available on this node (kernel psi=1 not enabled)"
+    fi
+' > "${resourcePath}/memory.pressure" 2>&1
+
+
+  # Out of Memory events
+  oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c '
+    if [ -f /sys/fs/cgroup/memory.events ]; then
+      echo "=== memory.events (cgroup v2) ===" 
+      cat /sys/fs/cgroup/memory.events
+    fi
+    if [ -f /sys/fs/cgroup/memory.oom_control ]; then
+      echo "=== memory.oom_control (cgroup v1) ==="
+      cat /sys/fs/cgroup/memory.oom_control
+    fi
+  ' > "${resourcePath}/memory.oom" 2>&1
+
+  # CPU usage
+  oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c "
+    cat /sys/fs/cgroup/cpu.stat | while read line; do
+      val=\$(echo \$line | awk '{print \$2}')
+      key=\$(echo \$line | awk '{print \$1}')
+      if [[ \$key == *_usec ]] && [ \$val -ge 1000000 ]; then
+        sec=\$(awk \"BEGIN {printf \\\"%.2f\\\", \$val/1000000}\")
+        echo \"\$line (\$sec s)\"
+      else
+        echo \"\$line\"
+      fi
+    done
+  " > "${resourcePath}/cpu.stat" 2>&1
+
+  # CPU limit
+  oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c '
+    cpu_max=$(cat /sys/fs/cgroup/cpu.max)
+    quota=$(echo $cpu_max | awk "{print \$1}")
+    period=$(echo $cpu_max | awk "{print \$2}")
+    if [ "$quota" = "max" ]; then
+      echo "CPU Limit: uncapped (no quota set)"
+    else
+      cores=$(awk "BEGIN {printf \"%.2f\", $quota/$period}")
+      echo "CPU Limit: $quota/$period us = $cores cores"
+    fi
+  ' > "${resourcePath}/cpu.max" 2>&1
+
+  # CPU pressure
+oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c '
+  if [ -f /sys/fs/cgroup/cpu.pressure ]; then
+    cat /sys/fs/cgroup/cpu.pressure
+  else
+    echo "PSI not available on this node (kernel psi=1 not enabled)"
+  fi
+' > "${resourcePath}/cpu.pressure" 2>&1
+}
+
 function getSkupperRouterSkstatInNamespace() {
   local routerNamespace="${1}"
   local flags=("g" "c" "l" "n" "e" "a" "m" "p")
@@ -28,6 +117,7 @@ function getSkupperRouterSkstatInNamespace() {
     for flag in "${flags[@]}"; do
       oc exec -n "${sitens}" "${routerName}" -c router -- skstat -"${flag}" > "${logPath}/skstat.${flag}" 2>&1
     done
+    getPodResources "${sitens}" "${routerName}" "router"
   done 
 }
 


### PR DESCRIPTION
Must gather script can now collect memory and CPU usage via container exec and also captures cgroup limits, requests, and throttling stats. 
Outputs the info to  "must-gather/namespaces/"namespace"/pods/"pod-name"/"container-name"/"container-name"/resources/". Creates files to track what each does

1. memory.info: Tracks current memory usage and shows the memory limit.
2. cpu.stat: Provides CPU stats on total usage time, user/syxstem breakdown, and nr_throttled which shows performance bottlenecks.
<img width="968" height="227" alt="Screenshot 2026-06-10 at 1 54 43 PM" src="https://github.com/user-attachments/assets/22295ac3-58af-4703-a358-c056f2be4694" />
3. cpu.max: maximum amount of CPU processing power allotted.

4. last.terminated: Provides an error message on why the previous container crashed if applicable. Helpful for identifying errors like Out of memory.

5. memory.pressure / cpu.pressure: Tracks how much time the pod spends waiting for CPU or memory to become available. This helps identify if the pod is slowing down because the node is too busy.