### PR TITLE
fix: respect SKUPPER_PLATFORM env var when auto-reloading namespaces

### DIFF
--- a/internal/nonkube/controller/input_resource_handler.go
+++ b/internal/nonkube/controller/input_resource_handler.go
@@ -65,6 +65,7 @@ func NewInputResourceHandler(stopCh chan struct{}, namespace string, inputPath s
 	var binary string
 
 	platform := types.Platform(utils.DefaultStr(os.Getenv("CONTAINER_ENGINE"),
+		os.Getenv(types.ENV_PLATFORM),
 		string(types.PlatformPodman)))
 
 	// TODO: add support for linux platform


### PR DESCRIPTION
`input_resource_handler` was reading `CONTAINER_ENGINE` to determine the platform for auto-bootstrap, falling back to podman when unset. The Ansible collection sets `SKUPPER_PLATFORM` instead of `CONTAINER_ENGINE`, so docker sites were always bootstrapped as podman under `reload_type: auto`.

issue detail is here: https://github.com/skupperproject/skupper/issues/2510

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform detection when the container engine setting is missing or empty.
  * The app now falls back to the platform environment value before using the default platform, helping ensure the correct Docker/Podman behavior in more environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->