### PR TITLE
Fix podman link tokens to use kubernetes.io/tls secrets

### DIFF
--- a/internal/nonkube/common/fs_config_renderer.go
+++ b/internal/nonkube/common/fs_config_renderer.go
@@ -578,6 +578,7 @@ func (c *FileSystemConfigurationRenderer) loadCertAsSecretFrom(basePath string, 
 			Name:      name,
 			Namespace: siteState.GetNamespace(),
 		},
+		Type: corev1.SecretTypeTLS,
 		Data: map[string][]byte{},
 	}
 	for _, file := range files {


### PR DESCRIPTION
Fixes #2518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newly created TLS secrets are now marked with the correct TLS type, improving compatibility with systems that validate secret formats.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->