### PR TITLE
Fix eventsource.Manager record sender

### DIFF
--- a/pkg/vanflow/eventsource/manager.go
+++ b/pkg/vanflow/eventsource/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync"
 	"time"
 
 	amqp "github.com/Azure/go-amqp"
@@ -11,6 +12,14 @@ import (
 	"github.com/skupperproject/skupper/pkg/vanflow/encoding"
 	"github.com/skupperproject/skupper/pkg/vanflow/session"
 	"github.com/skupperproject/skupper/pkg/vanflow/store"
+)
+
+const (
+	// recordSendTimeout bounds a single attempt to send a record message.
+	recordSendTimeout = 5 * time.Second
+	// recordSendRetryDelay is the pause before retrying a failed record
+	// message send.
+	recordSendRetryDelay = time.Second
 )
 
 type ManagerConfig struct {
@@ -42,6 +51,13 @@ type ManagerConfig struct {
 	UpdateBatchSize int
 }
 
+func (c ManagerConfig) updateBatchSize() int {
+	if c.UpdateBatchSize < 1 {
+		return 1
+	}
+	return c.UpdateBatchSize
+}
+
 type RecordUpdate struct {
 	Prev vanflow.Record
 	Curr vanflow.Record
@@ -51,9 +67,12 @@ type Manager struct {
 	ManagerConfig
 	container session.Container
 
-	flushQueue  chan struct{}
-	changeQueue chan RecordUpdate
-	sendQueue   chan vanflow.RecordMessage
+	notify chan struct{}
+
+	mu           sync.Mutex
+	pending      map[string]RecordUpdate
+	pendingSince time.Time
+	flushAt      *time.Time
 
 	logger *slog.Logger
 }
@@ -62,9 +81,8 @@ func NewManager(container session.Container, cfg ManagerConfig) *Manager {
 	return &Manager{
 		container:     container,
 		ManagerConfig: cfg,
-		flushQueue:    make(chan struct{}, 8),
-		changeQueue:   make(chan RecordUpdate, 256),
-		sendQueue:     make(chan vanflow.RecordMessage, 256),
+		notify:        make(chan struct{}, 1),
+		pending:       make(map[string]RecordUpdate),
 		logger: slog.New(slog.Default().Handler()).With(
 			slog.String("component", "vanflow.eventsource.manager"),
 			slog.String("instance", cfg.Source.ID),
@@ -72,37 +90,236 @@ func NewManager(container session.Container, cfg ManagerConfig) *Manager {
 	}
 }
 
+// PublishUpdate queues a record update for delivery.
 func (m *Manager) PublishUpdate(update RecordUpdate) {
-	m.changeQueue <- update
+	if update.Curr == nil {
+		return
+	}
+	id := update.Curr.Identity()
+
+	m.mu.Lock()
+	// squash existing updates
+	if prior, ok := m.pending[id]; ok {
+		update.Prev = prior.Prev
+	}
+	m.pending[id] = update
+	if m.pendingSince.IsZero() {
+		m.pendingSince = time.Now()
+	}
+	m.mu.Unlock()
+
+	m.signalWorkAvailable()
+}
+
+func (m *Manager) signalWorkAvailable() {
+	select {
+	case m.notify <- struct{}{}:
+	default:
+	}
 }
 
 func (m *Manager) Run(ctx context.Context) {
 	go m.listenFlushes(ctx)
 	go m.sendKeepalives(ctx)
-	go m.sendRecords(ctx)
-	m.serve(ctx)
+	m.sendRecords(ctx)
 }
 
 func (m *Manager) sendRecords(ctx context.Context) {
 	sender := m.container.NewSender(m.Source.Address, session.SenderOptions{})
 	defer sender.Close(ctx)
+
+	var retryIn time.Duration
 	for {
-		select {
-		case <-ctx.Done():
+		if !m.awaitSendWork(ctx, retryIn) {
 			return
-		case record := <-m.sendQueue:
-			msg, err := record.Encode()
-			if err != nil {
-				m.logger.Error("skipping record message after encoding error:", slog.Any("error", err))
-				continue
+		}
+		retryIn = 0
+
+		if m.flushDue(time.Now()) {
+			if err := m.streamFlush(ctx, sender); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				m.requestFlush()
+				retryIn = recordSendRetryDelay
+				m.logger.Error("error sending flush record message. retrying",
+					slog.Any("error", err))
 			}
-			if err := sender.Send(ctx, msg); err != nil {
-				m.logger.Error("error sending event source record", slog.Any("error", err))
-				continue
+			continue
+		}
+
+		batch := m.take(m.updateBatchSize())
+		msg, included := m.encodeUpdates(batch)
+		if msg == nil {
+			continue
+		}
+		if err := sendWithTimeout(ctx, recordSendTimeout, sender, msg); err != nil {
+			if ctx.Err() != nil {
+				return
 			}
-			m.logger.Info("record message sent", slog.Int("record_count", len(record.Records)))
+			m.requeue(included)
+			retryIn = recordSendRetryDelay
+			m.logger.Error("error sending record message. retrying",
+				slog.Any("error", err),
+				slog.Int("record_count", len(included)))
+			continue
+		}
+		m.logger.Info("record message sent", slog.Int("record_count", len(included)))
+	}
+}
+
+// awaitSendWork blocks until the record sender has a flush or records due
+// returns false when context is cancelled first.
+func (m *Manager) awaitSendWork(ctx context.Context, retryIn time.Duration) bool {
+	if retryIn > 0 {
+		return sleep(ctx, retryIn)
+	}
+	for {
+		wait, ready := m.workState(time.Now())
+		switch {
+		case ready:
+			return true
+		case wait > 0:
+			// There is work, but it is not due yet. Try again after a delay or
+			// notify signal.
+			if !m.waitFor(ctx, wait) {
+				return false
+			}
+		default:
+			select {
+			case <-ctx.Done():
+				return false
+			case <-m.notify:
+			}
 		}
 	}
+}
+
+// waitFor waits up to d for notify signal. Returns false when the context was
+// cancelled first.
+func (m *Manager) waitFor(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+	case <-m.notify:
+	}
+	return true
+}
+
+// workState reports whether the record sender should run now, or how long to
+// wait before asking again. A zero wait with ready false means there is
+// nothing outstanding.
+func (m *Manager) workState(now time.Time) (wait time.Duration, ready bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var flushWait time.Duration
+	if m.flushAt != nil {
+		if !now.Before(*m.flushAt) {
+			return 0, true
+		}
+		flushWait = m.flushAt.Sub(now)
+	}
+
+	// Queued updates are still served while a flush waits out its delay
+	updateWait, updateReady := m.updateWorkState(now)
+	switch {
+	case updateReady:
+		return 0, true
+	case updateWait > 0 && (flushWait == 0 || updateWait < flushWait):
+		return updateWait, false
+	default:
+		return flushWait, false
+	}
+}
+
+// updateWorkState reports the state of the pending updates. Callers must hold
+// the manager lock.
+func (m *Manager) updateWorkState(now time.Time) (wait time.Duration, ready bool) {
+	if len(m.pending) == 0 {
+		return 0, false
+	}
+	if m.UpdateBufferTime <= 0 || len(m.pending) >= m.updateBatchSize() {
+		return 0, true
+	}
+	if elapsed := now.Sub(m.pendingSince); elapsed < m.UpdateBufferTime {
+		return m.UpdateBufferTime - elapsed, false
+	}
+	return 0, true
+}
+
+// take removes up to limit updates from the pending set.
+func (m *Manager) take(limit int) []RecordUpdate {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if limit > len(m.pending) {
+		limit = len(m.pending)
+	}
+	if limit < 1 {
+		return nil
+	}
+	batch := make([]RecordUpdate, 0, limit)
+	for id, update := range m.pending {
+		batch = append(batch, update)
+		delete(m.pending, id)
+		if len(batch) == limit {
+			break
+		}
+	}
+	if len(m.pending) == 0 {
+		m.pendingSince = time.Time{}
+	}
+	return batch
+}
+
+// requeue returns a batch that failed to send to the pending set.
+func (m *Manager) requeue(batch []RecordUpdate) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, failed := range batch {
+		id := failed.Curr.Identity()
+		if current, ok := m.pending[id]; ok {
+			failed = current
+		}
+		// a failed send has an uncertain outcome. Do not presume prior state.
+		failed.Prev = nil
+		m.pending[id] = failed
+	}
+	if m.pendingSince.IsZero() {
+		m.pendingSince = time.Now()
+	}
+}
+
+// encodeUpdates encodes the updates containing a delta into a message. Returns
+// a message and the included record updates
+func (m *Manager) encodeUpdates(batch []RecordUpdate) (*amqp.Message, []RecordUpdate) {
+	var (
+		records  []vanflow.Record
+		included []RecordUpdate
+	)
+	for _, update := range batch {
+		delta, changed := m.diffRecord(update)
+		if !changed {
+			continue
+		}
+		records = append(records, delta)
+		included = append(included, update)
+	}
+	if len(records) == 0 {
+		m.logger.Debug("record updates buffered but none were changed", slog.Int("record_count", len(batch)))
+		return nil, nil
+	}
+	msg, err := vanflow.RecordMessage{Records: records}.Encode()
+	if err != nil {
+		m.logger.Error("skipping record message after encoding error",
+			slog.Any("error", err),
+			slog.Int("record_count", len(records)))
+		return nil, nil
+	}
+	return msg, included
 }
 
 func (m *Manager) diffRecord(d RecordUpdate) (vanflow.Record, bool) {
@@ -148,77 +365,57 @@ func (m *Manager) diffRecord(d RecordUpdate) (vanflow.Record, bool) {
 	return deltaRecord.(vanflow.Record), true
 }
 
-func (m *Manager) serve(ctx context.Context) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case update := <-m.changeQueue:
-			var buffer []RecordUpdate
-			if m.UpdateBufferTime > 0 && m.UpdateBatchSize > 1 {
-				bufferCtx, cancelBuffer := context.WithTimeout(ctx, m.UpdateBufferTime)
-				buffer = nextN(bufferCtx, m.changeQueue, m.UpdateBatchSize-1)
-				cancelBuffer()
-				if ctx.Err() != nil {
-					return
-				}
-			}
-			buffer = append([]RecordUpdate{update}, buffer...)
+// requestFlush schedules a flush of all store contents.
+func (m *Manager) requestFlush() {
+	m.mu.Lock()
+	if m.flushAt == nil {
+		at := time.Now().Add(m.FlushDelay)
+		m.flushAt = &at
+	}
+	m.mu.Unlock()
+	m.signalWorkAvailable()
+}
 
-			var record vanflow.RecordMessage
-			record.Records = make([]vanflow.Record, 0, len(buffer))
-			for _, update := range buffer {
-				delta, changed := m.diffRecord(update)
-				if !changed {
-					continue
-				}
-				record.Records = append(record.Records, delta)
+func (m *Manager) flushDue(now time.Time) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.flushAt != nil && !now.Before(*m.flushAt)
+}
+
+// streamFlush sends the contents of every store as a series of batched record
+// messages.
+func (m *Manager) streamFlush(ctx context.Context, sender session.Sender) error {
+	m.mu.Lock()
+	m.flushAt = nil
+	m.mu.Unlock()
+
+	m.logger.Info("servicing flush", slog.String("source", m.Source.ID))
+	for _, stor := range m.Stores {
+		entries := stor.List()
+		for len(entries) > 0 {
+			batch := entries
+			if n := m.FlushBatchSize; n > 0 && len(batch) > n {
+				batch = batch[:n]
 			}
-			if len(record.Records) == 0 {
-				m.logger.Debug("record changes buffered but none were changed", slog.Int("record_count", len(buffer)))
+			entries = entries[len(batch):]
+
+			records := make([]vanflow.Record, len(batch))
+			for i, entry := range batch {
+				records[i] = entry.Record
+			}
+			msg, err := vanflow.RecordMessage{Records: records}.Encode()
+			if err != nil {
+				m.logger.Error("skipping flush record message after encoding error",
+					slog.Any("error", err),
+					slog.Int("record_count", len(records)))
 				continue
 			}
-			select {
-			case <-ctx.Done():
-				return
-			case m.sendQueue <- record:
-			}
-
-		case <-m.flushQueue:
-			// handle a flush
-			if m.FlushDelay > 0 {
-				drainCtx, cancelDrain := context.WithTimeout(ctx, m.FlushDelay)
-				nextN(drainCtx, m.flushQueue, 2048)
-				cancelDrain()
-				if ctx.Err() != nil {
-					return
-				}
-			}
-			m.logger.Info("servicing flush", slog.String("source", m.Source.ID))
-			for _, stor := range m.Stores {
-				entries := stor.List()
-
-				for len(entries) > 0 {
-					var batch []store.Entry
-					batch, entries = entries, entries[:0]
-					if len(batch) > m.FlushBatchSize && m.FlushBatchSize > 0 {
-						batch, entries = batch[:m.FlushBatchSize], batch[m.FlushBatchSize:]
-					}
-
-					var record vanflow.RecordMessage
-					record.Records = make([]vanflow.Record, len(batch))
-					for i, entry := range batch {
-						record.Records[i] = entry.Record
-					}
-					select {
-					case <-ctx.Done():
-						return
-					case m.sendQueue <- record:
-					}
-				}
+			if err := sendWithTimeout(ctx, recordSendTimeout, sender, msg); err != nil {
+				return err
 			}
 		}
 	}
+	return nil
 }
 
 func (m *Manager) sendKeepalives(ctx context.Context) {
@@ -320,12 +517,10 @@ func (m *Manager) listenFlushes(ctx context.Context) {
 				return
 			}
 			m.logger.Error("flush receive error", slog.Any("error", err))
+			continue
 		}
 		flushReceiver.Accept(ctx, msg)
-		select {
-		case m.flushQueue <- struct{}{}:
-		default: // drop flush if queue is full
-		}
+		m.requestFlush()
 	}
 }
 
@@ -343,21 +538,13 @@ func sendWithTimeout(ctx context.Context, timeout time.Duration, sender session.
 	return err
 }
 
-// pulls next N items from a channel
-func nextN[T any](ctx context.Context, c <-chan T, n int) []T {
-	var out []T
-	if n < 1 {
-		return out
-	}
-	for {
-		select {
-		case <-ctx.Done():
-			return out
-		case t := <-c:
-			out = append(out, t)
-			if len(out) == n {
-				return out
-			}
-		}
+func sleep(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
 	}
 }

--- a/pkg/vanflow/eventsource/manager.go
+++ b/pkg/vanflow/eventsource/manager.go
@@ -128,12 +128,12 @@ func (m *Manager) sendRecords(ctx context.Context) {
 	sender := m.container.NewSender(m.Source.Address, session.SenderOptions{})
 	defer sender.Close(ctx)
 
-	var retryIn time.Duration
+	var retryAfter time.Duration
 	for {
-		if !m.awaitSendWork(ctx, retryIn) {
+		if !m.awaitSendWork(ctx, retryAfter) {
 			return
 		}
-		retryIn = 0
+		retryAfter = 0
 
 		if m.flushDue(time.Now()) {
 			if err := m.streamFlush(ctx, sender); err != nil {
@@ -141,7 +141,7 @@ func (m *Manager) sendRecords(ctx context.Context) {
 					return
 				}
 				m.requestFlush()
-				retryIn = recordSendRetryDelay
+				retryAfter = recordSendRetryDelay
 				m.logger.Error("error sending flush record message. retrying",
 					slog.Any("error", err))
 			}
@@ -158,7 +158,7 @@ func (m *Manager) sendRecords(ctx context.Context) {
 				return
 			}
 			m.requeue(included)
-			retryIn = recordSendRetryDelay
+			retryAfter = recordSendRetryDelay
 			m.logger.Error("error sending record message. retrying",
 				slog.Any("error", err),
 				slog.Int("record_count", len(included)))
@@ -170,9 +170,9 @@ func (m *Manager) sendRecords(ctx context.Context) {
 
 // awaitSendWork blocks until the record sender has a flush or records due
 // returns false when context is cancelled first.
-func (m *Manager) awaitSendWork(ctx context.Context, retryIn time.Duration) bool {
-	if retryIn > 0 {
-		return sleep(ctx, retryIn)
+func (m *Manager) awaitSendWork(ctx context.Context, retryAfter time.Duration) bool {
+	if retryAfter > 0 {
+		return sleep(ctx, retryAfter)
 	}
 	for {
 		wait, ready := m.workState(time.Now())

--- a/pkg/vanflow/eventsource/manager_scheduler_test.go
+++ b/pkg/vanflow/eventsource/manager_scheduler_test.go
@@ -1,0 +1,520 @@
+package eventsource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	amqp "github.com/Azure/go-amqp"
+	"github.com/google/go-cmp/cmp"
+	"github.com/skupperproject/skupper/pkg/vanflow"
+	"github.com/skupperproject/skupper/pkg/vanflow/session"
+	"github.com/skupperproject/skupper/pkg/vanflow/store"
+)
+
+func TestManagerSquashesDuplicateUpdates(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const updateDelay = 5 * time.Second
+		manager, sender := newSchedulerTestManager(ManagerConfig{
+			UpdateBufferTime: updateDelay,
+			UpdateBatchSize:  2,
+		})
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go manager.sendRecords(ctx)
+		synctest.Wait()
+
+		originalText, latestText := "original", "latest"
+		initialSeverity, latestSeverity := uint64(1), uint64(2)
+		initial := vanflow.LogRecord{
+			BaseRecord:  vanflow.NewBase("record"),
+			LogSeverity: &initialSeverity,
+			LogText:     &originalText,
+		}
+		middle := initial
+		middle.LogSeverity = &latestSeverity
+		manager.PublishUpdate(RecordUpdate{Prev: initial, Curr: middle})
+		synctest.Wait()
+		assertSendAttempts(t, sender, 0)
+
+		// A second update for the same identity neither fills the batch nor
+		// restarts the buffer delay.
+		time.Sleep(updateDelay - time.Second)
+		final := middle
+		final.LogText = &latestText
+		manager.PublishUpdate(RecordUpdate{Prev: middle, Curr: final})
+		synctest.Wait()
+		assertSendAttempts(t, sender, 0)
+
+		time.Sleep(time.Second - time.Millisecond)
+		synctest.Wait()
+		assertSendAttempts(t, sender, 0)
+
+		time.Sleep(time.Millisecond)
+		synctest.Wait()
+		messages := sender.recordMessages(t)
+		if len(messages) != 1 || len(messages[0].Records) != 1 {
+			t.Fatalf("expected one message containing one squashed update, got %+v", messages)
+		}
+		want := vanflow.LogRecord{
+			BaseRecord:  vanflow.NewBase("record"),
+			LogSeverity: &latestSeverity,
+			LogText:     &latestText,
+		}
+		if diff := cmp.Diff(want, messages[0].Records[0]); diff != "" {
+			t.Errorf("unexpected squashed update (-want +got):\n%s", diff)
+		}
+
+		down, up := "down", "up"
+		linkDown := vanflow.LinkRecord{
+			BaseRecord: vanflow.NewBase("link"),
+			Status:     &down,
+		}
+		linkUp := linkDown
+		linkUp.Status = &up
+		manager.PublishUpdate(RecordUpdate{Prev: linkDown, Curr: linkUp})
+		manager.PublishUpdate(RecordUpdate{Prev: linkUp, Curr: linkDown})
+		synctest.Wait()
+		assertSendAttempts(t, sender, 1)
+
+		time.Sleep(updateDelay)
+		synctest.Wait()
+		assertSendAttempts(t, sender, 1)
+		if got := managerPendingLen(manager); got != 0 {
+			t.Errorf("expected cancelled-out link updates to be drained: got %d pending", got)
+		}
+	})
+}
+
+func TestManagerSchedulesBufferedUpdatesBeforeDelayedFlush(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			updateDelay = 5 * time.Second
+			flushDelay  = 10 * time.Second
+		)
+		stor := store.NewSyncMapStore(store.SyncMapStoreConfig{})
+		stor.Add(managerTestRecord("stored"), store.SourceRef{ID: "source"})
+
+		manager, sender := newSchedulerTestManager(ManagerConfig{
+			Stores:           []store.Interface{stor},
+			UpdateBufferTime: updateDelay,
+			UpdateBatchSize:  2,
+			FlushDelay:       flushDelay,
+		})
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go manager.sendRecords(ctx)
+		synctest.Wait()
+
+		manager.requestFlush()
+		manager.PublishUpdate(RecordUpdate{Curr: managerTestRecord("updated")})
+		synctest.Wait()
+		assertSendAttempts(t, sender, 0)
+
+		time.Sleep(updateDelay - time.Millisecond)
+		synctest.Wait()
+		assertSendAttempts(t, sender, 0)
+
+		time.Sleep(time.Millisecond)
+		synctest.Wait()
+		assertMessageRecordIDs(t, sender, []string{"updated"})
+
+		time.Sleep(flushDelay - updateDelay - time.Millisecond)
+		synctest.Wait()
+		assertSendAttempts(t, sender, 1)
+
+		time.Sleep(time.Millisecond)
+		synctest.Wait()
+		assertMessageRecordIDs(t, sender, []string{"updated"}, []string{"stored"})
+	})
+}
+
+func TestManagerSendsFullUpdateBatchWithoutWaiting(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		manager, sender := newSchedulerTestManager(ManagerConfig{
+			UpdateBufferTime: time.Hour,
+			UpdateBatchSize:  2,
+		})
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go manager.sendRecords(ctx)
+		synctest.Wait()
+
+		manager.PublishUpdate(RecordUpdate{Curr: managerTestRecord("one")})
+		synctest.Wait()
+		assertSendAttempts(t, sender, 0)
+
+		manager.PublishUpdate(RecordUpdate{Curr: managerTestRecord("two")})
+		synctest.Wait()
+		assertMessageRecordIDs(t, sender, []string{"one", "two"})
+	})
+}
+
+func TestManagerFlushesInConfiguredBatchSizes(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		stor := store.NewSyncMapStore(store.SyncMapStoreConfig{})
+		for i := range 5 {
+			stor.Add(managerTestRecord(fmt.Sprintf("record-%d", i)), store.SourceRef{ID: "source"})
+		}
+		manager, sender := newSchedulerTestManager(ManagerConfig{
+			Stores:         []store.Interface{stor},
+			FlushBatchSize: 2,
+		})
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go manager.sendRecords(ctx)
+		synctest.Wait()
+
+		manager.requestFlush()
+		synctest.Wait()
+
+		messages := sender.recordMessages(t)
+		got := make([]int, len(messages))
+		for i, message := range messages {
+			got[i] = len(message.Records)
+		}
+		if diff := cmp.Diff([]int{2, 2, 1}, got); diff != "" {
+			t.Errorf("unexpected flush batch sizes (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestManagerSchedulesKeepalives(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			heartbeatInterval = 5 * time.Second
+			beaconInterval    = 10 * time.Second
+		)
+		container := newKeepaliveTestContainer()
+		manager := NewManager(container, ManagerConfig{
+			Source: Info{
+				ID:      "source",
+				Version: 2,
+				Type:    "test-source",
+				Address: "records",
+				Direct:  "direct",
+			},
+			HeartbeatInterval:            heartbeatInterval,
+			BeaconInterval:               beaconInterval,
+			UseAlternateHeartbeatAddress: true,
+		})
+		beacons := container.sender(beaconAddress)
+		heartbeats := container.sender("records" + sourceSuffixHeartbeats)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go manager.sendKeepalives(ctx)
+		synctest.Wait()
+
+		assertSendAttempts(t, beacons, 1)
+		assertSendAttempts(t, heartbeats, 0)
+		decodedBeacon := decodeManagerTestMessage(t, beacons.sentMessages()[0])
+		beacon, ok := decodedBeacon.(vanflow.BeaconMessage)
+		if !ok {
+			t.Fatalf("initial keepalive has type %T, want vanflow.BeaconMessage", decodedBeacon)
+		}
+		wantBeacon := vanflow.BeaconMessage{
+			MessageProps: vanflow.MessageProps{To: beaconAddress, Subject: "BEACON"},
+			Version:      2,
+			SourceType:   "test-source",
+			Address:      "records",
+			Direct:       "direct",
+			Identity:     "source",
+		}
+		if diff := cmp.Diff(wantBeacon, beacon); diff != "" {
+			t.Errorf("unexpected initial beacon (-want +got):\n%s", diff)
+		}
+
+		time.Sleep(heartbeatInterval - time.Nanosecond)
+		synctest.Wait()
+		assertSendAttempts(t, heartbeats, 0)
+
+		time.Sleep(time.Nanosecond)
+		synctest.Wait()
+		assertSendAttempts(t, heartbeats, 1)
+		decodedHeartbeat := decodeManagerTestMessage(t, heartbeats.sentMessages()[0])
+		heartbeat, ok := decodedHeartbeat.(vanflow.HeartbeatMessage)
+		if !ok {
+			t.Fatalf("keepalive has type %T, want vanflow.HeartbeatMessage", decodedHeartbeat)
+		}
+		if heartbeat.Identity != "source" || heartbeat.Version != 2 || heartbeat.Now == 0 {
+			t.Errorf("unexpected heartbeat: %+v", heartbeat)
+		}
+
+		time.Sleep(beaconInterval - heartbeatInterval - time.Nanosecond)
+		synctest.Wait()
+		assertSendAttempts(t, beacons, 1)
+
+		time.Sleep(time.Nanosecond)
+		synctest.Wait()
+		assertSendAttempts(t, beacons, 2)
+		assertSendAttempts(t, heartbeats, 2)
+	})
+}
+
+func TestManagerRetriesAfterSendTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		manager, sender := newSchedulerTestManager(ManagerConfig{})
+		sender.block()
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go manager.sendRecords(ctx)
+		synctest.Wait()
+
+		manager.PublishUpdate(RecordUpdate{Curr: managerTestRecord("record")})
+		synctest.Wait()
+		assertSendAttempts(t, sender, 1)
+
+		time.Sleep(recordSendTimeout - time.Nanosecond)
+		synctest.Wait()
+		assertSendAttempts(t, sender, 1)
+
+		time.Sleep(time.Nanosecond)
+		synctest.Wait()
+		assertSendAttempts(t, sender, 1)
+		if got := managerPendingLen(manager); got != 1 {
+			t.Fatalf("expected timed out record to be requeued: got %d pending records", got)
+		}
+
+		sender.unblock()
+		time.Sleep(recordSendRetryDelay - time.Nanosecond)
+		synctest.Wait()
+		assertSendAttempts(t, sender, 1)
+
+		time.Sleep(time.Nanosecond)
+		synctest.Wait()
+		assertSendAttempts(t, sender, 2)
+		assertMessageRecordIDs(t, sender, []string{"record"})
+		if got := managerPendingLen(manager); got != 0 {
+			t.Errorf("expected retry to drain pending records: got %d", got)
+		}
+	})
+}
+
+func TestManagerRetriesLatestFullRecordAfterUncertainSend(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		manager, sender := newSchedulerTestManager(ManagerConfig{})
+		sender.block()
+		sender.failNext(errors.New("send outcome uncertain"))
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go manager.sendRecords(ctx)
+		synctest.Wait()
+
+		stableText := "unchanged"
+		initialSeverity, updatedSeverity := uint64(1), uint64(2)
+		initial := vanflow.LogRecord{
+			BaseRecord:  vanflow.NewBase("record"),
+			LogSeverity: &initialSeverity,
+			LogText:     &stableText,
+		}
+		updated := initial
+		updated.LogSeverity = &updatedSeverity
+
+		manager.PublishUpdate(RecordUpdate{Prev: initial, Curr: updated})
+		synctest.Wait()
+		assertSendAttempts(t, sender, 1)
+
+		// Queue a reversion while the first send is in flight. The sender will
+		// report an error even though it records the message as delivered, so
+		// the manager cannot presume which state the receiver has.
+		manager.PublishUpdate(RecordUpdate{Prev: updated, Curr: initial})
+		synctest.Wait()
+		sender.unblock()
+		synctest.Wait()
+
+		if got := managerPendingLen(manager); got != 1 {
+			t.Fatalf("expected latest record to be requeued: got %d pending records", got)
+		}
+
+		time.Sleep(recordSendRetryDelay)
+		synctest.Wait()
+		assertSendAttempts(t, sender, 2)
+
+		messages := sender.recordMessages(t)
+		if len(messages) != 2 || len(messages[1].Records) != 1 {
+			t.Fatalf("expected an uncertain send and one full-record retry, got %+v", messages)
+		}
+		if diff := cmp.Diff(initial, messages[1].Records[0]); diff != "" {
+			t.Errorf("retry did not contain the complete latest record (-want +got):\n%s", diff)
+		}
+		if got := managerPendingLen(manager); got != 0 {
+			t.Errorf("expected retry to drain pending records: got %d", got)
+		}
+	})
+}
+
+func newSchedulerTestManager(config ManagerConfig) (*Manager, *schedulerTestSender) {
+	sender := &schedulerTestSender{}
+	container := &schedulerTestContainer{sender: sender}
+	config.Source = Info{ID: "source", Address: "records"}
+	return NewManager(container, config), sender
+}
+
+func managerTestRecord(id string) vanflow.LogRecord {
+	text := id
+	return vanflow.LogRecord{BaseRecord: vanflow.NewBase(id), LogText: &text}
+}
+
+func managerPendingLen(manager *Manager) int {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	return len(manager.pending)
+}
+
+func assertSendAttempts(t *testing.T, sender *schedulerTestSender, want int) {
+	t.Helper()
+	if got := sender.attempts(); got != want {
+		t.Errorf("unexpected send attempts: want %d, got %d", want, got)
+	}
+}
+
+func assertMessageRecordIDs(t *testing.T, sender *schedulerTestSender, want ...[]string) {
+	t.Helper()
+	messages := sender.recordMessages(t)
+	got := make([][]string, len(messages))
+	for i, message := range messages {
+		for _, record := range message.Records {
+			got[i] = append(got[i], record.Identity())
+		}
+		sort.Strings(got[i])
+	}
+	for i := range want {
+		sort.Strings(want[i])
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected sent record identities (-want +got):\n%s", diff)
+	}
+}
+
+func decodeManagerTestMessage(t *testing.T, message *amqp.Message) interface{} {
+	t.Helper()
+	decoded, err := vanflow.Decode(message)
+	if err != nil {
+		t.Fatalf("decode sent message: %v", err)
+	}
+	return decoded
+}
+
+type schedulerTestContainer struct {
+	sender *schedulerTestSender
+}
+
+func (*schedulerTestContainer) Start(context.Context)      {}
+func (*schedulerTestContainer) OnSessionError(func(error)) {}
+func (*schedulerTestContainer) NewReceiver(string, session.ReceiverOptions) session.Receiver {
+	panic("unexpected receiver")
+}
+func (c *schedulerTestContainer) NewSender(string, session.SenderOptions) session.Sender {
+	return c.sender
+}
+
+type schedulerTestSender struct {
+	mu       sync.Mutex
+	blocked  chan struct{}
+	nextErr  error
+	tries    int
+	received []*amqp.Message
+}
+
+func (s *schedulerTestSender) block() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.blocked = make(chan struct{})
+}
+
+func (s *schedulerTestSender) unblock() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	close(s.blocked)
+}
+
+func (s *schedulerTestSender) failNext(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextErr = err
+}
+
+func (s *schedulerTestSender) attempts() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.tries
+}
+
+func (s *schedulerTestSender) sentMessages() []*amqp.Message {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*amqp.Message(nil), s.received...)
+}
+
+func (s *schedulerTestSender) recordMessages(t *testing.T) []vanflow.RecordMessage {
+	t.Helper()
+	sent := s.sentMessages()
+	messages := make([]vanflow.RecordMessage, 0, len(sent))
+	for _, message := range sent {
+		decoded := decodeManagerTestMessage(t, message)
+		recordMessage, ok := decoded.(vanflow.RecordMessage)
+		if !ok {
+			t.Fatalf("sent message has type %T, want vanflow.RecordMessage", decoded)
+		}
+		messages = append(messages, recordMessage)
+	}
+	return messages
+}
+
+func (s *schedulerTestSender) Send(ctx context.Context, message *amqp.Message) error {
+	s.mu.Lock()
+	s.tries++
+	blocked := s.blocked
+	nextErr := s.nextErr
+	s.nextErr = nil
+	s.mu.Unlock()
+
+	if blocked != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-blocked:
+		}
+	}
+
+	s.mu.Lock()
+	s.received = append(s.received, message)
+	s.mu.Unlock()
+	return nextErr
+}
+
+func (*schedulerTestSender) Close(context.Context) error { return nil }
+
+type keepaliveTestContainer struct {
+	mu      sync.Mutex
+	senders map[string]*schedulerTestSender
+}
+
+func newKeepaliveTestContainer() *keepaliveTestContainer {
+	return &keepaliveTestContainer{senders: make(map[string]*schedulerTestSender)}
+}
+
+func (*keepaliveTestContainer) Start(context.Context)      {}
+func (*keepaliveTestContainer) OnSessionError(func(error)) {}
+func (*keepaliveTestContainer) NewReceiver(string, session.ReceiverOptions) session.Receiver {
+	panic("unexpected receiver")
+}
+func (c *keepaliveTestContainer) NewSender(address string, _ session.SenderOptions) session.Sender {
+	return c.sender(address)
+}
+
+func (c *keepaliveTestContainer) sender(address string) *schedulerTestSender {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	sender, ok := c.senders[address]
+	if !ok {
+		sender = &schedulerTestSender{}
+		c.senders[address] = sender
+	}
+	return sender
+}


### PR DESCRIPTION
Reimplement the vanflow eventsource Manager's send side. Replaces the Manager's buffered channel-backed "sendRecords" and "serve" goroutines with a single scheduling worker backed with a deduplicating map of pending record updates. Sends are now done with a timeout and failed batches are requeued and retried. Includes new manager unit test coverage missing from the initial implementation.

Closes https://github.com/skupperproject/skupper/issues/2531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance and Reliability**
  * Improved event update scheduling with centralized buffering and squashing of duplicate record updates to send only the latest changes.
  * Enhanced flush behavior with explicit, delay-based batching and more accurate flush timing.
  * Added timeout-aware retry handling for send failures and uncertain transmission outcomes.
  * Preserved periodic keepalive/beacon scheduling, including alternating heartbeat destinations.
* **Tests**
  * Added a comprehensive scheduler/manager test suite covering duplicate squashing, delayed batching, full-batch sends, configured flush batch sizes, keepalives, and retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->