### PR TITLE
Fix Network Observer Chart Hook Deletion Policy

### DIFF
--- a/charts/network-observer/templates/job_setup_secrets.yaml
+++ b/charts/network-observer/templates/job_setup_secrets.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:
@@ -55,7 +55,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -68,7 +68,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
       - ""
@@ -90,7 +90,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 subjects:
   - kind: ServiceAccount
     name: {{ include "network-observer.setupJobName" . }}


### PR DESCRIPTION
Changes the deletion policy on network-observer Chart's pre-install hook resources. Adds `before-hook-creation` so that Helm will delete resources from previous failed install attempts instead of erroring out.

Closes https://github.com/skupperproject/skupper/issues/2500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified Helm hook cleanup behavior for setup operations to adjust the timing of resource deletion during deployment cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->