### PR TITLE
Fixed resources URL used by redis e2e tests

### DIFF
--- a/tests/e2e/scenarios/redis/test.yml
+++ b/tests/e2e/scenarios/redis/test.yml
@@ -88,8 +88,8 @@
                 path: "{{ item }}"
                 platform: podman
               with_items:
-                - https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/podman-crs/listener-podman.yaml
-                - https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/v2/podman-crs/site-podman.yaml
+                - https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/podman-crs/listener-podman.yaml
+                - https://raw.githubusercontent.com/skupperproject/skupper-example-redis/refs/heads/main/podman-crs/site-podman.yaml
 
             - name: "[ {{ test_identifier }} ] - Apply token to podman site"
               skupper.v2.resource:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Podman site setup to pull the latest manifest files from the main branch, helping ensure the deployment uses current resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->