### PR TITLE
Fixed truncated output in ExecCommandInContainer

### DIFF
--- a/internal/kube/client/exec_util.go
+++ b/internal/kube/client/exec_util.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"io"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,9 +26,7 @@ func ExecCommandInContainer(command []string, podName string, containerName stri
 	}
 
 	buffer := bytes.Buffer{}
-	bufferedStdout := bufio.NewWriter(&buffer)
-
-	var stdout io.Writer = bufferedStdout
+	stdout := bufio.NewWriter(&buffer)
 
 	restClient, err := restclient.RESTClientFor(config)
 	if err != nil {
@@ -62,7 +59,7 @@ func ExecCommandInContainer(command []string, podName string, containerName stri
 	if err != nil {
 		return nil, err
 	}
-	if err := bufferedStdout.Flush(); err != nil {
+	if err := stdout.Flush(); err != nil {
 		return nil, err
 	}
 	return &buffer, nil

--- a/internal/kube/client/exec_util.go
+++ b/internal/kube/client/exec_util.go
@@ -26,10 +26,10 @@ func ExecCommandInContainer(command []string, podName string, containerName stri
 		targetContainer = containerName
 	}
 
-	var stdout io.Writer
-
 	buffer := bytes.Buffer{}
-	stdout = bufio.NewWriter(&buffer)
+	bufferedStdout := bufio.NewWriter(&buffer)
+
+	var stdout io.Writer = bufferedStdout
 
 	restClient, err := restclient.RESTClientFor(config)
 	if err != nil {
@@ -61,7 +61,9 @@ func ExecCommandInContainer(command []string, podName string, containerName stri
 	})
 	if err != nil {
 		return nil, err
-	} else {
-		return &buffer, nil
 	}
+	if err := bufferedStdout.Flush(); err != nil {
+		return nil, err
+	}
+	return &buffer, nil
 }


### PR DESCRIPTION
Fixes #2533 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of command output from container executions by ensuring buffered output is flushed before results are returned.
  * Flush failures are now reported instead of being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->