### PR TITLE
Collect pod resource usage and cgroup metrics in must-gather

### DIFF
--- a/scripts/skupper-gather.sh
+++ b/scripts/skupper-gather.sh
@@ -34,8 +34,14 @@ fi
 echo "===memory.info==="
 curr=$(cat "$d/memory.current" 2>/dev/null)
 max=$(cat "$d/memory.max" 2>/dev/null)
-curr_kb=$((${curr:-0} / 1024))
-curr_mb=$((${curr:-0} / 1024 / 1024))
+
+if [ -z "$curr" ]; then
+  usage_str="unknown (memory.current missing - cgroup v1?)"
+else
+  curr_kb=$((curr / 1024))
+  curr_mb=$((curr / 1024 / 1024))
+  usage_str="$curr bytes ($curr_kb KiB / $curr_mb MiB)"
+fi
 
 if [ -z "$max" ]; then
   limit_str="unknown (memory.max missing - cgroup v1?)"
@@ -47,7 +53,7 @@ else
   limit_str="$max bytes ($max_kb KiB / $max_mb MiB)"
 fi
 
-echo "Usage: $curr bytes ($curr_kb KiB / $curr_mb MiB) - Limit: $limit_str"
+echo "Usage: $usage_str - Limit: $limit_str"
 
 echo "===memory.pressure==="
 if [ -f "$d/memory.pressure" ]; then
@@ -79,8 +85,10 @@ while read -r key val; do
 done < "$d/cpu.stat"
 
 echo "===cpu.max==="
-read -r quota period < "$d/cpu.max"
-if [ "$quota" = "max" ]; then
+read -r quota period < "$d/cpu.max" 2>/dev/null
+if [ -z "$quota" ] || [ -z "$period" ]; then
+  echo "CPU Limit: unknown (cpu.max missing - cgroup v1?)"
+elif [ "$quota" = "max" ]; then
   echo "CPU Limit: uncapped (no quota set)"
 else
   cores=$(awk "BEGIN {printf \"%.2f\", $quota/$period}")

--- a/scripts/skupper-gather.sh
+++ b/scripts/skupper-gather.sh
@@ -32,12 +32,14 @@ else
 fi
 
 echo "===memory.info==="
-curr=$(cat "$d/memory.current")
-max=$(cat "$d/memory.max")
-curr_kb=$((curr / 1024))
-curr_mb=$((curr / 1024 / 1024))
+curr=$(cat "$d/memory.current" 2>/dev/null)
+max=$(cat "$d/memory.max" 2>/dev/null)
+curr_kb=$((${curr:-0} / 1024))
+curr_mb=$((${curr:-0} / 1024 / 1024))
 
-if [ "$max" = "max" ]; then
+if [ -z "$max" ]; then
+  limit_str="unknown (memory.max missing - cgroup v1?)"
+elif [ "$max" = "max" ]; then
   limit_str="max (uncapped)"
 else
   max_kb=$((max / 1024))

--- a/scripts/skupper-gather.sh
+++ b/scripts/skupper-gather.sh
@@ -124,8 +124,17 @@ function getSkupperRouterSkstatInNamespace() {
     for flag in "${flags[@]}"; do
       oc exec -n "${sitens}" "${routerName}" -c router -- skstat -"${flag}" > "${logPath}/skstat.${flag}" 2>&1
     done
-    getPodResources "${sitens}" "${routerName}" "router"
-  done 
+  done
+}
+
+function getSkupperResourcesInNamespace() {
+  local ns="${1}"
+
+  for podName in $(oc get pods -n "${ns}" -l app.kubernetes.io/part-of=skupper -oname); do
+    for container in $(oc get "${podName}" -n "${ns}" -o jsonpath='{.spec.containers[*].name}'); do
+      getPodResources "${ns}" "${podName}" "${container}"
+    done
+  done
 }
 
 function getCRDs() {
@@ -210,12 +219,14 @@ function main() {
     inspectNamespace "${sitens}"
 
     getSkupperRouterSkstatInNamespace "${sitens}"
+    getSkupperResourcesInNamespace "${sitens}"
   done
 
   # iterate over all namespaces which have AttachedConnectors
   for acns in $(oc get attachedconnector -A -o=jsonpath="{.items[*].metadata.namespace}"); do
     echo "Inspecting AttachedConnector in ${acns} namespace"
     inspectNamespace "${acns}"
+    getSkupperResourcesInNamespace "${acns}"
   done
 
   echo

--- a/scripts/skupper-gather.sh
+++ b/scripts/skupper-gather.sh
@@ -16,6 +16,83 @@ get_log_collection_args() {
   fi
 }
 
+# Collects cgroup v2 memory/CPU metrics as "===<filename>===" delimited sections.
+# CONTAINER_ID set: run on the node (oc debug), find the container's cgroup on the host.
+# CONTAINER_ID empty: run in the container, read /sys/fs/cgroup directly.
+read -r -d '' CGROUP_COLLECT_SCRIPT <<'COLLECT_EOF'
+if [ -n "${CONTAINER_ID}" ]; then
+  d=$(find /sys/fs/cgroup -type d -name "*${CONTAINER_ID}*" 2>/dev/null | head -1)
+  if [ -z "$d" ]; then
+    echo "===memory.info==="
+    echo "cgroup directory not found on node for container ${CONTAINER_ID}"
+    exit 0
+  fi
+else
+  d=/sys/fs/cgroup
+fi
+
+echo "===memory.info==="
+curr=$(cat "$d/memory.current")
+max=$(cat "$d/memory.max")
+curr_kb=$((curr / 1024))
+curr_mb=$((curr / 1024 / 1024))
+
+if [ "$max" = "max" ]; then
+  limit_str="max (uncapped)"
+else
+  max_kb=$((max / 1024))
+  max_mb=$((max / 1024 / 1024))
+  limit_str="$max bytes ($max_kb KiB / $max_mb MiB)"
+fi
+
+echo "Usage: $curr bytes ($curr_kb KiB / $curr_mb MiB) - Limit: $limit_str"
+
+echo "===memory.pressure==="
+if [ -f "$d/memory.pressure" ]; then
+  cat "$d/memory.pressure"
+else
+  echo "PSI not available on this node (kernel psi=1 not enabled)"
+fi
+
+echo "===cpu.stat==="
+while read -r key val; do
+  case "$key" in
+    usage_usec) desc='Total CPU time consumed (user + system)' ;;
+    user_usec) desc='Time spent in user-space (app logic)' ;;
+    system_usec) desc='Time spent in kernel-space (syscalls, I/O)' ;;
+    core_sched.force_idle_usec) desc='Time CPU forced idle for security (cross-HT side-channel protection)' ;;
+    nr_periods) desc='Number of CPU quota enforcement periods (0 = no quota set)' ;;
+    nr_throttled) desc='Times the container was throttled for exceeding CPU quota' ;;
+    throttled_usec) desc='Total time spent throttled/waiting for CPU quota' ;;
+    nr_bursts) desc='Times container used burst CPU capacity beyond quota' ;;
+    burst_usec) desc='Total time spent using burst CPU capacity' ;;
+    *) desc='' ;;
+  esac
+  if [[ $key == *_usec ]] && [ "$val" -ge 1000000 ]; then
+    sec=$(awk "BEGIN {printf \"%.2f\", $val/1000000}")
+    echo "$key $val ($sec s) | $desc"
+  else
+    echo "$key $val | $desc"
+  fi
+done < "$d/cpu.stat"
+
+echo "===cpu.max==="
+read -r quota period < "$d/cpu.max"
+if [ "$quota" = "max" ]; then
+  echo "CPU Limit: uncapped (no quota set)"
+else
+  cores=$(awk "BEGIN {printf \"%.2f\", $quota/$period}")
+  echo "CPU Limit: $quota/$period us = $cores cores"
+fi
+
+echo "===cpu.pressure==="
+if [ -f "$d/cpu.pressure" ]; then
+  cat "$d/cpu.pressure"
+else
+  echo "PSI not available on this node (kernel psi=1 not enabled)"
+fi
+COLLECT_EOF
+
 function getPodResources() {
   local ns="${1}"
   local podName="${2}"
@@ -27,89 +104,38 @@ function getPodResources() {
 
   echo "Collecting resource usage for pod ${podName} in ${ns}"
 
-  # Memory Info
-  oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c '
-    curr=$(cat /sys/fs/cgroup/memory.current)
-    max=$(cat /sys/fs/cgroup/memory.max)
-    curr_kb=$((curr / 1024))
-    curr_mb=$((curr / 1024 / 1024))
-
-    if [ "$max" = "max" ]; then
-      limit_str="max (uncapped)"
-    else
-      max_kb=$((max / 1024))
-      max_mb=$((max / 1024 / 1024))
-      limit_str="$max bytes ($max_kb KiB / $max_mb MiB)"
-    fi
-
-    echo "Usage: $curr bytes ($curr_kb KiB / $curr_mb MiB) - Limit: $limit_str" > /tmp/memory.info
-  ' 2>/dev/null
-  oc exec -n "${ns}" "${podName}" -c "${container}" -- cat /tmp/memory.info > "${resourcePath}/memory.info" 2>&1
-
-# Get previous container termination info
-oc get pod "${podName##"pod/"}" -n "${ns}" -o jsonpath="{.status.containerStatuses[?(@.name=='${container}')].lastState}" > "${resourcePath}/last.terminated" 2>/dev/null
-if [ ! -s "${resourcePath}/last.terminated" ]; then
-  echo "No previous termination recorded" > "${resourcePath}/last.terminated"
-fi
-
-  # Memory pressure
-oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c '
-    if [ -f /sys/fs/cgroup/memory.pressure ]; then
-      cat /sys/fs/cgroup/memory.pressure
-    else
-      echo "PSI not available on this node (kernel psi=1 not enabled)"
-    fi
-' > "${resourcePath}/memory.pressure" 2>&1
-
-# CPU usage
-oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c "
-  declare -A cpu_descriptions
-  cpu_descriptions=(
-    [usage_usec]='Total CPU time consumed (user + system)'
-    [user_usec]='Time spent in user-space (app logic)'
-    [system_usec]='Time spent in kernel-space (syscalls, I/O)'
-    [core_sched.force_idle_usec]='Time CPU forced idle for security (cross-HT side-channel protection)'
-    [nr_periods]='Number of CPU quota enforcement periods (0 = no quota set)'
-    [nr_throttled]='Times the container was throttled for exceeding CPU quota'
-    [throttled_usec]='Total time spent throttled/waiting for CPU quota'
-    [nr_bursts]='Times container used burst CPU capacity beyond quota'
-    [burst_usec]='Total time spent using burst CPU capacity'
-  )
-
-  cat /sys/fs/cgroup/cpu.stat | while read line; do
-    val=\$(echo \$line | awk '{print \$2}')
-    key=\$(echo \$line | awk '{print \$1}')
-    desc=\${cpu_descriptions[\$key]}
-    if [[ \$key == *_usec ]] && [ \$val -ge 1000000 ]; then
-      sec=\$(awk \"BEGIN {printf \\\"%.2f\\\", \$val/1000000}\")
-      echo \"\$line (\$sec s) | \$desc\"
-    else
-      echo \"\$line | \$desc\"
-    fi
-  done
-" > "${resourcePath}/cpu.stat" 2>&1
-
-  # CPU limit
-  oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c '
-    cpu_max=$(cat /sys/fs/cgroup/cpu.max)
-    quota=$(echo $cpu_max | awk "{print \$1}")
-    period=$(echo $cpu_max | awk "{print \$2}")
-    if [ "$quota" = "max" ]; then
-      echo "CPU Limit: uncapped (no quota set)"
-    else
-      cores=$(awk "BEGIN {printf \"%.2f\", $quota/$period}")
-      echo "CPU Limit: $quota/$period us = $cores cores"
-    fi
-  ' > "${resourcePath}/cpu.max" 2>&1
-
-  # CPU pressure
-oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c '
-  if [ -f /sys/fs/cgroup/cpu.pressure ]; then
-    cat /sys/fs/cgroup/cpu.pressure
-  else
-    echo "PSI not available on this node (kernel psi=1 not enabled)"
+  # Get previous container termination info
+  oc get pod "${podDirName}" -n "${ns}" -o jsonpath="{.status.containerStatuses[?(@.name=='${container}')].lastState}" > "${resourcePath}/last.terminated" 2>/dev/null
+  # jsonpath emits "{}" (not an empty file) when the container has no previous
+  # termination, so treat that as "nothing recorded" too.
+  if [ ! -s "${resourcePath}/last.terminated" ] || [ "$(cat "${resourcePath}/last.terminated")" = "{}" ]; then
+    echo "No previous termination recorded" > "${resourcePath}/last.terminated"
   fi
-' > "${resourcePath}/cpu.pressure" 2>&1
+
+  # Collect cgroup metrics: exec into the container when it has bash,
+  # otherwise (scratch-based images) read the container's cgroup from the
+  # node via oc debug.
+  local output
+  if oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c 'true' >/dev/null 2>&1; then
+    output=$(oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c "CONTAINER_ID='' ; ${CGROUP_COLLECT_SCRIPT}" 2>&1)
+  else
+    echo "  bash not available in container ${container} (scratch image), using oc debug node"
+    local nodeName containerID
+    nodeName=$(oc get pod "${podDirName}" -n "${ns}" -o jsonpath='{.spec.nodeName}' 2>/dev/null)
+    containerID=$(oc get pod "${podDirName}" -n "${ns}" -o jsonpath="{.status.containerStatuses[?(@.name=='${container}')].containerID}" 2>/dev/null)
+    containerID="${containerID##*://}"
+    if [ -z "${nodeName}" ] || [ -z "${containerID}" ]; then
+      echo "Unable to determine node or container ID for ${podName}/${container}" > "${resourcePath}/memory.info"
+      return
+    fi
+    output=$(oc debug "node/${nodeName}" -q -- chroot /host bash -c "CONTAINER_ID='${containerID}' ; ${CGROUP_COLLECT_SCRIPT}" 2>&1)
+  fi
+
+  # Split the delimited sections into individual files
+  echo "${output}" | awk -v dir="${resourcePath}" '
+    /^===[a-z.]+===$/ { f = dir "/" substr($0, 4, length($0) - 6); next }
+    f { print > f }
+  '
 }
 
 function getSkupperRouterSkstatInNamespace() {
@@ -117,7 +143,7 @@ function getSkupperRouterSkstatInNamespace() {
   local flags=("g" "c" "l" "n" "e" "a" "m" "p")
   prefix="pod/"
 
-  for routerName in $(oc get pods -n "${sitens}" -l app.kubernetes.io/name=skupper-router -oname); do 
+  for routerName in $(oc get pods -n "${sitens}" -l app.kubernetes.io/name=skupper-router -oname); do
     echo "Collecting skstats for pod ${routerName}.${routerNamespace}"
     local logPath=${BASE_COLLECTION_PATH}/namespaces/${sitens}/pods/${routerName##"$prefix"}/router/router/skstat
     mkdir -p "${logPath}"
@@ -136,6 +162,7 @@ function getSkupperResourcesInNamespace() {
     done
   done
 }
+
 
 function getCRDs() {
   local result=()

--- a/scripts/skupper-gather.sh
+++ b/scripts/skupper-gather.sh
@@ -235,12 +235,13 @@ function main() {
   # set global variable which is used when calling 'oc adm inspect'
   get_log_collection_args
 
-  # note: does not account for ns scoped controller
-  controllerNamespace=$(oc get pods --all-namespaces -l app.kubernetes.io/name=skupper-controller -o jsonpath="{.items[0].metadata.namespace}")
-  # this gets also logs for all pods in that namespace
-  inspect "ns/$controllerNamespace"
-  # collect resource utilization for the skupper-controller pod itself
-  getSkupperResourcesInNamespace "${controllerNamespace}" "app.kubernetes.io/name=skupper-controller"
+  # gather from every namespace that runs a controller pod.
+  for controllerNamespace in $(oc get pods --all-namespaces -l app.kubernetes.io/name=skupper-controller -o jsonpath="{.items[*].metadata.namespace}" | tr ' ' '\n' | sort -u); do
+    echo "Inspecting Skupper controller in ${controllerNamespace} namespace"
+    inspect "ns/$controllerNamespace"
+    # collect resource utilization for the skupper-controller pod itself
+    getSkupperResourcesInNamespace "${controllerNamespace}" "app.kubernetes.io/name=skupper-controller"
+  done
 
   inspect nodes
 

--- a/scripts/skupper-gather.sh
+++ b/scripts/skupper-gather.sh
@@ -16,6 +16,102 @@ get_log_collection_args() {
   fi
 }
 
+function getPodResources() {
+  local ns="${1}"
+  local podName="${2}"
+  local container="${3}"
+  local podDirName="${podName##"pod/"}"
+
+  local resourcePath=${BASE_COLLECTION_PATH}/namespaces/${ns}/pods/${podDirName}/${container}/${container}/resources
+  mkdir -p "${resourcePath}"
+
+  echo "Collecting resource usage for pod ${podName} in ${ns}"
+
+  # Memory Info
+  oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c '
+    curr=$(cat /sys/fs/cgroup/memory.current)
+    max=$(cat /sys/fs/cgroup/memory.max)
+    curr_kb=$((curr / 1024))
+    curr_mb=$((curr / 1024 / 1024))
+
+    if [ "$max" = "max" ]; then
+      limit_str="max (uncapped)"
+    else
+      max_kb=$((max / 1024))
+      max_mb=$((max / 1024 / 1024))
+      limit_str="$max bytes ($max_kb KiB / $max_mb MiB)"
+    fi
+
+    echo "Usage: $curr bytes ($curr_kb KiB / $curr_mb MiB) - Limit: $limit_str" > /tmp/memory.info
+  ' 2>/dev/null
+  oc exec -n "${ns}" "${podName}" -c "${container}" -- cat /tmp/memory.info > "${resourcePath}/memory.info" 2>&1
+
+# Get previous container termination info
+oc get pod "${podName##"pod/"}" -n "${ns}" -o jsonpath="{.status.containerStatuses[?(@.name=='${container}')].lastState}" > "${resourcePath}/last.terminated" 2>/dev/null
+if [ ! -s "${resourcePath}/last.terminated" ]; then
+  echo "No previous termination recorded" > "${resourcePath}/last.terminated"
+fi
+
+  # Memory pressure
+oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c '
+    if [ -f /sys/fs/cgroup/memory.pressure ]; then
+      cat /sys/fs/cgroup/memory.pressure
+    else
+      echo "PSI not available on this node (kernel psi=1 not enabled)"
+    fi
+' > "${resourcePath}/memory.pressure" 2>&1
+
+# CPU usage
+oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c "
+  declare -A cpu_descriptions
+  cpu_descriptions=(
+    [usage_usec]='Total CPU time consumed (user + system)'
+    [user_usec]='Time spent in user-space (app logic)'
+    [system_usec]='Time spent in kernel-space (syscalls, I/O)'
+    [core_sched.force_idle_usec]='Time CPU forced idle for security (cross-HT side-channel protection)'
+    [nr_periods]='Number of CPU quota enforcement periods (0 = no quota set)'
+    [nr_throttled]='Times the container was throttled for exceeding CPU quota'
+    [throttled_usec]='Total time spent throttled/waiting for CPU quota'
+    [nr_bursts]='Times container used burst CPU capacity beyond quota'
+    [burst_usec]='Total time spent using burst CPU capacity'
+  )
+
+  cat /sys/fs/cgroup/cpu.stat | while read line; do
+    val=\$(echo \$line | awk '{print \$2}')
+    key=\$(echo \$line | awk '{print \$1}')
+    desc=\${cpu_descriptions[\$key]}
+    if [[ \$key == *_usec ]] && [ \$val -ge 1000000 ]; then
+      sec=\$(awk \"BEGIN {printf \\\"%.2f\\\", \$val/1000000}\")
+      echo \"\$line (\$sec s) | \$desc\"
+    else
+      echo \"\$line | \$desc\"
+    fi
+  done
+" > "${resourcePath}/cpu.stat" 2>&1
+
+  # CPU limit
+  oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c '
+    cpu_max=$(cat /sys/fs/cgroup/cpu.max)
+    quota=$(echo $cpu_max | awk "{print \$1}")
+    period=$(echo $cpu_max | awk "{print \$2}")
+    if [ "$quota" = "max" ]; then
+      echo "CPU Limit: uncapped (no quota set)"
+    else
+      cores=$(awk "BEGIN {printf \"%.2f\", $quota/$period}")
+      echo "CPU Limit: $quota/$period us = $cores cores"
+    fi
+  ' > "${resourcePath}/cpu.max" 2>&1
+
+  # CPU pressure
+oc exec -n "${ns}" "${podName}" -c "${container}" -- bash -c '
+  if [ -f /sys/fs/cgroup/cpu.pressure ]; then
+    cat /sys/fs/cgroup/cpu.pressure
+  else
+    echo "PSI not available on this node (kernel psi=1 not enabled)"
+  fi
+' > "${resourcePath}/cpu.pressure" 2>&1
+}
+
 function getSkupperRouterSkstatInNamespace() {
   local routerNamespace="${1}"
   local flags=("g" "c" "l" "n" "e" "a" "m" "p")
@@ -28,6 +124,7 @@ function getSkupperRouterSkstatInNamespace() {
     for flag in "${flags[@]}"; do
       oc exec -n "${sitens}" "${routerName}" -c router -- skstat -"${flag}" > "${logPath}/skstat.${flag}" 2>&1
     done
+    getPodResources "${sitens}" "${routerName}" "router"
   done 
 }
 

--- a/scripts/skupper-gather.sh
+++ b/scripts/skupper-gather.sh
@@ -165,8 +165,9 @@ function getSkupperRouterSkstatInNamespace() {
 
 function getSkupperResourcesInNamespace() {
   local ns="${1}"
+  local labelSelector="${2:-app.kubernetes.io/part-of=skupper}"
 
-  for podName in $(oc get pods -n "${ns}" -l app.kubernetes.io/part-of=skupper -oname); do
+  for podName in $(oc get pods -n "${ns}" -l "${labelSelector}" -oname); do
     for container in $(oc get "${podName}" -n "${ns}" -o jsonpath='{.spec.containers[*].name}'); do
       getPodResources "${ns}" "${podName}" "${container}"
     done
@@ -238,6 +239,8 @@ function main() {
   controllerNamespace=$(oc get pods --all-namespaces -l app.kubernetes.io/name=skupper-controller -o jsonpath="{.items[0].metadata.namespace}")
   # this gets also logs for all pods in that namespace
   inspect "ns/$controllerNamespace"
+  # collect resource utilization for the skupper-controller pod itself
+  getSkupperResourcesInNamespace "${controllerNamespace}" "app.kubernetes.io/name=skupper-controller"
 
   inspect nodes
 


### PR DESCRIPTION
Must gather script can now collect memory and CPU usage via container exec and also captures cgroup limits, requests, and throttling stats.
Outputs the info to "must-gather/namespaces/"namespace"/pods/"pod-name"/"container-name"/"container-name"/resources/". Creates files to track what each does

1. memory.info: Tracks current memory usage and shows the memory limit.
2. cpu.stat: Provides CPU stats on total usage time, user/syxstem breakdown, and nr_throttled which shows performance bottlenecks. 
<img width="791" height="221" alt="Screenshot 2026-06-10 at 2 41 54 PM" src="https://github.com/user-attachments/assets/79bb702c-59ad-4ca0-8057-4eb0f705b3a0" />

3. cpu.max: maximum amount of CPU processing power allotted.
4. last.terminated: Provides an error message on why the previous container crashed if applicable. Helpful for identifying errors like Out of memory.
5. memory.pressure / cpu.pressure: Tracks how much time the pod spends waiting for CPU or memory to become available. This helps identify if the pod is slowing down because the node is too busy.

To run the script:

1. podman build -t skupper-gather-test -f Dockerfile.must-gather .
2. mkdir ./must-gather
3. podman run --rm --net=host -v $HOME/.kube/config:/root/.kube/config:Z -v $(pwd)/must-gather:/must-gather:Z -e KUBECONFIG=/root/.kube/config skupper-gather-test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed per-pod/per-container resource collection for Skupper workloads, including memory and CPU usage.
  * Includes memory/CPU pressure (PSI) indicators and reports “not available” when a signal can’t be retrieved.
  * Records each container’s prior termination state to aid troubleshooting.
  * Expanded data collection across both Skupper Site and AttachedConnector namespaces, plus the Skupper controller’s namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->