### PR TITLE
Site recovery stability

### DIFF
--- a/internal/kube/controller/controller.go
+++ b/internal/kube/controller/controller.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"regexp"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,32 +31,35 @@ import (
 )
 
 type Controller struct {
-	self                    skupperv2alpha1.Controller
-	deploymentName          string
-	deploymentUid           string
-	eventProcessor          *watchers.EventProcessor
-	stopCh                  <-chan struct{}
-	siteWatcher             *watchers.SiteWatcher
-	listenerWatcher         *watchers.ListenerWatcher
-	connectorWatcher        *watchers.ConnectorWatcher
-	multiKeyListenerWatcher *watchers.MultiKeyListenerWatcher
-	linkAccessWatcher       *watchers.RouterAccessWatcher
-	grantWatcher            *watchers.AccessGrantWatcher
-	serviceWatcher          *watchers.ServiceWatcher
-	sites                   map[string]*site.Site
-	startGrantServer        func()
-	accessMgr               *securedaccess.SecuredAccessManager
-	accessRecovery          *securedaccess.SecuredAccessResourceWatcher
-	certMgr                 *certificates.CertificateManagerImpl
-	siteSizing              *sizing.Registry
-	siteSizingWatcher       *watchers.ConfigMapWatcher
-	labelling               *labels.LabelsAndAnnotations
-	labellingWatcher        *watchers.ConfigMapWatcher
-	attachableConnectors    map[string]*skupperv2alpha1.AttachedConnector
-	disableSecContext       bool
-	log                     *slog.Logger
-	namespaces              *NamespaceConfig
-	observedServices        map[string]string
+	self                            skupperv2alpha1.Controller
+	deploymentName                  string
+	deploymentUid                   string
+	eventProcessor                  *watchers.EventProcessor
+	stopCh                          <-chan struct{}
+	siteWatcher                     *watchers.SiteWatcher
+	listenerWatcher                 *watchers.ListenerWatcher
+	connectorWatcher                *watchers.ConnectorWatcher
+	multiKeyListenerWatcher         *watchers.MultiKeyListenerWatcher
+	linkAccessWatcher               *watchers.RouterAccessWatcher
+	attachedConnectorWatcher        *watchers.AttachedConnectorWatcher
+	attachedConnectorBindingWatcher *watchers.AttachedConnectorBindingWatcher
+	grantWatcher                    *watchers.AccessGrantWatcher
+	serviceWatcher                  *watchers.ServiceWatcher
+	networkStatusWatcher            *watchers.ConfigMapWatcher
+	sites                           map[string]*site.Site
+	startGrantServer                func()
+	accessMgr                       *securedaccess.SecuredAccessManager
+	accessRecovery                  *securedaccess.SecuredAccessResourceWatcher
+	certMgr                         *certificates.CertificateManagerImpl
+	siteSizing                      *sizing.Registry
+	siteSizingWatcher               *watchers.ConfigMapWatcher
+	labelling                       *labels.LabelsAndAnnotations
+	labellingWatcher                *watchers.ConfigMapWatcher
+	attachableConnectors            map[string]*skupperv2alpha1.AttachedConnector
+	disableSecContext               bool
+	log                             *slog.Logger
+	namespaces                      *NamespaceConfig
+	observedServices                map[string]string
 }
 
 func skupperRouterConfig() internalinterfaces.TweakListOptionsFunc {
@@ -136,10 +140,10 @@ func NewController(cli internalclient.Clients, config *Config, options ...watche
 	controller.serviceWatcher = controller.eventProcessor.WatchServices(sansSkupperListenerServices(), config.WatchNamespace, filter(controller, controller.checkObservedService))
 	controller.connectorWatcher = controller.eventProcessor.WatchConnectors(config.WatchNamespace, filter(controller, controller.checkConnector))
 	controller.linkAccessWatcher = controller.eventProcessor.WatchRouterAccesses(config.WatchNamespace, filter(controller, controller.checkRouterAccess))
-	controller.eventProcessor.WatchAttachedConnectors(config.WatchNamespace, filter(controller, controller.checkAttachedConnector))
-	controller.eventProcessor.WatchAttachedConnectorBindings(config.WatchNamespace, filter(controller, controller.checkAttachedConnectorBinding))
+	controller.attachedConnectorWatcher = controller.eventProcessor.WatchAttachedConnectors(config.WatchNamespace, filter(controller, controller.checkAttachedConnector))
+	controller.attachedConnectorBindingWatcher = controller.eventProcessor.WatchAttachedConnectorBindings(config.WatchNamespace, filter(controller, controller.checkAttachedConnectorBinding))
 	controller.eventProcessor.WatchLinks(config.WatchNamespace, filter(controller, controller.checkLink))
-	controller.eventProcessor.WatchConfigMaps(skupperNetworkStatus(), config.WatchNamespace, filter(controller, controller.networkStatusUpdate))
+	controller.networkStatusWatcher = controller.eventProcessor.WatchConfigMaps(skupperNetworkStatus(), config.WatchNamespace, filter(controller, controller.networkStatusUpdate))
 	controller.eventProcessor.WatchConfigMaps(skupperRouterConfig(), config.WatchNamespace, filter(controller, controller.routerConfigUpdate))
 	controller.eventProcessor.WatchAccessTokens(config.WatchNamespace, filter(controller, controller.checkAccessToken))
 	controller.eventProcessor.WatchPods("skupper.io/component=router,skupper.io/type=site", config.WatchNamespace, filter(controller, controller.routerPodEvent))
@@ -214,34 +218,64 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 }
 
 func (c *Controller) init(stopCh <-chan struct{}) error {
-	c.log.Info("Starting informers")
+	initStart := time.Now()
+	log := c.log.With(slog.String("stage", "init"))
+	log.Info("Initialising controller", slog.String("version", c.self.Version))
+	errCount := 0
+
 	c.eventProcessor.StartWatchers(stopCh)
 	c.stopCh = stopCh
-
-	c.log.Info("Waiting for informer caches to sync")
+	syncStart := time.Now()
 	if ok := c.eventProcessor.WaitForCacheSync(stopCh); !ok {
 		return fmt.Errorf("Failed to wait for caches to sync")
 	}
+	log.Info("Informer caches synced", slog.Duration("duration", time.Since(syncStart)))
 	c.namespaces.recover()
 
+	sizingCount := 0
 	for _, config := range c.siteSizingWatcher.List() {
-		c.log.Info("Recovering site sizing",
+		log.Debug("Recovering site sizing",
 			slog.String("namespace", config.Namespace),
 			slog.String("name", config.Name),
 		)
 		c.siteSizing.Update(config.Namespace+"/"+config.Name, config)
+		sizingCount++
 	}
+	labellingCount := 0
 	for _, config := range c.labellingWatcher.List() {
-		c.log.Info("Recovering label and annotation configuration",
+		log.Debug("Recovering label and annotation configuration",
 			slog.String("namespace", config.Namespace),
 			slog.String("name", config.Name),
 		)
 		c.labelling.Update(config.Namespace+"/"+config.Name, config)
+		labellingCount++
 	}
+	c.certMgr.Recover()
+	c.accessRecovery.Recover()
 	// get observed services prior to restoring listeners
 	for _, svc := range c.serviceWatcher.List() {
 		c.observedServices[svc.Namespace+"/"+svc.ObjectMeta.Name] = svc.ObjectMeta.Name
 	}
+	log.Info("Configuration recovered",
+		slog.Int("siteSizings", sizingCount),
+		slog.Int("labellings", labellingCount),
+		slog.Int("observedServices", len(c.observedServices)),
+	)
+	// seed router access before site recovery
+	routerAccessCount := 0
+	for _, la := range c.linkAccessWatcher.List() {
+		if !c.namespaces.isControlled(la.Namespace) {
+			continue
+		}
+		site := c.getSite(la.ObjectMeta.Namespace)
+		log.Debug("Recovering router access",
+			slog.String("namespace", la.Namespace),
+			slog.String("name", la.Name),
+		)
+		site.CheckRouterAccess(la.ObjectMeta.Name, la)
+		routerAccessCount++
+	}
+	log.Info("Router access seeded", slog.Int("count", routerAccessCount))
 	//recover existing sites & bindings
 	siteRecovery := site.NewSiteRecovery(c.eventProcessor.GetKubeClient())
 	for _, site := range c.siteWatcher.List() {
@@ -249,35 +283,38 @@ func (c *Controller) init(stopCh <-chan struct{}) error {
 			continue
 		}
 		if !siteRecovery.IsActive(site) {
-			c.log.Info("Skipping site recovery as it is not the active site",
+			log.Warn("Skipping site recovery as it is not the active site",
 				slog.String("namespace", site.Namespace),
 				slog.String("name", site.Name),
 			)
 			continue
 		}
-		c.log.Info("Recovering site",
+		log.Info("Site recovery started",
 			slog.String("namespace", site.Namespace),
 			slog.String("name", site.Name),
 		)
 		err := c.getSite(site.ObjectMeta.Namespace).StartRecovery(site)
 		if err != nil {
-			c.log.Error("Error recovering site",
+			log.Warn("Error starting site recovery; will retry on finishing reconcile",
 				slog.String("namespace", site.Namespace),
 				slog.String("name", site.Name),
 				slog.Any("error", err),
 			)
+			errCount++
 		}
 	}
+	connectorCount := 0
 	for _, connector := range c.connectorWatcher.List() {
 		if !c.namespaces.isControlled(connector.Namespace) {
 			continue
 		}
 		site := c.getSite(connector.ObjectMeta.Namespace)
-		c.log.Info("Recovering connector",
+		log.Debug("Recovering connector",
 			slog.String("namespace", connector.Namespace),
 			slog.String("name", connector.Name),
 		)
 		site.CheckConnector(connector.ObjectMeta.Name, connector)
+		connectorCount++
 	}
 	for _, listener := range c.listenerWatcher.List() {
 		if !c.namespaces.isControlled(listener.Namespace) {
@@ -286,66 +323,138 @@ func (c *Controller) init(stopCh <-chan struct{}) error {
 		site := c.getSite(listener.ObjectMeta.Namespace)
 		site.CheckLeadListeners(listener)
 	}
+	listenerCount := 0
 	for _, listener := range c.listenerWatcher.List() {
 		if !c.namespaces.isControlled(listener.Namespace) {
 			continue
 		}
 		site := c.getSite(listener.ObjectMeta.Namespace)
-		c.log.Info("Recovering listener",
+		log.Debug("Recovering listener",
 			slog.String("namespace", listener.Namespace),
 			slog.String("name", listener.Name),
 		)
 		_, svcExists := c.observedServices[listener.ObjectMeta.Namespace+"/"+listener.Spec.Host]
 		site.CheckListener(listener.ObjectMeta.Name, listener, svcExists)
+		listenerCount++
 	}
+	multiKeyListenerCount := 0
 	if c.multiKeyListenerWatcher != nil {
 		for _, mkl := range c.multiKeyListenerWatcher.List() {
 			if !c.namespaces.isControlled(mkl.Namespace) {
 				continue
 			}
 			site := c.getSite(mkl.ObjectMeta.Namespace)
-			c.log.Info("Recovering multikeylistener",
+			log.Debug("Recovering multikeylistener",
 				slog.String("namespace", mkl.Namespace),
 				slog.String("name", mkl.Name),
 			)
 			site.CheckMultiKeyListener(mkl.ObjectMeta.Name, mkl)
+			multiKeyListenerCount++
 		}
 	}
-	for _, la := range c.linkAccessWatcher.List() {
-		if !c.namespaces.isControlled(la.Namespace) {
+	attachedConnectorBindingCount := 0
+	for _, binding := range c.attachedConnectorBindingWatcher.List() {
+		if !c.namespaces.isControlled(binding.Namespace) {
 			continue
 		}
-		site := c.getSite(la.ObjectMeta.Namespace)
-		c.log.Info("Recovering router access",
-			slog.String("namespace", la.Namespace),
-			slog.String("name", la.Name),
+		log.Debug("Recovering attached connector binding",
+			slog.String("namespace", binding.Namespace),
+			slog.String("name", binding.Name),
 		)
-		site.CheckRouterAccess(la.ObjectMeta.Name, la)
+		if err := c.checkAttachedConnectorBinding(binding.Namespace+"/"+binding.Name, binding); err != nil {
+			log.Error("Error recovering attached connector binding",
+				slog.String("namespace", binding.Namespace),
+				slog.String("name", binding.Name),
+				slog.Any("error", err),
+			)
+			errCount++
+		}
+		attachedConnectorBindingCount++
 	}
+	attachedConnectorCount := 0
+	for _, connector := range c.attachedConnectorWatcher.List() {
+		if !c.namespaces.isControlled(connector.Spec.SiteNamespace) {
+			continue
+		}
+		log.Debug("Recovering attached connector",
+			slog.String("namespace", connector.Namespace),
+			slog.String("name", connector.Name),
+		)
+		if err := c.checkAttachedConnector(connector.Namespace+"/"+connector.Name, connector); err != nil {
+			log.Error("Error recovering attached connector",
+				slog.String("namespace", connector.Namespace),
+				slog.String("name", connector.Name),
+				slog.Any("error", err),
+			)
+			errCount++
+		}
+		attachedConnectorCount++
+	}
+	// needed by listeners with exposePodsByName
+	networkStatusCount := 0
+	for _, cm := range c.networkStatusWatcher.List() {
+		if !c.namespaces.isControlled(cm.Namespace) {
+			continue
+		}
+		if err := c.networkStatusUpdate(cm.Namespace+"/"+cm.Name, cm); err != nil {
+			log.Error("Error recovering network status",
+				slog.String("namespace", cm.Namespace),
+				slog.String("name", cm.Name),
+				slog.Any("error", err),
+			)
+			errCount++
+		}
+		networkStatusCount++
+	}
+	log.Info("Bindings recovered",
+		slog.Int("connectors", connectorCount),
+		slog.Int("listeners", listenerCount),
+		slog.Int("multiKeyListeners", multiKeyListenerCount),
+		slog.Int("attachedConnectors", attachedConnectorCount),
+		slog.Int("attachedConnectorBindings", attachedConnectorBindingCount),
+		slog.Int("networkStatuses", networkStatusCount),
+	)
+	// Binding recovery creates pod watchers for selector-based connectors
+	// and attached connectors; wait for them to sync so that the initial
+	// router config write below reflects current pod state.
+	log.Info("Waiting for pod watchers to sync")
+	syncStart = time.Now()
+	if ok := c.eventProcessor.WaitForCacheSync(stopCh); !ok {
+		return fmt.Errorf("Failed to wait for caches to sync")
+	}
+	log.Info("Pod watchers synced", slog.Duration("duration", time.Since(syncStart)))
+	siteCount := 0
 	for _, site := range c.siteWatcher.List() {
 		if !c.namespaces.isControlled(site.Namespace) {
 			continue
 		}
+		siteCount++
+		siteStart := time.Now()
 		site.Status.Controller = &c.self
 		err := c.getSite(site.ObjectMeta.Namespace).Reconcile(site)
 		if err != nil {
-			c.log.Error("Error recovering site",
+			log.Error("Error finishing site recovery",
 				slog.String("namespace", site.Namespace),
 				slog.String("name", site.Name),
 				slog.Any("error", err),
 			)
+			errCount++
 		} else {
-			c.log.Info("Recovered site",
+			log.Info("Site recovery finished",
 				slog.String("namespace", site.Namespace),
 				slog.String("name", site.Name),
+				slog.Duration("duration", time.Since(siteStart)),
 			)
 		}
 	}
-	c.certMgr.Recover()
-	c.accessRecovery.Recover()
 	if c.startGrantServer != nil {
 		c.startGrantServer()
 	}
+	log.Info("Controller initialised",
+		slog.Int("sites", siteCount),
+		slog.Int("errors", errCount),
+		slog.Duration("duration", time.Since(initStart)),
+	)
 	return nil
 }
 

--- a/internal/kube/controller/controller.go
+++ b/internal/kube/controller/controller.go
@@ -366,7 +366,7 @@ func (c *Controller) init(stopCh <-chan struct{}) error {
 	}
 	attachedConnectorCount := 0
 	for _, connector := range c.attachedConnectorWatcher.List() {
-		if !c.namespaces.isControlled(connector.Spec.SiteNamespace) {
+		if !c.namespaces.isControlled(connector.Namespace) {
 			continue
 		}
 		log.Debug("Recovering attached connector",

--- a/internal/kube/controller/controller.go
+++ b/internal/kube/controller/controller.go
@@ -361,14 +361,7 @@ func (c *Controller) init(stopCh <-chan struct{}) error {
 			slog.String("namespace", binding.Namespace),
 			slog.String("name", binding.Name),
 		)
-		if err := c.checkAttachedConnectorBinding(binding.Namespace+"/"+binding.Name, binding); err != nil {
-			log.Error("Error recovering attached connector binding",
-				slog.String("namespace", binding.Namespace),
-				slog.String("name", binding.Name),
-				slog.Any("error", err),
-			)
-			errCount++
-		}
+		c.getSite(binding.Namespace).RecoverAttachedConnectorBinding(binding)
 		attachedConnectorBindingCount++
 	}
 	attachedConnectorCount := 0
@@ -380,14 +373,8 @@ func (c *Controller) init(stopCh <-chan struct{}) error {
 			slog.String("namespace", connector.Namespace),
 			slog.String("name", connector.Name),
 		)
-		if err := c.checkAttachedConnector(connector.Namespace+"/"+connector.Name, connector); err != nil {
-			log.Error("Error recovering attached connector",
-				slog.String("namespace", connector.Namespace),
-				slog.String("name", connector.Name),
-				slog.Any("error", err),
-			)
-			errCount++
-		}
+		c.attachableConnectors[connector.Namespace+"/"+connector.Name] = connector
+		c.getSite(connector.Spec.SiteNamespace).RecoverAttachedConnector(connector)
 		attachedConnectorCount++
 	}
 	// needed by listeners with exposePodsByName
@@ -431,7 +418,11 @@ func (c *Controller) init(stopCh <-chan struct{}) error {
 		siteCount++
 		siteStart := time.Now()
 		site.Status.Controller = &c.self
-		err := c.getSite(site.ObjectMeta.Namespace).Reconcile(site)
+		recoveredSite := c.getSite(site.ObjectMeta.Namespace)
+		err := recoveredSite.Reconcile(site)
+		if err == nil {
+			err = recoveredSite.FinishAttachedConnectorRecovery()
+		}
 		if err != nil {
 			log.Error("Error finishing site recovery",
 				slog.String("namespace", site.Namespace),

--- a/internal/kube/controller/controller_test.go
+++ b/internal/kube/controller/controller_test.go
@@ -28,6 +28,7 @@ import (
 	discoveryfake "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/dynamic"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/skupperproject/skupper/internal/fixtures"
@@ -662,6 +663,154 @@ func TestGeneral(t *testing.T) {
 				assert.DeepEqual(t, expected.Spec, actual.Spec)
 			}
 		})
+	}
+}
+
+func TestRecoveryPreservesRouterBridgeConfig(t *testing.T) {
+	flags := &flag.FlagSet{}
+	config, err := BoundConfig(flags)
+	assert.Assert(t, err)
+
+	uid := "49b03ad4-d414-42be-bbb5-b32d7d4ca503"
+	site := f.addUID(f.site("mysite", "test", "loadbalancer", false, false), uid)
+	attachedConnectorBinding := f.attachedConnectorBinding("attached-a", "test", "attached")
+	attachedConnectorBinding.Spec.RoutingKey = "attached-a"
+	attachedPod := f.pod("pod-a", "attached", map[string]string{"app": "attached-a"}, nil, f.podStatus("10.1.1.20", corev1.PodRunning, f.podCondition(corev1.PodReady, corev1.ConditionTrue)))
+	attachedPod.UID = types.UID("6ffbd287-42cc-4b71-b0a7-44f1befcc847")
+	normalPod := f.pod("pod-b", "test", map[string]string{"app": "normal-a"}, nil, f.podStatus("10.1.1.30", corev1.PodRunning, f.podCondition(corev1.PodReady, corev1.ConditionTrue)))
+	normalPod.UID = types.UID("a2b30f15-4fe3-4788-a68d-36105d147435")
+	siteCA := &skupperv2alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "skupper-site-ca",
+			Namespace: "test",
+			Labels: map[string]string{
+				"internal.skupper.io/certificate": "true",
+			},
+			Annotations: map[string]string{
+				"internal.skupper.io/controlled":   "true",
+				"internal.skupper.io/hosts-" + uid: "",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: skupperv2alpha1.SchemeGroupVersion.String(),
+					Kind:       "Site",
+					Name:       site.Name,
+					UID:        types.UID(uid),
+				},
+			},
+		},
+		Spec: skupperv2alpha1.CertificateSpec{
+			Subject: "mysite site CA",
+			Signing: true,
+		},
+	}
+	routerConfig := f.routerConfig("skupper-router", "test").
+		tcpListener("listener/listener-a", "1024", "", "").
+		tcpListener("listener/listener-a@pod-a", "1027", "backend-a.pod-a", "").
+		tcpListener("listener/listener-b", "1025", "", "").
+		tcpListener("multiAddress/mkl-a", "1026", "", "").
+		tcpConnector("connector/normal-a@10.1.1.30", "10.1.1.30", "8084", "", "").
+		tcpConnector("connector/attached-a@10.1.1.20", "10.1.1.20", "8083", "attached-a", "")
+	routerConfig.config.Bridges.TcpConnectors["connector/attached-a@10.1.1.20"] = qdr.TcpEndpoint{
+		Name:      "connector/attached-a@10.1.1.20",
+		SiteId:    uid,
+		Host:      "10.1.1.20",
+		Port:      "8083",
+		Address:   "attached-a",
+		ProcessID: "6ffbd287-42cc-4b71-b0a7-44f1befcc847",
+	}
+	routerConfigMap := routerConfig.asConfigMapWithOwner(site.Name, uid)
+	routerConfigMap.Labels = map[string]string{
+		"internal.skupper.io/router-config": "",
+	}
+	statusInfo := f.networkStatusInfo("mysite", "test", nil, map[string]string{"backend-a.pod-a": "10.1.1.10"}).info()
+	networkStatus := f.skupperNetworkStatus("test", statusInfo)
+	// the persisted site status already reflects the network, as it would
+	// after a controller restart
+	site.Status.Network = network.ExtractSiteRecords(*statusInfo)
+	site.Status.SitesInNetwork = len(site.Status.Network)
+
+	routerDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "skupper-router",
+			Namespace: "test",
+			Labels: map[string]string{
+				"skupper.io/component": "router",
+				"skupper.io/type":      "site",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: f.routerSelector(false)},
+		},
+	}
+	clients, err := fakeclient.NewFakeClient(config.Namespace, []runtime.Object{routerConfigMap, networkStatus, routerDeployment, attachedPod, normalPod}, []runtime.Object{
+		site,
+		siteCA,
+		f.routerAccess("skupper-router", "test", "loadbalancer", "skupper-site-server", true, "skupper-site-ca", f.role("inter-router", 55671), f.role("edge", 45671)),
+		f.connectorWithSelector("normal-a", "test", "app=normal-a", 8084),
+		f.attachedConnector("attached-a", "attached", "test", "app=attached-a", 8083),
+		attachedConnectorBinding,
+		f.listenerWithExposePodsByName("listener-a", "test", "backend-a", "backend-a", 8080),
+		f.listener("listener-b", "test", "backend-b", 8081),
+		f.multiKeyListener("mkl-a", "test", "backend-mkl", 8082),
+	}, "")
+	assert.Assert(t, err)
+	enableSSA(clients.GetDynamicClient())
+
+	var observed []qdr.BridgeConfig
+	clients.GetKubeClient().(*k8sfake.Clientset).PrependReactor("update", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		update := action.(k8stesting.UpdateAction)
+		cm := update.GetObject().(*corev1.ConfigMap)
+		if cm.Namespace == "test" && cm.Name == "skupper-router" {
+			config, err := qdr.GetRouterConfigFromConfigMap(cm)
+			if err != nil {
+				return true, nil, err
+			}
+			observed = append(observed, config.Bridges)
+		}
+		return false, nil, nil
+	})
+
+	controller, err := NewController(clients, config)
+	assert.Assert(t, err)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	err = controller.init(stopCh)
+	assert.Assert(t, err)
+
+	expectedTcpListeners := []string{
+		"listener/listener-a",
+		"listener/listener-a@pod-a",
+		"listener/listener-b",
+		"multiAddress/mkl-a",
+	}
+	expectedTcpConnectors := []string{
+		"connector/normal-a@10.1.1.30",
+		"connector/attached-a@10.1.1.20",
+	}
+	assert.Assert(t, len(observed) > 0, "expected at least one router config update after recovery")
+	for i, bridge := range observed {
+		for _, name := range expectedTcpListeners {
+			_, ok := bridge.TcpListeners[name]
+			assert.Assert(t, ok, "router config update %d was partial: missing %s", i, name)
+		}
+		for _, name := range expectedTcpConnectors {
+			_, ok := bridge.TcpConnectors[name]
+			assert.Assert(t, ok, "router config update %d was partial: missing %s", i, name)
+		}
+	}
+
+	actual, err := clients.GetKubeClient().CoreV1().ConfigMaps("test").Get(context.Background(), "skupper-router", metav1.GetOptions{})
+	assert.Assert(t, err)
+	configAfterRecovery, err := qdr.GetRouterConfigFromConfigMap(actual)
+	assert.Assert(t, err)
+	for _, name := range expectedTcpListeners {
+		_, ok := configAfterRecovery.Bridges.TcpListeners[name]
+		assert.Assert(t, ok, "final router config missing %s", name)
+	}
+	for _, name := range expectedTcpConnectors {
+		_, ok := configAfterRecovery.Bridges.TcpConnectors[name]
+		assert.Assert(t, ok, "final router config missing %s", name)
 	}
 }
 

--- a/internal/kube/controller/controller_test.go
+++ b/internal/kube/controller/controller_test.go
@@ -679,6 +679,10 @@ func TestRecoveryPreservesRouterBridgeConfig(t *testing.T) {
 	attachedPod.UID = types.UID("6ffbd287-42cc-4b71-b0a7-44f1befcc847")
 	normalPod := f.pod("pod-b", "test", map[string]string{"app": "normal-a"}, nil, f.podStatus("10.1.1.30", corev1.PodRunning, f.podCondition(corev1.PodReady, corev1.ConditionTrue)))
 	normalPod.UID = types.UID("a2b30f15-4fe3-4788-a68d-36105d147435")
+	normalConnector := f.connectorWithSelector("normal-a", "test", "app=normal-a", 8084)
+	normalConnector.SetConfigured(fmt.Errorf("No matches for selector"))
+	unmatchedConnector := f.connectorWithSelector("normal-b", "test", "app=normal-b", 8085)
+	unmatchedConnector.SetConfigured(fmt.Errorf("No matches for selector"))
 	siteCA := &skupperv2alpha1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "skupper-site-ca",
@@ -747,7 +751,8 @@ func TestRecoveryPreservesRouterBridgeConfig(t *testing.T) {
 		site,
 		siteCA,
 		f.routerAccess("skupper-router", "test", "loadbalancer", "skupper-site-server", true, "skupper-site-ca", f.role("inter-router", 55671), f.role("edge", 45671)),
-		f.connectorWithSelector("normal-a", "test", "app=normal-a", 8084),
+		normalConnector,
+		unmatchedConnector,
 		f.attachedConnector("attached-a", "attached", "test", "app=attached-a", 8083),
 		attachedConnectorBinding,
 		f.listenerWithExposePodsByName("listener-a", "test", "backend-a", "backend-a", 8080),
@@ -812,6 +817,19 @@ func TestRecoveryPreservesRouterBridgeConfig(t *testing.T) {
 		_, ok := configAfterRecovery.Bridges.TcpConnectors[name]
 		assert.Assert(t, ok, "final router config missing %s", name)
 	}
+
+	recoveredNormalConnector, err := clients.GetSkupperClient().SkupperV2alpha1().Connectors("test").Get(context.Background(), normalConnector.Name, metav1.GetOptions{})
+	assert.Assert(t, err)
+	configured := meta.FindStatusCondition(recoveredNormalConnector.Status.Conditions, skupperv2alpha1.CONDITION_TYPE_CONFIGURED)
+	assert.Assert(t, configured != nil)
+	assert.Equal(t, configured.Status, metav1.ConditionTrue)
+
+	recoveredUnmatchedConnector, err := clients.GetSkupperClient().SkupperV2alpha1().Connectors("test").Get(context.Background(), unmatchedConnector.Name, metav1.GetOptions{})
+	assert.Assert(t, err)
+	configured = meta.FindStatusCondition(recoveredUnmatchedConnector.Status.Conditions, skupperv2alpha1.CONDITION_TYPE_CONFIGURED)
+	assert.Assert(t, configured != nil)
+	assert.Equal(t, configured.Status, metav1.ConditionFalse)
+	assert.Equal(t, configured.Message, "No matches for selector")
 }
 
 func TestUpdate(t *testing.T) {

--- a/internal/kube/controller/controller_test.go
+++ b/internal/kube/controller/controller_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/skupperproject/skupper/internal/utils"
 	"github.com/skupperproject/skupper/internal/version"
 	skupperv2alpha1 "github.com/skupperproject/skupper/pkg/apis/skupper/v2alpha1"
+	fakeskupperv2alpha1 "github.com/skupperproject/skupper/pkg/generated/client/clientset/versioned/typed/skupper/v2alpha1/fake"
 )
 
 type WaitFunction func(t *testing.T, clients internalclient.Clients) bool
@@ -830,6 +831,93 @@ func TestRecoveryPreservesRouterBridgeConfig(t *testing.T) {
 	assert.Assert(t, configured != nil)
 	assert.Equal(t, configured.Status, metav1.ConditionFalse)
 	assert.Equal(t, configured.Message, "No matches for selector")
+}
+
+func TestAttachedConnectorRecoveryDoesNotFlapStatus(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		pod                    *corev1.Pod
+		persistedError         string
+		expectedCondition      metav1.ConditionStatus
+		expectedMessage        string
+		expectedBindingUpdates int
+	}{
+		{
+			name: "healthy binding",
+			pod: f.pod("mypod", "other", map[string]string{"app": "foo"}, nil,
+				f.podStatus("10.1.1.10", corev1.PodRunning, f.podCondition(corev1.PodReady, corev1.ConditionTrue))),
+			expectedCondition: metav1.ConditionTrue,
+			expectedMessage:   "OK",
+		},
+		{
+			name:              "persisted no matches",
+			persistedError:    "No matches for selector",
+			expectedCondition: metav1.ConditionFalse,
+			expectedMessage:   "No matches for selector",
+		},
+		{
+			name:                   "stale healthy status with no matches",
+			expectedCondition:      metav1.ConditionFalse,
+			expectedMessage:        "No matches for selector",
+			expectedBindingUpdates: 1,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := &flag.FlagSet{}
+			config, err := BoundConfig(flags)
+			assert.Assert(t, err)
+
+			binding := f.attachedConnectorBinding("myconnector", "test", "other")
+			connector := f.attachedConnector("myconnector", "other", "test", "app=foo", 8080)
+			var statusErr error
+			if tt.persistedError != "" {
+				statusErr = fmt.Errorf("%s", tt.persistedError)
+			}
+			binding.SetConfigured(statusErr)
+			connector.SetConfigured(statusErr)
+
+			var kubeObjects []runtime.Object
+			if tt.pod != nil {
+				kubeObjects = append(kubeObjects, tt.pod)
+			}
+			clients, err := fakeclient.NewFakeClient(config.Namespace, kubeObjects, []runtime.Object{
+				f.site("mysite", "test", "", false, false),
+				binding,
+				connector,
+			}, "")
+			assert.Assert(t, err)
+			enableSSA(clients.GetDynamicClient())
+
+			var bindingUpdates []metav1.Condition
+			clients.GetSkupperClient().SkupperV2alpha1().(*fakeskupperv2alpha1.FakeSkupperV2alpha1).PrependReactor("update", "attachedconnectorbindings", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				updated := action.(k8stesting.UpdateAction).GetObject().(*skupperv2alpha1.AttachedConnectorBinding)
+				condition := meta.FindStatusCondition(updated.Status.Conditions, skupperv2alpha1.CONDITION_TYPE_CONFIGURED)
+				assert.Assert(t, condition != nil)
+				bindingUpdates = append(bindingUpdates, *condition)
+				return false, nil, nil
+			})
+
+			controller, err := NewController(clients, config)
+			assert.Assert(t, err)
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			err = controller.init(stopCh)
+			assert.Assert(t, err)
+
+			actual, err := clients.GetSkupperClient().SkupperV2alpha1().AttachedConnectorBindings("test").Get(context.Background(), binding.Name, metav1.GetOptions{})
+			assert.Assert(t, err)
+			configured := meta.FindStatusCondition(actual.Status.Conditions, skupperv2alpha1.CONDITION_TYPE_CONFIGURED)
+			assert.Assert(t, configured != nil)
+			assert.Equal(t, configured.Status, tt.expectedCondition)
+			assert.Equal(t, configured.Message, tt.expectedMessage)
+			assert.Equal(t, len(bindingUpdates), tt.expectedBindingUpdates)
+			for _, update := range bindingUpdates {
+				assert.Assert(t, update.Message != "No matching AttachedConnector", "binding status flapped during recovery")
+			}
+		})
+	}
 }
 
 func TestUpdate(t *testing.T) {

--- a/internal/kube/site/attached_connector.go
+++ b/internal/kube/site/attached_connector.go
@@ -95,13 +95,31 @@ func (a *AttachedConnector) updateStatus() error {
 func (a *AttachedConnector) updateStatusNoBinding() error {
 	var errors []string
 	for _, definition := range a.definitions {
-		if definition.SetConfigured(fmt.Errorf("No matching AttachedConnectorBinding in site namespace")) {
+		if definition.SetConfigured(a.definitionConfigurationError(definition)) {
 			if err := a.updateDefinitionStatus(definition); err != nil {
 				errors = append(errors, err.Error())
 			}
 		}
 	}
 	return error_(errors)
+}
+
+func (a *AttachedConnector) definitionConfigurationError(definition *skupperv2alpha1.AttachedConnector) error {
+	if a.binding == nil {
+		return fmt.Errorf("No matching AttachedConnectorBinding in site namespace")
+	}
+	return fmt.Errorf("AttachedConnectorBinding %s/%s does not allow AttachedConnector in %s (only %s)", a.binding.Namespace, a.binding.Name, definition.Namespace, a.binding.Spec.ConnectorNamespace)
+}
+
+func (a *AttachedConnector) updateDefinitionStatusForCurrentBinding(definition *skupperv2alpha1.AttachedConnector) {
+	if definition.SetConfigured(a.definitionConfigurationError(definition)) {
+		if err := a.updateDefinitionStatus(definition); err != nil {
+			a.parent.logger.Error("Error updating status for AttachedConnector",
+				slog.String("namespace", definition.Namespace),
+				slog.String("name", definition.Name),
+				slog.Any("error", err))
+		}
+	}
 }
 
 func (a *AttachedConnector) updateStatusTo(err error, activeDefinition *skupperv2alpha1.AttachedConnector) error {
@@ -120,7 +138,7 @@ func (a *AttachedConnector) updateStatusTo(err error, activeDefinition *skupperv
 		if definition.Namespace == a.binding.Spec.ConnectorNamespace {
 			continue
 		}
-		if definition.SetConfigured(fmt.Errorf("AttachedConnectorBinding %s/%s does not allow AttachedConnector in %s (only %s)", a.binding.Namespace, a.binding.Name, definition.Namespace, a.binding.Spec.ConnectorNamespace)) {
+		if definition.SetConfigured(a.definitionConfigurationError(definition)) {
 			if err := a.updateDefinitionStatus(definition); err != nil {
 				errors = append(errors, err.Error())
 			}
@@ -217,7 +235,7 @@ func (a *AttachedConnector) watchPods() {
 	}
 }
 
-func (a *AttachedConnector) definitionUpdated(definition *skupperv2alpha1.AttachedConnector) bool {
+func (a *AttachedConnector) definitionUpdated(definition *skupperv2alpha1.AttachedConnector) (configure bool, evaluateDefinitionStatus bool) {
 	specChanged := true
 	selectorChanged := true
 	if existing, ok := a.definitions[definition.Namespace]; ok {
@@ -244,30 +262,14 @@ func (a *AttachedConnector) definitionUpdated(definition *skupperv2alpha1.Attach
 				slog.String("namespace", definition.Namespace),
 				slog.String("name", definition.Name))
 			a.watchPods()
-			return false // not ready to configure until selector returns pods
+			return false, false // not ready to configure until selector returns pods
 		}
-		return specChanged && a.watcher != nil
-	} else if a.binding == nil {
-		if definition.SetConfigured(fmt.Errorf("No matching AttachedConnectorBinding in site namespace")) {
-			if err := a.updateDefinitionStatus(definition); err != nil {
-				a.parent.logger.Error("Error updating status for AttachedConnector",
-					slog.String("namespace", definition.Namespace),
-					slog.String("name", definition.Name),
-					slog.Any("error", err))
-			}
-		}
-		return false
-	} else {
-		if definition.SetConfigured(fmt.Errorf("AttachedConnectorBinding %s/%s does not allow AttachedConnector in %s (only %s)", a.binding.Namespace, a.binding.Name, definition.Namespace, a.binding.Spec.ConnectorNamespace)) {
-			if err := a.updateDefinitionStatus(definition); err != nil {
-				a.parent.logger.Error("Error updating status for AttachedConnector",
-					slog.String("namespace", definition.Namespace),
-					slog.String("name", definition.Name),
-					slog.Any("error", err))
-			}
-		}
-		return false
+		configure = specChanged && a.watcher != nil
+		return configure, configure
 	}
+	// Definitions without a binding, and definitions excluded by a binding,
+	// do not affect router configuration but do need status evaluation.
+	return false, true
 }
 
 func (a *AttachedConnector) bindingUpdated(binding *skupperv2alpha1.AttachedConnectorBinding) bool {

--- a/internal/kube/site/attached_connector.go
+++ b/internal/kube/site/attached_connector.go
@@ -236,7 +236,9 @@ func (a *AttachedConnector) definitionUpdated(definition *skupperv2alpha1.Attach
 	}
 	a.definitions[definition.Namespace] = definition
 	if a.binding != nil && a.binding.Spec.ConnectorNamespace == definition.Namespace {
-		isSiteActive := a.parent.site != nil && a.parent.site.IsInitialised()
+		// watch pods for Sites that are not yet initialised so an initial
+		// bridge configuration on recovery contains this connector's targets.
+		isSiteActive := a.parent.site != nil
 		if isSiteActive && (selectorChanged || a.watcher == nil) {
 			a.parent.logger.Info("Watching pods for AttachedConnector",
 				slog.String("namespace", definition.Namespace),

--- a/internal/kube/site/extended_bindings.go
+++ b/internal/kube/site/extended_bindings.go
@@ -50,8 +50,12 @@ func (a *ExtendedBindings) init(context BindingContext, config *qdr.RouterConfig
 	if a.mapping == nil {
 		a.mapping = qdr.RecoverPortMapping(config)
 	}
-	a.exposed = ExposedPorts{}
-	a.selectors = map[string]TargetSelection{}
+	if a.exposed == nil {
+		a.exposed = ExposedPorts{}
+	}
+	if a.selectors == nil {
+		a.selectors = map[string]TargetSelection{}
+	}
 	a.bindings.SetBindingEventHandler(a)
 	a.bindings.SetConnectorConfiguration(a.updateBridgeConfigForConnector)
 	a.bindings.SetListenerConfiguration(a.updateBridgeConfigForListener)

--- a/internal/kube/site/extended_bindings.go
+++ b/internal/kube/site/extended_bindings.go
@@ -479,6 +479,10 @@ func (b *ExtendedBindings) SetSite(site *Site) {
 }
 
 func (b *ExtendedBindings) checkAttachedConnectorBinding(namespace string, name string, binding *skupperv2alpha1.AttachedConnectorBinding) error {
+	return b.updateAttachedConnectorBinding(namespace, name, binding, true)
+}
+
+func (b *ExtendedBindings) updateAttachedConnectorBinding(namespace string, name string, binding *skupperv2alpha1.AttachedConnectorBinding, reconcile bool) error {
 	connector, ok := b.connectors[name]
 	if !ok {
 		connector = NewAttachedConnector(name, namespace, b)
@@ -496,6 +500,9 @@ func (b *ExtendedBindings) checkAttachedConnectorBinding(namespace string, name 
 		}
 	}
 	if (binding == nil && connector.bindingDeleted()) || (binding != nil && connector.bindingUpdated(binding)) {
+		if !reconcile {
+			return nil
+		}
 		if b.site != nil {
 			if err := b.site.updateRouterConfig(b.site.bindings); err != nil {
 				return connector.configurationError(err)
@@ -507,22 +514,51 @@ func (b *ExtendedBindings) checkAttachedConnectorBinding(namespace string, name 
 	return nil
 }
 
+func (b *ExtendedBindings) recoverAttachedConnectorBinding(binding *skupperv2alpha1.AttachedConnectorBinding) {
+	_ = b.updateAttachedConnectorBinding(binding.Namespace, binding.Name, binding, false)
+}
+
+func (b *ExtendedBindings) recoverAttachedConnector(definition *skupperv2alpha1.AttachedConnector) {
+	_ = b.updateAttachedConnector(definition.Name, definition, false)
+}
+
 func (b *ExtendedBindings) attachedConnectorUpdated(name string, definition *skupperv2alpha1.AttachedConnector) error {
+	return b.updateAttachedConnector(name, definition, true)
+}
+
+func (b *ExtendedBindings) updateAttachedConnector(name string, definition *skupperv2alpha1.AttachedConnector, reconcile bool) error {
 	connector, ok := b.connectors[name]
 	if !ok {
 		connector = NewAttachedConnector(name, definition.Spec.SiteNamespace, b)
 		b.connectors[name] = connector
 	}
-	if connector.definitionUpdated(definition) {
-		if b.site != nil {
-			if err := b.site.updateRouterConfig(b.site.bindings); err != nil {
-				return connector.configurationError(err)
-			} else {
-				return connector.updateStatus()
-			}
+	configure, evaluateDefinitionStatus := connector.definitionUpdated(definition)
+	if !reconcile {
+		return nil
+	}
+	if configure {
+		if b.site == nil {
+			return nil
 		}
+		if err := b.site.updateRouterConfig(b.site.bindings); err != nil {
+			return connector.configurationError(err)
+		}
+		return connector.updateStatus()
+	}
+	if evaluateDefinitionStatus {
+		connector.updateDefinitionStatusForCurrentBinding(definition)
 	}
 	return nil
+}
+
+func (b *ExtendedBindings) finishAttachedConnectorRecovery() error {
+	var errors []string
+	for _, connector := range b.connectors {
+		if err := connector.updateStatus(); err != nil {
+			errors = append(errors, err.Error())
+		}
+	}
+	return error_(errors)
 }
 
 func (b *ExtendedBindings) attachedConnectorDeleted(namespace string, name string) error {

--- a/internal/kube/site/extended_bindings.go
+++ b/internal/kube/site/extended_bindings.go
@@ -382,6 +382,14 @@ func (b *ExtendedBindings) GetConnector(name string) *skupperv2alpha1.Connector 
 	return b.bindings.GetConnector(name)
 }
 
+func (b *ExtendedBindings) selectedPods(name string) ([]skupperv2alpha1.PodDetails, bool) {
+	selector, ok := b.selectors[name]
+	if !ok || selector == nil {
+		return nil, false
+	}
+	return selector.List(), true
+}
+
 func (b *ExtendedBindings) Map(cf site.ConnectorFunction, lf site.ListenerFunction) {
 	b.bindings.Map(cf, lf)
 }

--- a/internal/kube/site/site.go
+++ b/internal/kube/site/site.go
@@ -1805,6 +1805,24 @@ func (s *Site) CheckAttachedConnectorBinding(namespace string, name string, bind
 	return s.bindings.checkAttachedConnectorBinding(namespace, name, binding)
 }
 
+// RecoverAttachedConnectorBinding loads a binding without evaluating status
+// until the rest of the attached connector state has been recovered.
+func (s *Site) RecoverAttachedConnectorBinding(binding *skupperv2alpha1.AttachedConnectorBinding) {
+	s.bindings.recoverAttachedConnectorBinding(binding)
+}
+
+// RecoverAttachedConnector loads a definition and starts its pod watcher
+// without evaluating status from partially recovered state.
+func (s *Site) RecoverAttachedConnector(connector *skupperv2alpha1.AttachedConnector) {
+	s.bindings.recoverAttachedConnector(connector)
+}
+
+// FinishAttachedConnectorRecovery evaluates status after all definitions and
+// bindings have been loaded and their pod watchers have synchronized.
+func (s *Site) FinishAttachedConnectorRecovery() error {
+	return s.bindings.finishAttachedConnectorRecovery()
+}
+
 func (s *Site) AttachedConnectorUpdated(connector *skupperv2alpha1.AttachedConnector) error {
 	return s.bindings.attachedConnectorUpdated(connector.Name, connector)
 }

--- a/internal/kube/site/site.go
+++ b/internal/kube/site/site.go
@@ -127,6 +127,11 @@ func (s *Site) CheckLeadListeners(listener *skupperv2alpha1.Listener) bool {
 	return false
 }
 
+// StartRecovery prepares the site for controller startup: it recovers the
+// existing router config and sets up site resources, but leaves the site
+// uninitialised. While uninitialised, bindings, router access etc. can be
+// recovered without triggering router config writes. The recovery process ends
+// when Reconcile() is called.
 func (s *Site) StartRecovery(site *skupperv2alpha1.Site) error {
 	if err := s.migrateRouterDeploymentSelectors(context.TODO(), site); err != nil {
 		return err
@@ -192,12 +197,28 @@ const PROXY_PROFILE_PATH = "/etc/skupper-router-proxies"
 
 func (s *Site) Reconcile(siteDef *skupperv2alpha1.Site) error {
 	err := s.reconcile(siteDef, false)
-	return s.updateConfigured(err)
+	if err := s.updateConfigured(err); err != nil {
+		return err
+	}
+	if len(s.linkAccess) == 0 {
+		return nil
+	}
+	return s.updateResolved()
 }
 
 func (s *Site) reconcile(siteDef *skupperv2alpha1.Site, inRecovery bool) error {
 	if s.site != nil && s.site.Name != siteDef.Name {
 		return s.markSiteInactive(siteDef, fmt.Errorf("An active site already exists in the namespace (%s)", s.site.Name))
+	}
+	// Informer copies can lag our own site status updates; conditions are only
+	// ever set, never removed. Carry over any conditions the incoming copy
+	// is missing to avoid conflicts.
+	if s.site != nil && s.site.UID == siteDef.UID {
+		for _, condition := range s.site.Status.Conditions {
+			if meta.FindStatusCondition(siteDef.Status.Conditions, condition.Type) == nil {
+				meta.SetStatusCondition(&siteDef.Status.Conditions, condition)
+			}
+		}
 	}
 	s.site = siteDef
 	s.name = string(siteDef.ObjectMeta.Name)
@@ -224,7 +245,12 @@ func (s *Site) reconcile(siteDef *skupperv2alpha1.Site, inRecovery bool) error {
 		if len(routerConfigs) > 0 {
 			routerConfig = routerConfigs[0]
 		}
-		s.initialised = true
+		// While recovering, the site stays uninitialised so that recovery
+		// of bindings, router access etc. does not write partial router
+		// config. The controller's final Reconcile re-enters this branch
+		// with inRecovery=false and recoverRouterConfig performs a single
+		// complete write from the fully recovered state.
+		s.initialised = !inRecovery
 		s.currentGroups = s.groups()
 		s.bindings.init(s, routerConfig)
 		s.setBindingsConfiguredStatus(nil)
@@ -1494,9 +1520,47 @@ func (s *Site) CheckSslAndProxyProfiles(config *qdr.RouterConfig) error {
 }
 
 func (s *Site) NetworkStatusUpdated(network []skupperv2alpha1.SiteRecord) error {
-	if s.site == nil || reflect.DeepEqual(s.site.Status.Network, network) {
+	if s.site == nil {
 		return nil
 	}
+	// Only the site status update can be skipped when the network is
+	// unchanged; the binding related handling below must still run so
+	// that in-memory state (e.g. targets for listeners with
+	// exposePodsByName) is derived from the network on controller
+	// recovery, where the recovered status already matches.
+	if !reflect.DeepEqual(s.site.Status.Network, network) {
+		if err := s.updateNetworkStatus(network); err != nil {
+			return err
+		}
+	}
+
+	// find the site record for this site, then process the link records it contains
+	linkRecords := internalnetwork.GetLinkRecordsForSite(s.site.GetSiteId(), network)
+	for _, linkRecord := range linkRecords {
+		if link, ok := s.links[linkRecord.Name]; ok {
+			if err := s.updateLinkOperationalCondition(link.Definition(), linkRecord.Operational, linkRecord.RemoteSiteId, linkRecord.RemoteSiteName); err != nil {
+				s.logger.Error("Error updating operational status of link",
+					slog.String("namespace", s.site.Namespace),
+					slog.String("link", linkRecord.Name),
+					slog.Any("error", err))
+			}
+		}
+	}
+	if config := s.bindings.networkUpdated(network); config != nil {
+		if err := s.updateRouterConfig(config); err != nil {
+			return err
+		}
+	}
+
+	bindingStatus := newBindingStatus(s.clients, network)
+	s.bindings.Map(bindingStatus.updateMatchingListenerCount, bindingStatus.updateMatchingConnectorCount)
+	s.bindings.MapOverMultiKeyListeners(bindingStatus.updateMultiKeyListenerDestination)
+	s.logger.Debug("Updating matching listeners for attached connectors")
+	s.bindings.MapOverAttachedConnectors(bindingStatus.updateMatchingListenerCountForAttachedConnector)
+	return bindingStatus.error()
+}
+
+func (s *Site) updateNetworkStatus(network []skupperv2alpha1.SiteRecord) error {
 	prev := s.site.DeepCopy()
 	s.site.Status.Network = network
 	s.site.Status.SitesInNetwork = len(network)
@@ -1528,31 +1592,7 @@ func (s *Site) NetworkStatusUpdated(network []skupperv2alpha1.SiteRecord) error 
 		}
 		s.site = updated
 	}
-
-	// find the site record for this site, then process the link records it contains
-	linkRecords := internalnetwork.GetLinkRecordsForSite(s.site.GetSiteId(), network)
-	for _, linkRecord := range linkRecords {
-		if link, ok := s.links[linkRecord.Name]; ok {
-			if err := s.updateLinkOperationalCondition(link.Definition(), linkRecord.Operational, linkRecord.RemoteSiteId, linkRecord.RemoteSiteName); err != nil {
-				s.logger.Error("Error updating operational status of link",
-					slog.String("namespace", s.site.Namespace),
-					slog.String("link", linkRecord.Name),
-					slog.Any("error", err))
-			}
-		}
-	}
-	if config := s.bindings.networkUpdated(network); config != nil {
-		if err := s.updateRouterConfig(config); err != nil {
-			return err
-		}
-	}
-
-	bindingStatus := newBindingStatus(s.clients, network)
-	s.bindings.Map(bindingStatus.updateMatchingListenerCount, bindingStatus.updateMatchingConnectorCount)
-	s.bindings.MapOverMultiKeyListeners(bindingStatus.updateMultiKeyListenerDestination)
-	s.logger.Debug("Updating matching listeners for attached connectors")
-	s.bindings.MapOverAttachedConnectors(bindingStatus.updateMatchingListenerCountForAttachedConnector)
-	return bindingStatus.error()
+	return nil
 }
 
 func (s *Site) markSiteInactive(site *skupperv2alpha1.Site, err error) error {

--- a/internal/kube/site/site.go
+++ b/internal/kube/site/site.go
@@ -1258,7 +1258,8 @@ func (s *Site) updateMultiKeyListenerStatus(mkl *skupperv2alpha1.MultiKeyListene
 
 func (s *Site) setBindingsConfiguredStatus(err error) {
 	lf := func(listener *skupperv2alpha1.Listener) *skupperv2alpha1.Listener {
-		if listener.SetConfigured(nil) {
+		configuredErr := stderrors.Join(err, s.missingTlsCredentialsErr(listener.Spec.TlsCredentials))
+		if listener.SetConfigured(configuredErr) {
 			updated, err := s.clients.GetSkupperClient().SkupperV2alpha1().Listeners(listener.ObjectMeta.Namespace).UpdateStatus(context.TODO(), listener, metav1.UpdateOptions{})
 			if err == nil {
 				return updated
@@ -1272,7 +1273,19 @@ func (s *Site) setBindingsConfiguredStatus(err error) {
 		return nil
 	}
 	cf := func(connector *skupperv2alpha1.Connector) *skupperv2alpha1.Connector {
-		if connector.SetConfigured(nil) {
+		configuredErr := stderrors.Join(err, s.missingTlsCredentialsErr(connector.Spec.TlsCredentials))
+		if connector.Spec.Selector != "" {
+			selected, ok := s.bindings.selectedPods(connector.Name)
+			if !ok && configuredErr == nil {
+				// Without a synchronized target selection there is no authoritative
+				// status to replace the persisted status with.
+				return nil
+			}
+			if ok && len(selected) == 0 {
+				configuredErr = stderrors.Join(configuredErr, stderrors.New("No matches for selector"))
+			}
+		}
+		if connector.SetConfigured(configuredErr) {
 			updated, err := s.clients.GetSkupperClient().SkupperV2alpha1().Connectors(connector.ObjectMeta.Namespace).UpdateStatus(context.TODO(), connector, metav1.UpdateOptions{})
 			if err == nil {
 				return updated

--- a/internal/kube/site/site_test.go
+++ b/internal/kube/site/site_test.go
@@ -1373,6 +1373,9 @@ func Test_CheckSecuredAccess(t *testing.T) {
 						t.Fatal(err)
 					}
 				}
+				if err := s.Reconcile(s.site); err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			if err := s.CheckSecuredAccess(tt.args.name, tt.args.sa); err != nil {


### PR DESCRIPTION
Expand the controller and Site initialization process. Attempt to fully recover state before considering a Site initialized and writing configuration.

Fixes https://github.com/skupperproject/skupper/issues/2504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller recovery for listeners, connectors, bindings, router network status, and existing router bridge configuration.
  * Prevented attached connector status from unnecessarily flapping during recovery.
  * Improved configured-status reporting for missing TLS credentials and unavailable connector selector pods.
  * Preserved existing site status conditions and deferred partial router updates until recovery completes.

* **Reliability**
  * Added additional recovery synchronization to ensure resources are ready before site reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->