### PR TITLE
Fixing the lexical error Hello-world test

### DIFF
--- a/tests/e2e/collections/ansible_collections/e2e/tests/roles/run_curl/tasks/main.yml
+++ b/tests/e2e/collections/ansible_collections/e2e/tests/roles/run_curl/tasks/main.yml
@@ -32,17 +32,18 @@
     namespace: "{{ curl_namespace }}"
     kubeconfig: "{{ kubeconfig }}"
     pod: curl
-    command: >-
+    command: >
       sh -c '
-        response=$(curl -s {{ run_curl_address }});
-        code=$(curl -s -w "%{http_code}" -o /dev/null {{ run_curl_address }});
-        if [ $code -eq 200 ]; then
-          echo "BODY: $response";
-          exit 0;
-        else
-          echo "BODY: $response";
-          exit 1;
-        fi
+      response=$(curl -s -w "\n%{http_code}"  "{{ run_curl_address }}");
+      code=$(echo "$response" | tail -n 1);
+      body=$(echo "$response" | sed "$ d");
+      if [ "$code" = "200" ]; then
+        echo "BODY: $body";
+        exit 0;
+      else
+        echo "BODY: $body";
+        exit 1;
+      fi
       '
   register: curl_result
   until: curl_result is success


### PR DESCRIPTION
While I was running the E2E tests, I had the follwing error for hello-world module. 

```
fatal: [west]: FAILED! => {"attempts": 30, "changed": true, "msg": "Task failed: Action failed: Unknown error.", "rc": 1, "return_code": 1, 
"stderr": "cannot parse the data: `lexical error: invalid character inside string.\n
{\"user\":{\"uid\":0,\"gid\":0,\"addi\n                     (right here) ------^\n`\n",
"stderr_lines": ["cannot parse the data: `lexical error: invalid character inside string.", " 
{\"user\":{\"uid\":0,\"gid\":0,\"addi", "                     (right here) ------^", "`"], 
"stdout": "", "stdout_lines": []}

```

## Description

Fixes a critical runtime failure in the `run_curl` role where the task fails with an `Unknown error` (`lexical error: invalid character inside string`). 

The failure occurs because ansible task definition contain end of line character in sh location. As of now it has been noticed in s390x. 

## Changes

### Key Changes

* **Single Network Call (`curl -s -w "\n%{http_code}" "{{ run_curl_address }}"`)**: Reduces traffic by making exactly one request to the backend. The API response text is captured alongside the 3-digit HTTP status code, which is appended to a brand-new line at the very bottom.
* **Local Code Extraction (`tail -n 1`)**: Pipes the combined response string and isolates only the final line to extract the HTTP status code.
* **Local Body Preservation (`sed "$ d"`)**: Trims the appended status code line from the stream, safely preserving the original API message body (including any native trailing text or newlines).
* **Defensive String Evaluation (`[ "$code" = "200" ]`)**: Switches the conditional check to a robust string comparison. This protects the shell executor from crashing if network drops cause the status code to return empty.
* **Clean YAML Syntax**: Formatted using the folded block scalar (`>`) to preserve intended script indentation and readability without breaking the Kubernetes command processor array.


## Testing Triaged

- [x] Verified that payloads containing nested JSON quotes no longer trigger a `lexical error`.
- [x] Confirmed that the loop correctly runs exactly one HTTP request per retry iteration.
- [x] Confirmed the task successfully completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end curl output handling by capturing both the response body and HTTP status code from a single curl execution.
  * Updated the role’s output formatting to reliably extract the status code and present results consistently as `BODY: <body>` on success and on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->