### PR TITLE
Updated label used by expose-pods-by-name test

### DIFF
--- a/tests/e2e/scenarios/expose-pods-by-name/test.yml
+++ b/tests/e2e/scenarios/expose-pods-by-name/test.yml
@@ -111,7 +111,7 @@
                 kubeconfig: "{{ kubeconfig }}"
                 namespace: "{{ namespace_prefix }}-{{ namespace_name }}"
                 label_selectors:
-                  - internal.skupper.io/listener = true
+                  - internal.skupper.io/listener = backend
               register: svc_list
               until:
                 - svc_list.resources is defined
@@ -286,7 +286,7 @@
                 kubeconfig: "{{ kubeconfig }}"
                 namespace: "{{ namespace_prefix }}-{{ namespace_name }}"
                 label_selectors:
-                  - internal.skupper.io/listener = true
+                  - internal.skupper.io/listener = backend
               register: svc_list
               until:
                 - svc_list.resources is defined


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an end-to-end scenario to more accurately detect exposed services, improving reliability of pod-to-service name checks before and after deployment restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->