### PR TITLE
Added check so edge sites can't have HA enabled

### DIFF
--- a/internal/kube/site/site.go
+++ b/internal/kube/site/site.go
@@ -116,6 +116,9 @@ func (s *Site) verifySiteSpec(site *skupperv2alpha1.Site) error {
 	if site.Spec.LinkAccess != "" && site.Spec.LinkAccess != "none" && site.Spec.LinkAccess != "default" && !s.access.IsValidAccessType(site.Spec.LinkAccess) {
 		return fmt.Errorf("Unsupported value for LinkAccess: %s", site.Spec.LinkAccess)
 	}
+	if site.Spec.Edge && site.Spec.HA {
+		return fmt.Errorf("Edge sites cannot have HA enabled")
+	}
 	return nil
 }
 

--- a/internal/kube/site/site_test.go
+++ b/internal/kube/site/site_test.go
@@ -1100,6 +1100,53 @@ func TestSite_CheckLink(t *testing.T) {
 	}
 }
 
+func TestSite_verifySiteSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    skupperv2alpha1.SiteSpec
+		wantErr string
+	}{
+		{
+			name: "empty spec",
+			spec: skupperv2alpha1.SiteSpec{},
+		},
+		{
+			name: "edge without ha",
+			spec: skupperv2alpha1.SiteSpec{Edge: true},
+		},
+		{
+			name: "ha without edge",
+			spec: skupperv2alpha1.SiteSpec{HA: true},
+		},
+		{
+			name:    "edge with ha",
+			spec:    skupperv2alpha1.SiteSpec{Edge: true, HA: true},
+			wantErr: "Edge sites cannot have HA enabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := newSiteMocks("test", nil, nil, "", false)
+			assert.Assert(t, err)
+
+			site := &skupperv2alpha1.Site{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "site1",
+					Namespace: "test",
+				},
+				Spec: tt.spec,
+			}
+			err = s.verifySiteSpec(site)
+			if tt.wantErr == "" {
+				assert.Assert(t, err)
+			} else {
+				assert.Error(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestSite_CheckRouterAccess(t *testing.T) {
 	type args struct {
 		name string

--- a/internal/nonkube/common/site_state_validator.go
+++ b/internal/nonkube/common/site_state_validator.go
@@ -68,6 +68,9 @@ func (s *SiteStateValidator) validateSite(site *v2alpha1.Site) error {
 	if err := ValidateName(site.Name); err != nil {
 		return fmt.Errorf("invalid site name: %w", err)
 	}
+	if site.Spec.Edge && site.Spec.HA {
+		return fmt.Errorf("invalid site %q: edge sites cannot have HA enabled", site.Name)
+	}
 	return nil
 }
 

--- a/internal/nonkube/common/site_state_validator_test.go
+++ b/internal/nonkube/common/site_state_validator_test.go
@@ -27,6 +27,29 @@ func TestSiteStateValidator_Validate(t *testing.T) {
 			errorContains: "invalid site name:",
 		},
 		{
+			info: "invalid-site-edge-with-ha",
+			siteState: customize(func(siteState *api.SiteState) {
+				siteState.Site.Spec.Edge = true
+				siteState.Site.Spec.HA = true
+			}),
+			valid:         false,
+			errorContains: "edge sites cannot have HA enabled",
+		},
+		{
+			info: "valid-site-edge-without-ha",
+			siteState: customize(func(siteState *api.SiteState) {
+				siteState.Site.Spec.Edge = true
+			}),
+			valid: true,
+		},
+		{
+			info: "valid-site-ha-without-edge",
+			siteState: customize(func(siteState *api.SiteState) {
+				siteState.Site.Spec.HA = true
+			}),
+			valid: true,
+		},
+		{
 			info: "invalid-link-access-name",
 			siteState: customize(func(siteState *api.SiteState) {
 				for _, la := range siteState.RouterAccesses {


### PR DESCRIPTION
Addresses #2536 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject site configurations where both Edge and high availability are enabled at the same time.
  * Improved configuration feedback with a clear error message naming the invalid combination.

* **Tests**
  * Expanded test coverage to verify acceptance of valid Edge-only and HA-only configurations.
  * Added a failing-case test for the invalid Edge+HA combination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->