### PR TITLE
Drain fsnotify Errors channel to prevent file watcher stall

### DIFF
--- a/internal/filesystem/file_watcher.go
+++ b/internal/filesystem/file_watcher.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -131,10 +132,60 @@ func (w *FileWatcher) processEvents(stopCh <-chan struct{}) {
 				}
 				w.handlerLock.RUnlock()
 			}
+		case err, ok := <-w.watcher.Errors:
+			// Drain and log watcher errors so the watcher does not get stuck.
+			if !ok {
+				// Errors channel closed: the watcher has been closed.
+				w.started = false
+				return
+			}
+			w.logger.Error("file watcher error", slog.String("error", err.Error()))
+			if errors.Is(err, fsnotify.ErrEventOverflow) {
+				// Events were dropped; resync to recover the missed changes.
+				w.resync()
+			}
 		case <-stopCh:
 			_ = w.watcher.Close()
 			w.started = false
 			return
+		}
+	}
+}
+
+// resync re-emits OnCreate for the files currently present under each watched
+// path, so handlers can recover after dropped events.
+func (w *FileWatcher) resync() {
+	w.handlerLock.RLock()
+	defer w.handlerLock.RUnlock()
+	for path, handlers := range w.handlerMap {
+		stat, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		var existingFilesAndDirectories []string
+		if stat.IsDir() {
+			pathEntries, err := os.ReadDir(path)
+			if err != nil {
+				w.logger.Error("error reading monitored path during resync",
+					slog.String("path", path),
+					slog.String("error", err.Error()))
+				continue
+			}
+			for _, entry := range pathEntries {
+				existingFilesAndDirectories = append(existingFilesAndDirectories, filepath.Join(path, entry.Name()))
+			}
+		} else {
+			existingFilesAndDirectories = append(existingFilesAndDirectories, path)
+		}
+		for _, handler := range handlers {
+			for _, existingPath := range existingFilesAndDirectories {
+				if handler.Filter(existingPath) {
+					w.triggerCh <- eventTrigger{
+						operation: handler.OnCreate,
+						name:      existingPath,
+					}
+				}
+			}
 		}
 	}
 }

--- a/internal/filesystem/file_watcher.go
+++ b/internal/filesystem/file_watcher.go
@@ -41,6 +41,7 @@ type FileWatcher struct {
 	started     bool
 	resyncing   atomic.Bool
 	watcher     *fsnotify.Watcher
+	errCh       chan error
 	refresh     chan bool
 	triggerCh   chan eventTrigger
 	handlerMap  map[string][]FSChangeHandler
@@ -56,7 +57,11 @@ func NewWatcher(attrs ...slog.Attr) (*FileWatcher, error) {
 		logger = logger.With(slog.Any(attr.Key, attr.Value))
 	}
 	return &FileWatcher{
-		watcher:    watcher,
+		watcher: watcher,
+		// The watcher's own error channel. Kept as a field so tests can
+		// substitute a channel they control, since fsnotify closes this one
+		// from a goroutine that shutdown does not synchronize with.
+		errCh:      watcher.Errors,
 		logger:     logger,
 		refresh:    make(chan bool),
 		triggerCh:  make(chan eventTrigger),
@@ -134,7 +139,7 @@ func (w *FileWatcher) processEvents(stopCh <-chan struct{}) {
 				}
 				w.handlerLock.RUnlock()
 			}
-		case err, ok := <-w.watcher.Errors:
+		case err, ok := <-w.errCh:
 			// Drain and log watcher errors so the watcher does not get stuck.
 			if !ok {
 				// Errors channel closed: the watcher has been closed.

--- a/internal/filesystem/file_watcher.go
+++ b/internal/filesystem/file_watcher.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -38,6 +39,7 @@ type FileWatcher struct {
 	watcherLock sync.Mutex
 	logger      *slog.Logger
 	started     bool
+	resyncing   atomic.Bool
 	watcher     *fsnotify.Watcher
 	refresh     chan bool
 	triggerCh   chan eventTrigger
@@ -136,25 +138,39 @@ func (w *FileWatcher) processEvents(stopCh <-chan struct{}) {
 			// Drain and log watcher errors so the watcher does not get stuck.
 			if !ok {
 				// Errors channel closed: the watcher has been closed.
-				w.started = false
+				w.setStarted(false)
 				return
 			}
 			w.logger.Error("file watcher error", slog.String("error", err.Error()))
 			if errors.Is(err, fsnotify.ErrEventOverflow) {
 				// Events were dropped; resync to recover the missed changes.
-				w.resync()
+				// Run it off the event loop so we keep servicing events, and
+				// coalesce overlapping overflows into a single resync.
+				if w.resyncing.CompareAndSwap(false, true) {
+					go func() {
+						defer w.resyncing.Store(false)
+						w.resync(stopCh)
+					}()
+				}
 			}
 		case <-stopCh:
 			_ = w.watcher.Close()
-			w.started = false
+			w.setStarted(false)
 			return
 		}
 	}
 }
 
+func (w *FileWatcher) setStarted(started bool) {
+	w.runningLock.Lock()
+	defer w.runningLock.Unlock()
+	w.started = started
+}
+
 // resync re-emits OnCreate for the files currently present under each watched
-// path, so handlers can recover after dropped events.
-func (w *FileWatcher) resync() {
+// path, so handlers can recover after dropped events. It returns early if
+// stopCh is closed so it cannot leak on shutdown.
+func (w *FileWatcher) resync(stopCh <-chan struct{}) {
 	w.handlerLock.RLock()
 	defer w.handlerLock.RUnlock()
 	for path, handlers := range w.handlerMap {
@@ -180,9 +196,13 @@ func (w *FileWatcher) resync() {
 		for _, handler := range handlers {
 			for _, existingPath := range existingFilesAndDirectories {
 				if handler.Filter(existingPath) {
-					w.triggerCh <- eventTrigger{
+					select {
+					case w.triggerCh <- eventTrigger{
 						operation: handler.OnCreate,
 						name:      existingPath,
+					}:
+					case <-stopCh:
+						return
 					}
 				}
 			}

--- a/internal/filesystem/zz_overflow_test.go
+++ b/internal/filesystem/zz_overflow_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,15 +16,15 @@ import (
 
 type ovHandler struct {
 	w              *fsnotify.Watcher
-	reTriggerCount int
+	reTriggerCount atomic.Int32
 	n              atomic.Int32
 }
 
 func (h *ovHandler) OnBasePathAdded(string) {}
 func (h *ovHandler) OnCreate(name string) {
 	if strings.Contains(name, "b-0010.") {
-		h.reTriggerCount++
-		if h.reTriggerCount == 1 {
+		count := h.reTriggerCount.Add(1)
+		if count == 1 {
 			// force an overflow error
 			h.w.Errors <- fsnotify.ErrEventOverflow
 		}
@@ -39,6 +41,9 @@ func (h *ovHandler) Filter(s string) bool { return filepath.Ext(s) == ".yaml" }
 // It then writes a single "canary" file and waits 8 seconds, if that file is never reported,
 // the watcher has stopped delivering events permanently, and the test fails.
 func TestOverflowKillsWatcher(t *testing.T) {
+	if testing.Short() {
+		t.Skip("floods the kernel event queue and takes ~20s; run without -short")
+	}
 	dir := t.TempDir()
 	w, err := NewWatcher()
 	if err != nil {
@@ -76,7 +81,84 @@ func TestOverflowKillsWatcher(t *testing.T) {
 			afterBurst, burst)
 	}
 
-	if h.reTriggerCount != 2 {
-		t.Error("WATCHER IS DEAD: expected 2 events on file b-0010.yaml, got:", h.reTriggerCount)
+	if got := h.reTriggerCount.Load(); got != 2 {
+		t.Errorf("WATCHER IS DEAD: expected 2 events on file b-0010.yaml, got: %d", got)
 	}
+}
+
+// countHandler records how many OnCreate callbacks each file received.
+type countHandler struct {
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+func newCountHandler() *countHandler {
+	return &countHandler{counts: map[string]int{}}
+}
+
+func (h *countHandler) OnBasePathAdded(string) {}
+func (h *countHandler) OnCreate(name string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.counts[filepath.Base(name)]++
+}
+func (h *countHandler) OnUpdate(string)      {}
+func (h *countHandler) OnRemove(string)      {}
+func (h *countHandler) Filter(s string) bool { return filepath.Ext(s) == ".yaml" }
+
+func (h *countHandler) count(base string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.counts[base]
+}
+
+func TestOverflowTriggersResync(t *testing.T) {
+	dir := t.TempDir()
+	w, err := NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := newCountHandler()
+	w.Add(dir, h)
+
+	errs := make(chan error)
+	w.errCh = errs
+
+	stop := make(chan struct{})
+	w.Start(stop)
+	defer close(stop)
+
+	waitFor(t, 5*time.Second, "watch on "+dir+" to be registered", func() bool {
+		return slices.Contains(w.watcher.WatchList(), dir)
+	})
+
+	const name = "a.yaml"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0644); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+	waitFor(t, 5*time.Second, "initial OnCreate for "+name, func() bool {
+		return h.count(name) >= 1
+	})
+
+	select {
+	case errs <- fsnotify.ErrEventOverflow:
+	case <-time.After(2 * time.Second):
+		t.Fatal("nothing is draining the watcher error channel: the watcher would stall here")
+	}
+
+	waitFor(t, 5*time.Second, "resync OnCreate for "+name, func() bool {
+		return h.count(name) >= 2
+	})
+}
+
+func waitFor(t *testing.T, timeout time.Duration, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %v waiting for %s", timeout, what)
 }

--- a/internal/filesystem/zz_overflow_test.go
+++ b/internal/filesystem/zz_overflow_test.go
@@ -36,14 +36,18 @@ func TestOverflowKillsWatcher(t *testing.T) {
 
 	const burst = 2000
 	for i := 0; i < burst; i++ {
-		os.WriteFile(filepath.Join(dir, fmt.Sprintf("b-%04d.yaml", i)), []byte("x"), 0644)
+		if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("b-%04d.yaml", i)), []byte("x"), 0644); err != nil {
+			t.Fatalf("writing burst file %d: %v", i, err)
+		}
 	}
 	time.Sleep(10 * time.Second)
 	afterBurst := h.n.Load()
 	t.Logf("phase 1: OnCreate fired %d / %d", afterBurst, burst)
 
 	before := h.n.Load()
-	os.WriteFile(filepath.Join(dir, "canary.yaml"), []byte("x"), 0644)
+	if err := os.WriteFile(filepath.Join(dir, "canary.yaml"), []byte("x"), 0644); err != nil {
+		t.Fatalf("writing canary file: %v", err)
+	}
 	time.Sleep(8 * time.Second)
 	delta := h.n.Load() - before
 

--- a/internal/filesystem/zz_overflow_test.go
+++ b/internal/filesystem/zz_overflow_test.go
@@ -4,18 +4,35 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/fsnotify/fsnotify"
 )
 
-type ovHandler struct{ n atomic.Int32 }
+type ovHandler struct {
+	w              *fsnotify.Watcher
+	reTriggerCount int
+	n              atomic.Int32
+}
 
 func (h *ovHandler) OnBasePathAdded(string) {}
-func (h *ovHandler) OnCreate(string)        { h.n.Add(1); time.Sleep(120 * time.Millisecond) }
-func (h *ovHandler) OnUpdate(string)        {}
-func (h *ovHandler) OnRemove(string)        {}
-func (h *ovHandler) Filter(s string) bool   { return filepath.Ext(s) == ".yaml" }
+func (h *ovHandler) OnCreate(name string) {
+	if strings.Contains(name, "b-0010.") {
+		h.reTriggerCount++
+		if h.reTriggerCount == 1 {
+			// force an overflow error
+			h.w.Errors <- fsnotify.ErrEventOverflow
+		}
+	}
+	h.n.Add(1)
+	time.Sleep(120 * time.Millisecond)
+}
+func (h *ovHandler) OnUpdate(string)      {}
+func (h *ovHandler) OnRemove(string)      {}
+func (h *ovHandler) Filter(s string) bool { return filepath.Ext(s) == ".yaml" }
 
 // The test floods a watched directory with 2000 files while using a deliberately slow handler,
 // which overflows the kernel's inotify queue and triggers an fsnotify error that nothing consumes.
@@ -27,7 +44,9 @@ func TestOverflowKillsWatcher(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := &ovHandler{}
+	h := &ovHandler{
+		w: w.watcher,
+	}
 	w.Add(dir, h)
 	stop := make(chan struct{})
 	w.Start(stop)
@@ -55,5 +74,9 @@ func TestOverflowKillsWatcher(t *testing.T) {
 	if delta == 0 {
 		t.Errorf("WATCHER IS DEAD: canary create was never reported (phase1 delivered %d/%d)",
 			afterBurst, burst)
+	}
+
+	if h.reTriggerCount != 2 {
+		t.Error("WATCHER IS DEAD: expected 2 events on file b-0010.yaml, got:", h.reTriggerCount)
 	}
 }

--- a/internal/filesystem/zz_overflow_test.go
+++ b/internal/filesystem/zz_overflow_test.go
@@ -81,8 +81,8 @@ func TestOverflowKillsWatcher(t *testing.T) {
 			afterBurst, burst)
 	}
 
-	if got := h.reTriggerCount.Load(); got != 2 {
-		t.Errorf("WATCHER IS DEAD: expected 2 events on file b-0010.yaml, got: %d", got)
+	if got := h.reTriggerCount.Load(); got < 2 {
+		t.Errorf("WATCHER IS DEAD: expected at least 2 events on file b-0010.yaml, got: %d", got)
 	}
 }
 

--- a/internal/filesystem/zz_overflow_test.go
+++ b/internal/filesystem/zz_overflow_test.go
@@ -1,0 +1,55 @@
+package filesystem
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type ovHandler struct{ n atomic.Int32 }
+
+func (h *ovHandler) OnBasePathAdded(string) {}
+func (h *ovHandler) OnCreate(string)        { h.n.Add(1); time.Sleep(120 * time.Millisecond) }
+func (h *ovHandler) OnUpdate(string)        {}
+func (h *ovHandler) OnRemove(string)        {}
+func (h *ovHandler) Filter(s string) bool   { return filepath.Ext(s) == ".yaml" }
+
+// The test floods a watched directory with 2000 files while using a deliberately slow handler,
+// which overflows the kernel's inotify queue and triggers an fsnotify error that nothing consumes.
+// It then writes a single "canary" file and waits 8 seconds, if that file is never reported,
+// the watcher has stopped delivering events permanently, and the test fails.
+func TestOverflowKillsWatcher(t *testing.T) {
+	dir := t.TempDir()
+	w, err := NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := &ovHandler{}
+	w.Add(dir, h)
+	stop := make(chan struct{})
+	w.Start(stop)
+	defer close(stop)
+	time.Sleep(1500 * time.Millisecond)
+
+	const burst = 2000
+	for i := 0; i < burst; i++ {
+		os.WriteFile(filepath.Join(dir, fmt.Sprintf("b-%04d.yaml", i)), []byte("x"), 0644)
+	}
+	time.Sleep(10 * time.Second)
+	afterBurst := h.n.Load()
+	t.Logf("phase 1: OnCreate fired %d / %d", afterBurst, burst)
+
+	before := h.n.Load()
+	os.WriteFile(filepath.Join(dir, "canary.yaml"), []byte("x"), 0644)
+	time.Sleep(8 * time.Second)
+	delta := h.n.Load() - before
+
+	t.Logf("phase 2: canary file -> OnCreate delta = %d", delta)
+	if delta == 0 {
+		t.Errorf("WATCHER IS DEAD: canary create was never reported (phase1 delivered %d/%d)",
+			afterBurst, burst)
+	}
+}


### PR DESCRIPTION
Fixes issue #2546 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-watching reliability when errors or event queue overflows occur.
  * Automatically resynchronizes monitored files and directories to avoid missed updates.
  * Ensures watching continues after large bursts of filesystem activity.

* **Tests**
  * Added coverage for recovery after high-volume file event processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->