### PR TITLE
Add skupper-source OCI image for downstream build contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,13 @@ workflows:
             - publish-oci-images
           context:
             - skupper-org
+      - publish-source-image:
+          <<: *run_for_numeric_tags
+          image_tag: << pipeline.git.tag >>
+          requires:
+            - publish-oci-images
+          context:
+            - skupper-org
   build:
     jobs:
       - build-all:
@@ -376,6 +383,20 @@ jobs:
           command: docker login quay.io -u ${QUAY_LOGIN} -p ${QUAY_PASSWORD}
       - run: make docker-build-must-gather IMAGE_TAG="<< parameters.image_tag >>"
       - run: make docker-push-must-gather IMAGE_TAG="<< parameters.image_tag >>"
+  publish-source-image:
+    executor:
+      name: go_cimg
+    parameters:
+      image_tag:
+        type: string
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Docker login
+          command: docker login quay.io -u ${QUAY_LOGIN} -p ${QUAY_PASSWORD}
+      - run: make docker-build-source IMAGE_TAG="<< parameters.image_tag >>"
+      - run: make docker-push-source IMAGE_TAG="<< parameters.image_tag >>"
   generate-operator-bundle:
     executor:
       name: go_cimg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,7 +395,6 @@ jobs:
       - run:
           name: Docker login
           command: docker login quay.io -u ${QUAY_LOGIN} -p ${QUAY_PASSWORD}
-      - run: make docker-build-source IMAGE_TAG="<< parameters.image_tag >>"
       - run: make docker-push-source IMAGE_TAG="<< parameters.image_tag >>"
   generate-operator-bundle:
     executor:

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .circleci
 .github
 .codespellrc
+.git/
 
 # Documentation
 README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 .github
 .codespellrc
 .git/
+vendor/
 
 # Documentation
 README.md

--- a/Dockerfile.source
+++ b/Dockerfile.source
@@ -1,6 +1,16 @@
 # OCI image that packages the Skupper source tree for reproducible downstream builds.
 # Not intended to be run; publish to quay.io/skupper/skupper-source:<version> and
 # consume via build context / additional build contexts instead of git clone.
+ARG GO_IMAGE_BASE_TAG=1.25
+FROM golang:${GO_IMAGE_BASE_TAG} AS vendor
+
+WORKDIR /go/src/app
+COPY go.mod go.sum .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+COPY . .
+RUN go mod vendor
+
 FROM scratch
 
 LABEL \
@@ -8,4 +18,4 @@ LABEL \
   org.opencontainers.image.description="Skupper source tree at a fixed release for downstream container builds"
 
 # Match upstream Dockerfile.* builder layout (WORKDIR /go/src/app).
-COPY . /go/src/app
+COPY --from=vendor /go/src/app /go/src/app

--- a/Dockerfile.source
+++ b/Dockerfile.source
@@ -5,7 +5,7 @@ ARG GO_IMAGE_BASE_TAG=1.25
 FROM golang:${GO_IMAGE_BASE_TAG} AS vendor
 
 WORKDIR /go/src/app
-COPY go.mod go.sum .
+COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 COPY . .

--- a/Dockerfile.source
+++ b/Dockerfile.source
@@ -1,0 +1,11 @@
+# OCI image that packages the Skupper source tree for reproducible downstream builds.
+# Not intended to be run; publish to quay.io/skupper/skupper-source:<version> and
+# consume via build context / additional build contexts instead of git clone.
+FROM scratch
+
+LABEL \
+  org.opencontainers.image.title="Skupper source" \
+  org.opencontainers.image.description="Skupper source tree at a fixed release for downstream container builds"
+
+# Match upstream Dockerfile.* builder layout (WORKDIR /go/src/app).
+COPY . /go/src/app

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GOARCH ?= amd64
 
 REGISTRY := quay.io/skupper
 IMAGE_TAG := v2-dev
+SOURCE_IMAGE := skupper-source
 ROUTER_IMAGE_TAG := main
 PLATFORMS ?= linux/amd64,linux/arm64
 CONTAINERFILES := Dockerfile.cli Dockerfile.kube-adaptor Dockerfile.controller Dockerfile.network-observer Dockerfile.system-controller
@@ -119,6 +120,19 @@ podman-build-must-gather:
 
 podman-push-must-gather:
 	${PODMAN} push "${REGISTRY}/skupper-must-gather:${IMAGE_TAG}"
+
+## Source tree OCI image for downstream build contexts (see Dockerfile.source).
+docker-build-source:
+	${DOCKER} build $(SHARED_IMAGE_LABELS) -t "${REGISTRY}/${SOURCE_IMAGE}:${IMAGE_TAG}" -f Dockerfile.source .
+
+docker-push-source: docker-build-source
+	${DOCKER} push "${REGISTRY}/${SOURCE_IMAGE}:${IMAGE_TAG}"
+
+podman-build-source:
+	${PODMAN} build $(SHARED_IMAGE_LABELS) -t "${REGISTRY}/${SOURCE_IMAGE}:${IMAGE_TAG}" -f Dockerfile.source .
+
+podman-push-source: podman-build-source
+	${PODMAN} push "${REGISTRY}/${SOURCE_IMAGE}:${IMAGE_TAG}"
 
 ## Print fully qualified image names by arch
 describe-multiarch-oci:

--- a/Makefile
+++ b/Makefile
@@ -123,13 +123,13 @@ podman-push-must-gather:
 
 ## Source tree OCI image for downstream build contexts (see Dockerfile.source).
 docker-build-source:
-	${DOCKER} build $(SHARED_IMAGE_LABELS) -t "${REGISTRY}/${SOURCE_IMAGE}:${IMAGE_TAG}" -f Dockerfile.source .
+	${DOCKER} build --build-arg GO_IMAGE_BASE_TAG=$(GO_IMAGE_BASE_TAG) $(SHARED_IMAGE_LABELS) -t "${REGISTRY}/${SOURCE_IMAGE}:${IMAGE_TAG}" -f Dockerfile.source .
 
 docker-push-source: docker-build-source
 	${DOCKER} push "${REGISTRY}/${SOURCE_IMAGE}:${IMAGE_TAG}"
 
 podman-build-source:
-	${PODMAN} build $(SHARED_IMAGE_LABELS) -t "${REGISTRY}/${SOURCE_IMAGE}:${IMAGE_TAG}" -f Dockerfile.source .
+	${PODMAN} build --build-arg GO_IMAGE_BASE_TAG=$(GO_IMAGE_BASE_TAG) $(SHARED_IMAGE_LABELS) -t "${REGISTRY}/${SOURCE_IMAGE}:${IMAGE_TAG}" -f Dockerfile.source .
 
 podman-push-source: podman-build-source
 	${PODMAN} push "${REGISTRY}/${SOURCE_IMAGE}:${IMAGE_TAG}"


### PR DESCRIPTION
Fixes #2559

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for distributing the Skupper source tree as an OCI image for downstream builds.
  * Added Docker and Podman commands to build and publish source images.
  * Source images now include vendored Go dependencies for more reproducible builds.
  * Source images are published alongside release container images.
* **Chores**
  * Automated source-image publishing as part of the release workflow.
  * Excluded Git metadata and existing vendor content from the source-image build context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->