### PR TITLE
Clarify semantics of AttachedConnector spec.tlsCredentials

### DIFF
--- a/config/crd/bases/skupper_attached_connector_crd.yaml
+++ b/config/crd/bases/skupper_attached_connector_crd.yaml
@@ -34,7 +34,7 @@ spec:
                 tlsCredentials:
                   description: |-
                     Advanced. The name of a bundle of TLS certificates used for secure router-to-server communication. The bundle contains the trusted server certificate (usually a CA). It optionally includes a client certificate and key for mutual TLS.
-                    On Kubernetes, the value is the name of a Secret in the current namespace. On Docker, Podman, and Linux, the value is the name of a directory under input/certs/ in the current namespace.
+                    The value is the name of a Secret in the Site namespace (spec.siteNamespace).
                   type: string
                 useClientCert:
                   type: boolean


### PR DESCRIPTION
Closes https://github.com/skupperproject/skupper/issues/2526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified where TLS certificate bundles are stored for connector setup, making the reference location in the Site namespace easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->