### PR TITLE
feat: add readiness probe and read only root filesystem

### DIFF
--- a/charts/network-observer/templates/_deployment.yaml
+++ b/charts/network-observer/templates/_deployment.yaml
@@ -22,6 +22,8 @@
     secretName: {{ include "network-observer.basicAuthSecretName" . }}
 {{- end }}
 {{- end }}
+- name: proxy-tmp
+  emptyDir: {}
 {{- end -}}
 
 {{- define "network-observer.nginxProxySpec" -}}
@@ -52,6 +54,8 @@ volumeMounts:
     name: {{ include "network-observer.tlsSecretName" . }}
   - mountPath: /etc/nginx
     name: nginx-config
+  - mountPath: /tmp
+    name: proxy-tmp
 {{- if eq .Values.auth.strategy "basic" }}
   - mountPath: /etc/httpusers
     name: nginx-htpasswd
@@ -90,4 +94,6 @@ volumeMounts:
     name: {{ include "network-observer.tlsSecretName" . }}
   - mountPath: /etc/session-secrets/
     name: session-cookie-secret
+  - mountPath: /tmp
+    name: proxy-tmp
 {{- end -}}

--- a/charts/network-observer/templates/_deployment.yaml
+++ b/charts/network-observer/templates/_deployment.yaml
@@ -22,8 +22,6 @@
     secretName: {{ include "network-observer.basicAuthSecretName" . }}
 {{- end }}
 {{- end }}
-- name: proxy-tmp
-  emptyDir: {}
 {{- end -}}
 
 {{- define "network-observer.nginxProxySpec" -}}
@@ -36,6 +34,14 @@ command:
 {{- with .Values.nginx.securityContext }}
 securityContext:
   {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- if .Values.nginx.readinessProbe.enabled }}    
+readinessProbe:
+  {{- omit .Values.nginx.readinessProbe "enabled" | toYaml | nindent 2 }}
+{{- end }}
+{{- if .Values.nginx.livenessProbe.enabled }}    
+livenessProbe:
+  {{- omit .Values.nginx.livenessProbe "enabled" | toYaml | nindent 2 }}
 {{- end }}
 ports:
   - name: https
@@ -56,6 +62,8 @@ volumeMounts:
     name: nginx-config
   - mountPath: /tmp
     name: proxy-tmp
+  - mountPath: /var/cache/nginx
+    name: nginx-cache
 {{- if eq .Values.auth.strategy "basic" }}
   - mountPath: /etc/httpusers
     name: nginx-htpasswd

--- a/charts/network-observer/templates/deployment.yaml
+++ b/charts/network-observer/templates/deployment.yaml
@@ -103,6 +103,18 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.prometheus.readinessProbe.enabled }}    
+          readinessProbe:
+            {{- omit .Values.prometheus.readinessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.prometheus.livenessProbe.enabled }}    
+          livenessProbe:
+            {{- omit .Values.prometheus.livenessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.prometheus.startupProbe.enabled }}    
+          startupProbe:
+            {{- omit .Values.prometheus.startupProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           args:
             - --config.file=/etc/prometheus/prometheus.yml
             - --storage.tsdb.path=/prometheus/
@@ -145,6 +157,10 @@ spec:
       {{- with .Values.prometheus.extraVolumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
+      - emptyDir: {}
+        name: proxy-tmp
+      - emptyDir: {}
+        name: nginx-cache
       - name: skupper-management-client
         secret:
           defaultMode: 420

--- a/charts/network-observer/templates/deployment.yaml
+++ b/charts/network-observer/templates/deployment.yaml
@@ -47,6 +47,10 @@ spec:
       {{- end }}
       containers:
         - name: network-observer
+          {{- if .Values.livenessProbe.enabled }}    
+          livenessProbe:
+            {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           {{- if .Values.readinessProbe.enabled }}    
           readinessProbe:
             {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}

--- a/charts/network-observer/templates/deployment.yaml
+++ b/charts/network-observer/templates/deployment.yaml
@@ -47,6 +47,10 @@ spec:
       {{- end }}
       containers:
         - name: network-observer
+          {{- if .Values.readinessProbe.enabled }}    
+          readinessProbe:
+            {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.securityContext }}

--- a/charts/network-observer/values.yaml
+++ b/charts/network-observer/values.yaml
@@ -229,13 +229,13 @@ securityContext:
 
 skipManagementLabels: false
 
-## Controller containers' readiness probe. Evaluated as a template.
+## Controller containers' readiness probe
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 readinessProbe:
-  enabled: true
+  enabled: false
   # httpGet:
   #   path: /healthz
-  #   port: 9000
+  #   port: 9191
   #   scheme: HTTP
   # failureThreshold: 3
   # initialDelaySeconds: 60
@@ -243,16 +243,16 @@ readinessProbe:
   # successThreshold: 1
   # timeoutSeconds: 30
 
-  ## Default backend containers' liveness probe. Evaluated as a template.
-  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
-  livenessProbe:
-    enabled: true
-    # httpGet:
-    #   path: /healthz
-    #   port: http
-    #   scheme: HTTP
-    # failureThreshold: 3
-    # initialDelaySeconds: 60
-    # periodSeconds: 30
-    # successThreshold: 1
-    # timeoutSeconds: 30
+## Default backend containers' liveness probe
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+livenessProbe:
+  enabled: false
+  # httpGet:
+  #   path: /healthz
+  #   port: 9191
+  #   scheme: HTTP
+  # failureThreshold: 3
+  # initialDelaySeconds: 60
+  # periodSeconds: 30
+  # successThreshold: 1
+  # timeoutSeconds: 30

--- a/charts/network-observer/values.yaml
+++ b/charts/network-observer/values.yaml
@@ -20,6 +20,7 @@ prometheus:
   pullPolicy: IfNotPresent
   tag: "v3.11.3"
   securityContext:
+    readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     capabilities:
       drop:
@@ -79,6 +80,7 @@ nginx:
   tag: "1.31.0-alpine"
   pullPolicy: IfNotPresent
   securityContext:
+    readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     capabilities:
       drop:
@@ -90,6 +92,7 @@ openshiftOauthProxy:
   tag: "4.22.0"
   pullPolicy: IfNotPresent
   securityContext:
+    readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     capabilities:
       drop:
@@ -218,6 +221,7 @@ podSecurityContext:
 
 # network-observer container securityContext
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   capabilities:
     drop:

--- a/charts/network-observer/values.yaml
+++ b/charts/network-observer/values.yaml
@@ -235,10 +235,24 @@ readinessProbe:
   enabled: true
   # httpGet:
   #   path: /healthz
-  #   port: 11972
+  #   port: 9000
   #   scheme: HTTP
   # failureThreshold: 3
   # initialDelaySeconds: 60
   # periodSeconds: 30
   # successThreshold: 1
   # timeoutSeconds: 30
+
+  ## Default backend containers' liveness probe. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  livenessProbe:
+    enabled: true
+    # httpGet:
+    #   path: /healthz
+    #   port: http
+    #   scheme: HTTP
+    # failureThreshold: 3
+    # initialDelaySeconds: 60
+    # periodSeconds: 30
+    # successThreshold: 1
+    # timeoutSeconds: 30

--- a/charts/network-observer/values.yaml
+++ b/charts/network-observer/values.yaml
@@ -224,3 +224,17 @@ securityContext:
       - ALL
 
 skipManagementLabels: false
+
+## Controller containers' readiness probe. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+readinessProbe:
+  enabled: true
+  # httpGet:
+  #   path: /healthz
+  #   port: 11972
+  #   scheme: HTTP
+  # failureThreshold: 3
+  # initialDelaySeconds: 60
+  # periodSeconds: 30
+  # successThreshold: 1
+  # timeoutSeconds: 30

--- a/charts/network-observer/values.yaml
+++ b/charts/network-observer/values.yaml
@@ -25,6 +25,27 @@ prometheus:
     capabilities:
       drop:
         - ALL
+  startupProbe: 
+    enabled: true               
+    httpGet:                   
+      path: /-/ready
+      port: 9090             
+    periodSeconds: 10
+    failureThreshold: 60       
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /-/ready
+      port: 9090
+    periodSeconds: 10
+    failureThreshold: 6        
+  livenessProbe:    
+    enabled: true           
+    httpGet:
+      path: /-/healthy
+      port: 9090
+    periodSeconds: 15
+    failureThreshold: 4
 
   # Additional arguments for the Prometheus container
   extraArgs:
@@ -85,6 +106,20 @@ nginx:
     capabilities:
       drop:
         - ALL
+  readinessProbe:
+    enabled: true
+    tcpSocket:
+      port: 8443          
+    initialDelaySeconds: 2     
+    periodSeconds: 5
+    failureThreshold: 2
+  livenessProbe:
+    enabled: true
+    tcpSocket:
+      port: 8443
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    failureThreshold: 4
 
 # openshift oauth proxy configuration when auth strategy is openshift
 openshiftOauthProxy:
@@ -232,27 +267,27 @@ skipManagementLabels: false
 ## Controller containers' readiness probe
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 readinessProbe:
-  enabled: false
-  # httpGet:
-  #   path: /healthz
-  #   port: 9191
-  #   scheme: HTTP
-  # failureThreshold: 3
-  # initialDelaySeconds: 60
-  # periodSeconds: 30
-  # successThreshold: 1
-  # timeoutSeconds: 30
+  enabled: true
+  httpGet:
+    path: /metrics
+    port: 9000
+    scheme: HTTP
+  failureThreshold: 3
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  successThreshold: 1
+  timeoutSeconds: 30
 
 ## Default backend containers' liveness probe
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 livenessProbe:
-  enabled: false
-  # httpGet:
-  #   path: /healthz
-  #   port: 9191
-  #   scheme: HTTP
-  # failureThreshold: 3
-  # initialDelaySeconds: 60
-  # periodSeconds: 30
-  # successThreshold: 1
-  # timeoutSeconds: 30
+  enabled: true
+  httpGet:
+    path: /metrics
+    port: 9000
+    scheme: HTTP
+  failureThreshold: 3
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  successThreshold: 1
+  timeoutSeconds: 30


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * Hardened runtime security by enabling a read-only root filesystem and reducing privileges for the chart’s main containers.
  * Added a dedicated writable temporary directory (and an NGINX cache volume) to maintain expected runtime behavior.
  * Made health checks more flexible: liveness/readiness/startup probes are now conditionally rendered for both the NGINX/proxy and monitoring containers when enabled via chart settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->