### PR TITLE
Fixes deadlock with FileWatcher

### DIFF
--- a/internal/filesystem/file_watcher.go
+++ b/internal/filesystem/file_watcher.go
@@ -159,8 +159,10 @@ func (w *FileWatcher) processEvents(stopCh <-chan struct{}) {
 				}
 			}
 		case <-stopCh:
+			w.runningLock.Lock()
 			_ = w.watcher.Close()
-			w.setStarted(false)
+			w.started = false
+			w.runningLock.Unlock()
 			return
 		}
 	}
@@ -251,10 +253,11 @@ func (w *FileWatcher) monitorPaths(stopCh <-chan struct{}) {
 	interval := time.Second
 	ticker := time.NewTicker(interval)
 	w.handlerLock.RLock()
-	if len(w.handlerMap) > 0 {
+	handlersCount := len(w.handlerMap)
+	w.handlerLock.RUnlock()
+	if handlersCount > 0 {
 		w.manageWatchers()
 	}
-	w.handlerLock.RUnlock()
 	for {
 		select {
 		case <-w.refresh:
@@ -338,10 +341,7 @@ func (w *FileWatcher) manageWatchers() {
 }
 
 func (w *FileWatcher) Add(name string, handler FSChangeHandler) {
-	w.runningLock.Lock()
-	defer w.runningLock.Unlock()
 	w.handlerLock.Lock()
-	defer w.handlerLock.Unlock()
 	handlers, ok := w.handlerMap[name]
 	if !ok {
 		w.handlerMap[name] = []FSChangeHandler{handler}
@@ -350,7 +350,11 @@ func (w *FileWatcher) Add(name string, handler FSChangeHandler) {
 		slog.String("path", name))
 
 	w.handlerMap[name] = append(handlers, handler)
-	if w.started {
+	w.handlerLock.Unlock()
+	w.runningLock.Lock()
+	started := w.started
+	w.runningLock.Unlock()
+	if started {
 		w.refresh <- true
 	}
 }

--- a/internal/filesystem/file_watcher.go
+++ b/internal/filesystem/file_watcher.go
@@ -109,33 +109,39 @@ func (w *FileWatcher) processEvents(stopCh <-chan struct{}) {
 				for _, handler := range handlers {
 					//go handler.OnCreate(event.Name)
 					w.logger.Info("OnCreate", slog.String("name", event.Name))
-					w.triggerCh <- eventTrigger{
-						operation: handler.OnCreate,
-						name:      event.Name,
+					select {
+					case w.triggerCh <- eventTrigger{operation: handler.OnCreate, name: event.Name}:
+					case <-stopCh:
+						return
 					}
 				}
 			case event.Has(fsnotify.Write):
 				for _, handler := range handlers {
 					w.logger.Info("OnUpdate", slog.String("name", event.Name))
 					//go handler.OnUpdate(event.Name)
-					w.triggerCh <- eventTrigger{
-						operation: handler.OnUpdate,
-						name:      event.Name,
+					select {
+					case w.triggerCh <- eventTrigger{operation: handler.OnUpdate, name: event.Name}:
+					case <-stopCh:
+						return
 					}
 				}
 			case event.Has(fsnotify.Remove):
 				for _, handler := range handlers {
 					w.logger.Info("OnRemove", slog.String("name", event.Name))
 					//go handler.OnRemove(event.Name)
-					w.triggerCh <- eventTrigger{
-						operation: handler.OnRemove,
-						name:      event.Name,
+					select {
+					case w.triggerCh <- eventTrigger{operation: handler.OnRemove, name: event.Name}:
+					case <-stopCh:
+						return
 					}
 				}
 				// if object being watched is removed, watch for it to show up again
 				w.handlerLock.RLock()
 				if _, ok := w.handlerMap[event.Name]; ok {
-					w.refresh <- true
+					select {
+					case w.refresh <- true:
+					default:
+					}
 				}
 				w.handlerLock.RUnlock()
 			}
@@ -256,14 +262,14 @@ func (w *FileWatcher) monitorPaths(stopCh <-chan struct{}) {
 	handlersCount := len(w.handlerMap)
 	w.handlerLock.RUnlock()
 	if handlersCount > 0 {
-		w.manageWatchers()
+		w.manageWatchers(stopCh)
 	}
 	for {
 		select {
 		case <-w.refresh:
-			w.manageWatchers()
+			w.manageWatchers(stopCh)
 		case <-ticker.C:
-			w.manageWatchers()
+			w.manageWatchers(stopCh)
 		case <-stopCh:
 			w.logger.Info("Stop monitoring paths")
 			return
@@ -271,7 +277,7 @@ func (w *FileWatcher) monitorPaths(stopCh <-chan struct{}) {
 	}
 }
 
-func (w *FileWatcher) manageWatchers() {
+func (w *FileWatcher) manageWatchers(stopCh <-chan struct{}) {
 	w.watcherLock.Lock()
 	defer w.watcherLock.Unlock()
 	w.handlerLock.RLock()
@@ -324,15 +330,17 @@ func (w *FileWatcher) manageWatchers() {
 			existingFilesAndDirectories = append(existingFilesAndDirectories, path)
 		}
 		for _, handler := range handlers {
-			w.triggerCh <- eventTrigger{
-				operation: handler.OnBasePathAdded,
-				name:      path,
+			select {
+			case w.triggerCh <- eventTrigger{operation: handler.OnBasePathAdded, name: path}:
+			case <-stopCh:
+				return
 			}
 			for _, existingPath := range existingFilesAndDirectories {
 				if handler.Filter(existingPath) {
-					w.triggerCh <- eventTrigger{
-						operation: handler.OnCreate,
-						name:      existingPath,
+					select {
+					case w.triggerCh <- eventTrigger{operation: handler.OnCreate, name: existingPath}:
+					case <-stopCh:
+						return
 					}
 				}
 			}
@@ -355,6 +363,9 @@ func (w *FileWatcher) Add(name string, handler FSChangeHandler) {
 	started := w.started
 	w.runningLock.Unlock()
 	if started {
-		w.refresh <- true
+		select {
+		case w.refresh <- true:
+		default:
+		}
 	}
 }

--- a/internal/filesystem/file_watcher_test.go
+++ b/internal/filesystem/file_watcher_test.go
@@ -422,46 +422,41 @@ func (t *counterHandler) Filter(name string) bool {
 }
 
 func TestFileWatcher_AddDuringShutdown(t *testing.T) {
-	const numGoroutines = 50
-	dirs := make([]string, numGoroutines)
-	for i := range dirs {
-		dirs[i] = t.TempDir()
-	}
-
 	w, err := NewWatcher(slog.String("owner", "test.shutdown"))
 	assert.Assert(t, err)
 
 	stop := make(chan struct{})
 	w.Start(stop)
 
-	handler := newCounterHandler(func(string) bool { return true })
-
-	waitCh := make(chan struct{})
-	var wg sync.WaitGroup
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		dir := dirs[i]
-		go func() {
-			defer wg.Done()
-			<-waitCh
-			w.Add(dir, handler)
-		}()
-	}
-
-	// Release all calls to w.Add and immediately close stop channel to force a race.
-	close(waitCh)
+	// Stop the watcher and wait for started to reflect it is down
 	close(stop)
+	assert.Assert(t, utils.RetryError(time.Millisecond*10, 100, func() error {
+		w.runningLock.Lock()
+		defer w.runningLock.Unlock()
+		if w.started {
+			return fmt.Errorf("watcher still running")
+		}
+		return nil
+	}))
+
+	// Force started to true, to simulate Add called after channel consumers are down
+	w.runningLock.Lock()
+	w.started = true
+	w.runningLock.Unlock()
+
+	handler := newCounterHandler(func(string) bool { return true })
+	dir := t.TempDir()
 
 	done := make(chan struct{})
 	go func() {
-		wg.Wait()
+		w.Add(dir, handler)
 		close(done)
 	}()
 
 	select {
 	case <-done:
-		// completed without deadlock
-	case <-time.After(3 * time.Second):
-		t.Fatal("Add blocked after shutdown: possible deadlock on w.refresh")
+		// Add returned without blocking — fix is working correctly
+	case <-time.After(time.Second):
+		t.Fatal("Add blocked after shutdown: deadlock on w.refresh")
 	}
 }

--- a/internal/filesystem/file_watcher_test.go
+++ b/internal/filesystem/file_watcher_test.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
+	goslices "slices"
 	"strings"
 	"sync"
 	"testing"
@@ -30,6 +32,32 @@ const (
 	updated
 	removed
 )
+
+func TestFileWatcher_Add(t *testing.T) {
+	var w *FileWatcher
+	var err error
+
+	stop := make(chan struct{})
+	w, err = NewWatcher(slog.String("owner", "test.watcher"))
+	assert.Assert(t, err)
+	w.Start(stop)
+
+	handler := newCounterHandler(func(name string) bool { return true })
+	var paths []string
+	for i := 0; i < 100; i++ {
+		tmpPath := t.TempDir()
+		paths = append(paths, tmpPath)
+		w.Add(tmpPath, handler)
+	}
+	keys := goslices.Collect(maps.Keys(w.handlerMap))
+	goslices.Sort(paths)
+	goslices.Sort(keys)
+	assert.Assert(t, slices.Equal(paths, keys))
+	for _, path := range paths {
+		_ = w.watcher.Remove(path)
+	}
+	close(stop)
+}
 
 func TestFileWatcher(t *testing.T) {
 	stop := make(chan struct{})

--- a/internal/filesystem/file_watcher_test.go
+++ b/internal/filesystem/file_watcher_test.go
@@ -420,3 +420,48 @@ func (t *counterHandler) GetRemovedCount(basePath string) int {
 func (t *counterHandler) Filter(name string) bool {
 	return t.filter(name)
 }
+
+func TestFileWatcher_AddDuringShutdown(t *testing.T) {
+	const numGoroutines = 50
+	dirs := make([]string, numGoroutines)
+	for i := range dirs {
+		dirs[i] = t.TempDir()
+	}
+
+	w, err := NewWatcher(slog.String("owner", "test.shutdown"))
+	assert.Assert(t, err)
+
+	stop := make(chan struct{})
+	w.Start(stop)
+
+	handler := newCounterHandler(func(string) bool { return true })
+
+	waitCh := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		dir := dirs[i]
+		go func() {
+			defer wg.Done()
+			<-waitCh
+			w.Add(dir, handler)
+		}()
+	}
+
+	// Release all calls to w.Add and immediately close stop channel to force a race.
+	close(waitCh)
+	close(stop)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// completed without deadlock
+	case <-time.After(3 * time.Second):
+		t.Fatal("Add blocked after shutdown: possible deadlock on w.refresh")
+	}
+}


### PR DESCRIPTION
Fixes #2551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-watcher synchronization for more reliable starting, stopping, refreshing, and adding watch paths.
  * Reduced blocking during watcher operations, including shutdown.
  * Ensured file-change notifications stop promptly when monitoring ends.

* **Tests**
  * Added coverage for registering and cleaning up multiple watch directories.
  * Added coverage confirming watch paths can be added without blocking during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->